### PR TITLE
feat: enhance model download functionality and set hebrew-ai model fo…

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -16,6 +16,8 @@ pub struct TranscribeOptions {
     pub max_text_ctx: Option<i32>,
     pub word_timestamps: Option<bool>,
     pub max_sentence_len: Option<i32>,
+    pub sampling_strategy: Option<String>,
+    pub sampling_bestof_or_beam_size: Option<i32>,
 }
 
 impl fmt::Debug for TranscribeOptions {

--- a/core/src/test.rs
+++ b/core/src/test.rs
@@ -25,6 +25,8 @@ fn test_transcribe() {
         temperature: None,
         translate: None,
         word_timestamps: None,
+        sampling_bestof_or_beam_size: None,
+        sampling_strategy: None,
     };
     let start = Instant::now();
     let result = crate::transcribe::transcribe(&ctx, options, None, None, None, None, None);

--- a/desktop/src-tauri/locales/en-US/common.json
+++ b/desktop/src-tauri/locales/en-US/common.json
@@ -40,7 +40,7 @@
 	"download-models-link": "Download Models",
 	"downloading": "Downloading... {{progress}}%",
 	"downloading-ai-models": "Downloading AI models...",
-	"downloading-model": "Downloading OpenAI Model...",
+	"downloading-model": "Downloading {{company}} Model...",
 	"downloading-ytdlp": "Downloading ytdlp",
 	"enable-logs": "Enable Logs",
 	"error": "Error",

--- a/desktop/src-tauri/locales/he-IL/common.json
+++ b/desktop/src-tauri/locales/he-IL/common.json
@@ -40,7 +40,7 @@
 	"download-models-link": "הורדת מודלים",
 	"downloading": "מוריד... {{progress}}%",
 	"downloading-ai-models": "מוריד מודלים...",
-	"downloading-model": "מוריד מודל בינה מלאכותית",
+	"downloading-model": "מוריד מודל בינה מלאכותית מאת {{company}}",
 	"downloading-ytdlp": "מוריד ytdlp",
 	"enable-logs": "הפעל לוגים",
 	"error": "שגיאה",

--- a/desktop/src-tauri/src/cli.rs
+++ b/desktop/src-tauri/src/cli.rs
@@ -195,6 +195,8 @@ pub async fn run(app_handle: &AppHandle) -> Result<()> {
         max_text_ctx: args.max_text_ctx,
         word_timestamps: Some(args.word_timestamps),
         max_sentence_len: args.max_sentence_len,
+        sampling_strategy: None,
+        sampling_bestof_or_beam_size: None,
     };
     let model_path = prepare_model_path(&args.model.context("model")?, app_handle)?;
 

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -2,12 +2,6 @@ pub const LOG_FILENAME_PREFIX: &str = "log";
 pub const LOG_FILENAME_SUFFIX: &str = ".txt";
 pub const DEFAULT_LOG_DIRECTIVE: &str = "vibe=DEBUG,vibe_core=DEBUG,whisper_rs=INFO";
 pub const STORE_FILENAME: &str = "app_config.json";
-pub const DEFAULT_MODEL_URLS: &[&str] = &[
-    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q8_0.bin",
-    "https://github.com/thewh1teagle/vibe/releases/download/v0.0.1/ggml-medium-q8_0.bin",
-];
-pub const DEAFULT_MODEL_FILENAME: &str = "ggml-medium-q8_0.bin";
-
 // Diarization
 pub const SEGMENT_MODEL_FILENAME: &str = "segmentation-3.0.onnx";
 pub const EMBEDDING_MODEL_FILENAME: &str = "wespeaker_en_voxceleb_CAM++.onnx";

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./gen/schemas/desktop-schema.json",
 	"productName": "vibe",
-	"version": "3.0.3",
+	"version": "3.0.5",
 	"identifier": "github.com.thewh1teagle.vibe",
 	"app": {
 		"windows": [],

--- a/desktop/src/components/Params.tsx
+++ b/desktop/src/components/Params.tsx
@@ -444,6 +444,43 @@ export default function ModelOptions({ options, setOptions }: ParamsProps) {
 							type="number"
 						/>
 					</label>
+					<label className="form-control w-full">
+						<div className="label">
+							<span className="label-text flex items-center gap-1">
+								<InfoTooltip text="Greedy vs Beam Search: Default is Beam Search (Size 5, Patience -1), which evaluates 5 possible sequences at each step for more accurate results, but is slower. Greedy, on the other hand, selects the best token from the top 5 at each step, making it faster but potentially less accurate." />
+								{t('common.sampling-strategy')}
+							</span>
+						</div>
+
+						<select
+							value={preference.modelOptions.sampling_strategy}
+							onChange={(e) => {
+								const newStrategy = e.target.value
+								preference.setModelOptions({ ...preference.modelOptions, sampling_strategy: newStrategy as 'greedy' | 'beam search' })
+							}}
+							className="select select-bordered capitalize">
+							{['beam search', 'greedy'].map((name) => (
+								<option key={name} value={name}>
+									{name}
+								</option>
+							))}
+						</select>
+					</label>
+					<label className="form-control w-full">
+						<div className="label">
+							<span className="label-text flex items-center gap-1">
+								<InfoTooltip text="best_of: Top candidates in Greedy mode (default: 5) — higher = better accuracy, slower. beam_size: Paths explored in Beam Search (default: 5) — higher = better accuracy, slower." />
+								{preference.modelOptions.sampling_strategy === 'greedy' ? 'Besf of' : 'Beam size'}
+							</span>
+						</div>
+						<input
+							step={1}
+							value={preference.modelOptions.sampling_bestof_or_beam_size ?? 5}
+							onChange={(e) => setOptions({ ...options, sampling_bestof_or_beam_size: parseInt(e.target.value) })}
+							className="input input-bordered"
+							type="number"
+						/>
+					</label>
 					<div className="label mt-10">
 						<span className="label-text text-2xl font-bold">{t('common.ffmpeg-options')}</span>
 					</div>

--- a/desktop/src/lib/config.ts
+++ b/desktop/src/lib/config.ts
@@ -1,12 +1,20 @@
 export const aboutURL = 'https://thewh1teagle.github.io/vibe/'
 export const updateVersionURL = 'https://github.com/thewh1teagle/vibe/releases/latest'
-export const modelsURL = 'https://thewh1teagle.github.io/vibe/docs#models'
+export const modelsDocURL = 'https://thewh1teagle.github.io/vibe/docs#models'
 export const discordURL = 'https://discord.gg/EcxWSstQN8'
 export const unsupportedCpuReadmeURL = 'https://thewh1teagle.github.io/vibe/docs#install'
 export const supportVibeURL = 'https://thewh1teagle.github.io/vibe/?action=support-vibe'
 export const storeFilename = 'app_config.json'
 export const latestReleaseURL = 'https://github.com/thewh1teagle/vibe/releases/latest'
 export const latestVersionWithoutVulkan = 'https://github.com/thewh1teagle/vibe/releases/download/v2.4.0/vibe_2.4.0_x64-setup.exe'
+
+export const modelUrls = {
+	default: [
+		'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q8_0.bin',
+		'https://github.com/thewh1teagle/vibe/releases/download/v0.0.1/ggml-medium-q8_0.bin', // Fallback
+	],
+	hebrew: ['https://huggingface.co/thewh1teagle/whisper-large-v3-turbo-ivrit/resolve/main/ggml-model.int8.bin'],
+}
 
 export const embeddingModelFilename = 'wespeaker_en_voxceleb_CAM++.onnx'
 export const segmentModelFilename = 'segmentation-3.0.onnx'

--- a/desktop/src/lib/utils.ts
+++ b/desktop/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core'
-import * as path from '@tauri-apps/api/path'
-import * as fs from '@tauri-apps/plugin-fs'
+import * as pathExt from '@tauri-apps/api/path'
+import * as fsExt from '@tauri-apps/plugin-fs'
 import * as config from './config'
 import { Dispatch, SetStateAction } from 'react'
 import { load } from '@tauri-apps/plugin-store'
@@ -14,15 +14,15 @@ export interface NamedPath {
 export type ModifyState<T> = Dispatch<SetStateAction<T>>
 
 export async function pathToNamedPath(pathString: string) {
-	const name = await path.basename(pathString)
+	const name = await pathExt.basename(pathString)
 	return { name, path: pathString }
 }
 
 export async function ls(where: string) {
-	const entries = await fs.readDir(where)
+	const entries = await fsExt.readDir(where)
 	const paths: NamedPath[] = []
 	for (const entry of entries) {
-		const abs = await path.join(where, entry.name)
+		const abs = await pathExt.join(where, entry.name)
 		paths.push({ name: entry.name, path: abs })
 	}
 	return paths
@@ -57,7 +57,7 @@ export async function resetApp() {
 		await store.clear()
 		if (modelPath) {
 			try {
-				await fs.remove(modelPath)
+				await fsExt.remove(modelPath)
 			} catch (e) {
 				console.error(e)
 			}
@@ -100,4 +100,35 @@ export async function stopKeepAwake() {
 	} catch (e) {
 		console.error(`Keep awake failed: ${e}`)
 	}
+}
+
+export async function downloadModel(url: string) {
+	let filename = await getFilenameFromUrl(url)
+	if (!filename.endsWith('.bin')) {
+		filename = 'ggml-model.bin'
+	}
+	const modelsFolder = await invoke<string>('get_models_folder')
+	let modelPath = await pathExt.join(modelsFolder, filename)
+	if (await fsExt.exists(modelPath)) {
+		filename = randomString(8, 'ggml-model_', '.bin')
+		modelPath = await pathExt.join(modelsFolder, filename)
+	}
+	await invoke('download_model', { url, path: modelPath })
+	return modelPath
+}
+
+export function randomString(length: number, prefix: string, suffix: string) {
+	const chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
+	let result = prefix
+	for (let i = 0; i < length; i++) {
+		result += chars.charAt(Math.floor(Math.random() * chars.length))
+	}
+	return result + suffix
+}
+
+export async function getFilenameFromUrl(url: string) {
+	// Get it from the url itself parse as url object and get last part
+	const urlObj = new URL(url)
+	const fileName = urlObj.pathname.split('/').pop() || ''
+	return fileName
 }

--- a/desktop/src/pages/settings/viewModel.ts
+++ b/desktop/src/pages/settings/viewModel.ts
@@ -19,7 +19,7 @@ async function openModelPath() {
 }
 
 async function openModelsUrl() {
-	shell.open(config.modelsURL)
+	shell.open(config.modelsDocURL)
 }
 
 async function reportIssue() {

--- a/desktop/src/pages/setup/Page.tsx
+++ b/desktop/src/pages/setup/Page.tsx
@@ -7,7 +7,7 @@ function App() {
 
 	return (
 		<div className="w-[100vw] h-[100vh] flex flex-col justify-center items-center">
-			<div className="text-3xl m-5 font-bold">{t('common.downloading-model')}</div>
+			<div className="text-3xl m-5 font-bold">{t('common.downloading-model', { company: vm.modelCompany })}</div>
 			{vm.downloadProgress > 0 && (
 				<>
 					<progress className="progress progress-primary w-56 my-2" value={vm.downloadProgress} max="100"></progress>

--- a/desktop/src/providers/Preference.tsx
+++ b/desktop/src/providers/Preference.tsx
@@ -87,6 +87,8 @@ export interface ModelOptions {
 	max_text_ctx?: number
 	word_timestamps?: boolean
 	max_sentence_len?: number
+	sampling_strategy: 'greedy' | 'beam search'
+	sampling_bestof_or_beam_size?: number
 }
 
 const systemIsDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -105,6 +107,8 @@ const defaultOptions = {
 		max_text_ctx: undefined,
 		word_timestamps: false,
 		max_sentence_len: 1,
+		sampling_strategy: 'beam search' as 'greedy' | 'beam search',
+		sampling_bestof_or_beam_size: 5,
 	},
 	ffmpegOptions: {
 		normalize_loudness: false,


### PR DESCRIPTION
Set hebrew ai model by default if locale ends with `IL`
Enhance models download - add random suffix if already exists
Set int8 turbo model by default for everyone

Show models info when downloading such as company name (OpenAI / Ivrit-AI etc)

FUTURE:

random suffix but keep useful model name?
random suffix should be date?
Let's assume most users don't touch it for now