### PR TITLE
clean: remove opencl

### DIFF
--- a/.github/workflows/linux_special.yml
+++ b/.github/workflows/linux_special.yml
@@ -121,7 +121,6 @@ jobs:
               with:
                   path: |
                       desktop/src-tauri/openblas
-                      desktop/src-tauri/clblast
                       desktop/src-tauri/ffmpeg
                   key: ${{ runner.os }}-pre-build
 

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -100,7 +100,6 @@ jobs:
               with:
                   path: |
                       desktop/src-tauri/openblas
-                      desktop/src-tauri/clblast
                       desktop/src-tauri/ffmpeg
                   key: ${{ matrix.platform }}-pre-build
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ openblas/
 *.7z
 .env
 !samples/*
-clblast/
 vulkan_sdk/
 vulkan_runtime/
 schemas/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,10 +59,9 @@
                 "env": {
                     "FFMPEG_DIR": "${workspaceFolder}\\desktop\\src-tauri\\ffmpeg",
                     "OPENBLAS_PATH": "${workspaceFolder}\\desktop\\src-tauri\\openblas",
-                    "CLBlast_DIR": "${workspaceFolder}\\desktop\\src-tauri\\clblast",
                     "LIBCLANG_PATH": "C:\\Program Files\\LLVM\\bin",
-                    "PATH": "${env:PATH};${workspaceFolder}\\desktop\\src-tauri\\openblas\\bin;${workspaceFolder}\\desktop\\src-tauri\\clblast\\bin;${workspaceFolder}\\desktop\\src-tauri\\ffmpeg\\bin\\x64",
-                    "RUSTFLAGS": "-L ${workspaceFolder}\\desktop\\src-tauri\\clblast\\lib -L ${workspaceFolder}\\desktop\\src-tauri\\openblas\\lib"
+                    "PATH": "${env:PATH};${workspaceFolder}\\desktop\\src-tauri\\openblas\\bin;${workspaceFolder}\\desktop\\src-tauri\\ffmpeg\\bin\\x64",
+                    "RUSTFLAGS": "-L ${workspaceFolder}\\desktop\\src-tauri\\openblas\\lib"
                 },
             },
             "args": [],

--- a/core/build.rs
+++ b/core/build.rs
@@ -49,9 +49,6 @@ fn main() {
     // ffmpeg
     let ffmpeg_dir = env::var("FFMPEG_DIR").unwrap_or_default();
     let ffmpeg_dir = PathBuf::from(ffmpeg_dir);
-    // clblast
-    let clblast_dir = env::var("CLBlast_DIR").unwrap_or_default();
-    let clblast_dir = PathBuf::from(clblast_dir);
 
     // openblas
     let openblas_dir = env::var("OPENBLAS_PATH").unwrap_or_default();
@@ -94,7 +91,6 @@ fn main() {
                 format!("{}\\*.dll", ffmpeg_dir.join("bin\\x64").to_str().unwrap()),
                 format!("{}\\*.exe", ffmpeg_dir.join("bin\\x64").to_str().unwrap()),
                 format!("{}\\*.dll", openblas_dir.join("..\\bin").to_str().unwrap()),
-                format!("{}\\*.dll", clblast_dir.join("..\\..\\..\\bin").to_str().unwrap()),
             ];
             for pattern in patterns {
                 for entry in glob::glob(&pattern).unwrap().flatten() {

--- a/desktop/src-tauri/tauri.windows.conf.json
+++ b/desktop/src-tauri/tauri.windows.conf.json
@@ -6,7 +6,8 @@
             }
         },
         "resources": {
-            "ffmpeg\\bin\\x64\\*": "./"
+            "ffmpeg\\bin\\x64\\*": "./",
+            "vulkan_runtime\\x64\\*.dll": "./"
         }
     }
 }

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -32,6 +32,14 @@ _Vulkan (Linux)_
 sudo apt-get install -y mesa-vulkan-drivers
 ```
 
+_Vulkan (Windows)_
+
+**Run as admin once!!!**
+
+```console
+bun run scripts\pre_build.js --vulkan
+```
+
 ## Build
 
 Install dependencies from `desktop` folder
@@ -66,7 +74,6 @@ See [whisper.cpp#nvidia-support](https://github.com/ggerganov/whisper.cpp?tab=re
 		"resources": {
 			"ffmpeg\\bin\\x64\\*.dll": "./",
 			"openblas\\bin\\*.dll": "./",
-			"clblast\\bin\\*.dll": "./",
 			"C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5\\bin\\cudart64_*": "./",
 			"C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5\\bin\\cublas64_*": "./",
 			"C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5\\bin\\cublasLt64_*": "./"
@@ -130,7 +137,6 @@ Rust analyzer failed to run on windows
 "rust-analyzer.cargo.extraEnv": {
 	"FFMPEG_DIR": "${workspaceFolder}\\desktop\\src-tauri\\ffmpeg",
 	"OPENBLAS_PATH": "${workspaceFolder}\\desktop\\src-tauri\\openblas",
-	"CLBlast_DIR": "${workspaceFolder}\\desktop\\src-tauri\\clblast",
 	"LIBCLANG_PATH": "C:\\Program Files\\LLVM\\bin"
 }
 ```
@@ -226,7 +232,6 @@ cargo +nightly -Zunstable-options update --breaking
 	"rust-analyzer.runnables.extraEnv": {
 		"FFMPEG_DIR": "${workspaceFolder}\\desktop\\src-tauri\\ffmpeg",
 		"OPENBLAS_PATH": "${workspaceFolder}\\desktop\\src-tauri\\openblas",
-		"CLBlast_DIR": "${workspaceFolder}\\desktop\\src-tauri\\clblast",
 		"LIBCLANG_PATH": "C:\\Program Files\\LLVM\\bin"
 	},
 	"rust-analyzer.runnables.extraArgs": ["--release"]
@@ -238,7 +243,6 @@ cargo +nightly -Zunstable-options update --breaking
 ```console
 bun run scripts/pre_build.js
 # Export env
-$env:PATH += ";$pwddesktop\src-tauri\clblast\bin"
 $env:PATH += ";$pwd\desktop\src-tauri\openblas\bin"
 cargo test --target x86_64-pc-windows-msvc --features "vulkan" -p vibe_core --release -- --nocapture
 ```

--- a/scripts/pre_build.js
+++ b/scripts/pre_build.js
@@ -20,7 +20,6 @@ function hasFeature(name) {
 const config = {
 	ffmpegRealname: 'ffmpeg',
 	openblasRealname: 'openblas',
-	clblastRealname: 'clblast',
 	vulkanRuntimeRealName: 'vulkan_runtime',
 	vulkanSdkRealName: 'vulkan_sdk',
 	windows: {
@@ -29,9 +28,6 @@ const config = {
 
 		openBlasName: 'OpenBLAS-0.3.26-x64',
 		openBlasUrl: 'https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.26/OpenBLAS-0.3.26-x64.zip',
-
-		clblastName: 'CLBlast-1.6.2-windows-x64',
-		clblastUrl: 'https://github.com/CNugteren/CLBlast/releases/download/1.6.2/CLBlast-1.6.2-windows-x64.zip',
 
 		vulkanRuntimeName: 'VulkanRT-1.3.290.0-Components',
 		vulkanRuntimeUrl: 'https://sdk.lunarg.com/sdk/download/1.3.290.0/windows/VulkanRT-1.3.290.0-Components.zip',
@@ -75,7 +71,6 @@ const config = {
 const exports = {
 	ffmpeg: path.join(cwd, config.ffmpegRealname),
 	openBlas: path.join(cwd, config.openblasRealname),
-	clblast: path.join(cwd, config.clblastRealname, 'lib/cmake/CLBlast'),
 	libClang: 'C:\\Program Files\\LLVM\\bin',
 	cmake: 'C:\\Program Files\\CMake\\bin',
 }
@@ -112,16 +107,6 @@ if (platform == 'windows') {
 		fs.cp(path.join(config.openblasRealname, 'include'), path.join(config.openblasRealname, 'lib'), { recursive: true, force: true })
 		// It tries to link only openblas.lib but our is libopenblas.lib`
 		fs.cp(path.join(config.openblasRealname, 'lib/libopenblas.lib'), path.join(config.openblasRealname, 'lib/openblas.lib'))
-	}
-
-	// Setup CLBlast
-	if (!(await fs.exists(config.clblastRealname)) && !hasFeature('cuda')) {
-		await $`C:\\msys64\\usr\\bin\\wget.exe -nc --show-progress ${config.windows.clblastUrl} -O ${config.windows.clblastName}.zip`
-		await $`"C:\\Program Files\\7-Zip\\7z.exe" x ${config.windows.clblastName}.zip` // 7z file inside
-		await $`"C:\\Program Files\\7-Zip\\7z.exe" x ${config.windows.clblastName}.7z` // Inner folder
-		await $`mv ${config.windows.clblastName} ${config.clblastRealname}`
-		await $`rm ${config.windows.clblastName}.zip`
-		await $`rm ${config.windows.clblastName}.7z`
 	}
 
 	// Setup Vulkan
@@ -344,7 +329,6 @@ if (action?.includes('--build' || action.includes('--dev'))) {
 	process.env['FFMPEG_DIR'] = exports.ffmpeg
 	if (platform === 'windows') {
 		process.env['OPENBLAS_PATH'] = exports.openBlas
-		process.env['CLBlast_DIR'] = exports.clblast
 		process.env['LIBCLANG_PATH'] = process.env['LIBCLANG_PATH'] || exports.libClang
 		process.env['PATH'] = `${process.env['PATH']};${exports.cmake}`
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced Vulkan support for Tauri applications on Ubuntu 22.04.
	- Added instructions for building with Vulkan support on Windows.

- **Bug Fixes**
	- Removed deprecated references to `clblast` across various configurations and scripts, streamlining the build process.

- **Documentation**
	- Updated `BUILDING.md` to reflect changes in build requirements and instructions regarding Vulkan and `clblast`.

- **Chores**
	- Enhanced `.gitignore` to exclude additional file types and directories, improving repository cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->