### PR TITLE
Add OpenAI support and update LlmConfig interface

### DIFF
--- a/desktop/src/lib/llm/index.ts
+++ b/desktop/src/lib/llm/index.ts
@@ -1,22 +1,28 @@
 import { Claude, deafultConfig as defaultClaudeConfig } from './claude'
 import { Ollama, defaultConfig as defaultOllamaConfig } from './ollama'
+import { OpenAI, defaultConfig as defaultOpenAIConfig } from './openai'
+
 
 export interface Llm {
 	ask(prompt: string): Promise<string>
 }
 
 export interface LlmConfig {
-	platform: 'ollama' | 'claude'
+	platform: 'ollama' | 'claude' | 'openai'
 	enabled: boolean
 	prompt: string
 
 	// Claude
-	claudeApiKey: string
+	claudeApiKey?: string
 	model: string
 	maxTokens?: number
 
 	// Ollama
-	ollamaBaseUrl: string
+	ollamaBaseUrl?: string
+
+	// OpenAI-compatible
+	openaiApiKey?: string
+	openaiBaseUrl?: string
 }
 
-export { Ollama, Claude, defaultClaudeConfig, defaultOllamaConfig }
+export { Ollama, Claude, OpenAI, defaultClaudeConfig, defaultOllamaConfig, defaultOpenAIConfig }

--- a/desktop/src/lib/llm/openai.ts
+++ b/desktop/src/lib/llm/openai.ts
@@ -1,0 +1,42 @@
+import { fetch } from '@tauri-apps/plugin-http'
+import { Llm, LlmConfig } from './index'
+
+export function defaultConfig(): LlmConfig {
+    return {
+        enabled: false,
+        platform: 'openai',
+        model: 'gpt-3.5-turbo',
+        openaiApiKey: '',
+        openaiBaseUrl: 'https://api.openai.com/v1',
+        prompt: `Please summarize the following transcription: \n\n"""\n%s\n"""\n`,
+        claudeApiKey: '',
+        ollamaBaseUrl: '',
+    }
+}
+
+export class OpenAI implements Llm {
+    private config: LlmConfig
+
+    constructor(config: LlmConfig) {
+        this.config = config
+    }
+
+    async ask(prompt: string): Promise<string> {
+        const body = JSON.stringify({
+            model: this.config.model,
+            messages: [{ role: 'user', content: prompt }],
+            stream: false
+        })
+        const headers = {
+            'Authorization': `Bearer ${this.config.openaiApiKey}`,
+            'Content-Type': 'application/json',
+        }
+        const response = await fetch(`${this.config.openaiBaseUrl}/chat/completions`, {
+            method: 'POST',
+            headers,
+            body,
+        })
+        const data = await response.json()
+        return data.choices?.[0]?.message?.content || ''
+    }
+}

--- a/desktop/src/pages/home/viewModel.ts
+++ b/desktop/src/pages/home/viewModel.ts
@@ -16,7 +16,7 @@ import successSound from '~/assets/success.mp3'
 import { TextFormat } from '~/components/FormatSelect'
 import { AudioDevice } from '~/lib/audio'
 import * as config from '~/lib/config'
-import { Claude, Llm, Ollama } from '~/lib/llm'
+import { Claude, Llm, Ollama, OpenAI } from '~/lib/llm'
 import * as transcript from '~/lib/transcript'
 import { useConfirmExit } from '~/lib/useConfirmExit'
 import { NamedPath, ls, openPath, pathToNamedPath, startKeepAwake, stopKeepAwake } from '~/lib/utils'
@@ -100,8 +100,11 @@ export function viewModel() {
 		if (preference.llmConfig?.platform === 'ollama') {
 			const llmInstance = new Ollama(preference.llmConfig)
 			setLlm(llmInstance)
-		} else {
+		} else if (preference.llmConfig?.platform === 'claude') {
 			const llmInstance = new Claude(preference.llmConfig)
+			setLlm(llmInstance)
+		} else if (preference.llmConfig?.platform === 'openai') {
+			const llmInstance = new OpenAI(preference.llmConfig)
 			setLlm(llmInstance)
 		}
 	}, [preference.llmConfig])


### PR DESCRIPTION
This pull request adds support for OpenAI-compatible language models to the application, alongside existing Claude and Ollama integrations. The changes introduce a new `OpenAI` class, update configuration interfaces, and extend the logic for selecting the LLM backend.

**OpenAI integration:**

* Added a new `OpenAI` class in `openai.ts` that implements the `Llm` interface, enabling the app to send prompts to OpenAI-compatible APIs and receive responses.
* Introduced a `defaultConfig` function for OpenAI, specifying default parameters like `model`, `openaiApiKey`, and `openaiBaseUrl`.
* Updated the `LlmConfig` interface in `index.ts` to include OpenAI-specific configuration options (`openaiApiKey`, `openaiBaseUrl`), and added `'openai'` as a valid platform.
* Modified the LLM selection logic in `viewModel.ts` to instantiate and use the `OpenAI` class when the platform is set to `'openai'`.
* Updated imports in `viewModel.ts` to include the new `OpenAI` class.