### PR TITLE
Add more languages to models page

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -44,35 +44,37 @@ For high accuracy and more computational resources, excels in complex scenarios.
 
 Specialized for Hebrew (Ivrit) language data, optimized for high speed and accuracy in Hebrew tasks.
 
-[👉 Magic Setup (Large v3 Turbo)](https://tinyurl.com/t9r3tyxk)
+[👉 Magic Setup (Large v3 Turbo)](https://tinyurl.com/t9r3tyxk)  
 [🔽 Direct Download (Large v3 Turbo)](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin?download=true)	
 </details>
 
 <details>
 <summary>🇳🇴 Norwegian</summary>
+	
 Optimised for Norwegian by the [AI Lab at the National Library of Norway](https://huggingface.co/NbAiLab).
 
-[👉 Magic Setup (medium)](https://tinyurl.com/5wzb9ux8)
+[👉 Magic Setup (medium)](https://tinyurl.com/5wzb9ux8)  
 [🔽 Direct Download (medium)](https://huggingface.co/NbAiLab/nb-whisper-medium/blob/main/ggml-model.bin?download=true)
 
-[👉 Magic Setup (large)](https://tinyurl.com/f228efbu)
+[👉 Magic Setup (large)](https://tinyurl.com/f228efbu)  
 [🔽 Direct Download (large)](https://huggingface.co/NbAiLab/nb-whisper-large/blob/main/ggml-model.bin?download=true)
 
-More models of smaller sizes are available via [their huggingface download page](https://huggingface.co/NbAiLab/nb-whisper-large).
+More models of smaller sizes are available via [their huggingface download page](https://huggingface.co/NbAiLab/nb-whisper-large).  
 Find the size you want, download the *ggml-model.bin* file, rename the file, and palce it in vibe's model folder.
 </details>
 
 <details>
 <summary>🇸🇪 Swedish</summary>
+
 Optimised for Swedish by the [Data Lab at the National Library of Sweden](https://huggingface.co/KBLab).
 
-[👉 Magic Setup (medium)](https://tinyurl.com/ynawnc33)
+[👉 Magic Setup (medium)](https://tinyurl.com/ynawnc33)  
 [🔽 Direct Download (medium)](https://huggingface.co/KBLab/kb-whisper-medium/blob/main/ggml-model.bin?download=true)
 
-[👉 Magic Setup (large v3)](https://tinyurl.com/46dvpeky)
+[👉 Magic Setup (large v3)](https://tinyurl.com/46dvpeky)  
 [🔽 Direct Download (large v3)](https://huggingface.co/KBLab/kb-whisper-large/blob/main/ggml-model.bin?download=true)
 
-More models of smaller sizes are available via [their huggingface download page](https://huggingface.co/KBLab/kb-whisper-large).
+More models of smaller sizes are available via [their huggingface download page](https://huggingface.co/KBLab/kb-whisper-large).  
 Find the size you want, download the *ggml-model.bin* file, rename the file, and palce it in vibe's model folder.
 </details>
 </details>

--- a/docs/models.md
+++ b/docs/models.md
@@ -52,27 +52,27 @@ Specialized for Hebrew (Ivrit) language data, optimized for high speed and accur
 <summary>🇳🇴 Norwegian</summary>
 Optimised for Norwegian by the [AI Lab at the National Library of Norway](https://huggingface.co/NbAiLab).
 
-[👉 Magic Setup (medium)](vibe://download/?url=https://huggingface.co/NbAiLab/nb-whisper-medium/blob/main/ggml-model.bin?download=true)
+[👉 Magic Setup (medium)](https://tinyurl.com/5wzb9ux8)
 [🔽 Direct Download (medium)](https://huggingface.co/NbAiLab/nb-whisper-medium/blob/main/ggml-model.bin?download=true)
 
-[👉 Magic Setup (large)](vibe://download/?url=https://huggingface.co/NbAiLab/nb-whisper-large/blob/main/ggml-model.bin?download=true)
+[👉 Magic Setup (large)](https://tinyurl.com/f228efbu)
 [🔽 Direct Download (large)](https://huggingface.co/NbAiLab/nb-whisper-large/blob/main/ggml-model.bin?download=true)
 
-More sizes available via [their huggingface download page](https://huggingface.co/NbAiLab/nb-whisper-large).
+More models of smaller sizes are available via [their huggingface download page](https://huggingface.co/NbAiLab/nb-whisper-large).
 Find the size you want, download the *ggml-model.bin* file, rename the file, and palce it in vibe's model folder.
 </details>
 
 <details>
-<summary>🇸🇪 Swedish</summary
+<summary>🇸🇪 Swedish</summary>
 Optimised for Swedish by the [Data Lab at the National Library of Sweden](https://huggingface.co/KBLab).
 
-[👉 Magic Setup (medium)](vibe://download/?url=https://huggingface.co/KBLab/kb-whisper-medium/blob/main/ggml-model.bin?download=true)
+[👉 Magic Setup (medium)](https://tinyurl.com/ynawnc33)
 [🔽 Direct Download (medium)](https://huggingface.co/KBLab/kb-whisper-medium/blob/main/ggml-model.bin?download=true)
 
-[👉 Magic Setup (large v3)](vibe://download/?url=https://huggingface.co/KBLab/kb-whisper-large/blob/main/ggml-model.bin?download=true)
+[👉 Magic Setup (large v3)](https://tinyurl.com/46dvpeky)
 [🔽 Direct Download (large v3)](https://huggingface.co/KBLab/kb-whisper-large/blob/main/ggml-model.bin?download=true)
 
-More sizes available via [their huggingface download page](https://huggingface.co/KBLab/kb-whisper-large).
+More models of smaller sizes are available via [their huggingface download page](https://huggingface.co/KBLab/kb-whisper-large).
 Find the size you want, download the *ggml-model.bin* file, rename the file, and palce it in vibe's model folder.
 </details>
 </details>

--- a/docs/models.md
+++ b/docs/models.md
@@ -37,12 +37,45 @@ For high accuracy and more computational resources, excels in complex scenarios.
 [👉 Magic Setup](https://tinyurl.com/yphwban5)  
 [🔽 Direct Download](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin)
 
-### ✡️ Ivrit Model v3 Turbo (Recommended)
+### Models optimised for other languages
+
+<details>
+<summary>✡️ Hebrew (Ivrit)</summary>
 
 Specialized for Hebrew (Ivrit) language data, optimized for high speed and accuracy in Hebrew tasks.
 
-[👉 Magic Setup](https://tinyurl.com/t9r3tyxk)  
-[🔽 Direct Download](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin?download=true)
+[👉 Magic Setup (Large v3 Turbo)](https://tinyurl.com/t9r3tyxk)
+[🔽 Direct Download (Large v3 Turbo)](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin?download=true)	
+</details>
+
+<details>
+<summary>🇳🇴 Norwegian</summary>
+Optimised for Norwegian by the [AI Lab at the National Library of Norway](https://huggingface.co/NbAiLab).
+
+[👉 Magic Setup (medium)](vibe://download/?url=https://huggingface.co/NbAiLab/nb-whisper-medium/blob/main/ggml-model.bin?download=true)
+[🔽 Direct Download (medium)](https://huggingface.co/NbAiLab/nb-whisper-medium/blob/main/ggml-model.bin?download=true)
+
+[👉 Magic Setup (large)](vibe://download/?url=https://huggingface.co/NbAiLab/nb-whisper-large/blob/main/ggml-model.bin?download=true)
+[🔽 Direct Download (large)](https://huggingface.co/NbAiLab/nb-whisper-large/blob/main/ggml-model.bin?download=true)
+
+More sizes available via [their huggingface download page](https://huggingface.co/NbAiLab/nb-whisper-large).
+Find the size you want, download the *ggml-model.bin* file, rename the file, and palce it in vibe's model folder.
+</details>
+
+<details>
+<summary>🇸🇪 Swedish</summary
+Optimised for Swedish by the [Data Lab at the National Library of Sweden](https://huggingface.co/KBLab).
+
+[👉 Magic Setup (medium)](vibe://download/?url=https://huggingface.co/KBLab/kb-whisper-medium/blob/main/ggml-model.bin?download=true)
+[🔽 Direct Download (medium)](https://huggingface.co/KBLab/kb-whisper-medium/blob/main/ggml-model.bin?download=true)
+
+[👉 Magic Setup (large v3)](vibe://download/?url=https://huggingface.co/KBLab/kb-whisper-large/blob/main/ggml-model.bin?download=true)
+[🔽 Direct Download (large v3)](https://huggingface.co/KBLab/kb-whisper-large/blob/main/ggml-model.bin?download=true)
+
+More sizes available via [their huggingface download page](https://huggingface.co/KBLab/kb-whisper-large).
+Find the size you want, download the *ggml-model.bin* file, rename the file, and palce it in vibe's model folder.
+</details>
+</details>
 
 Enjoy exploring these models and enhancing your Vibe! 🌐✨
 


### PR DESCRIPTION
Hello,

I restructured the models page a bit and added models that I know are optimised for other languages and have a quasi-official status in these communities (Swedish and Norwegian, provided by their respective national libraries). I put them into fold-outs alongside the hebrew model.

Unsure if there would be a file conflict when downloading two models of the same name via vibe, as they don't seem to be renamed. One could potentially add the repository name, as the added models are all called `ggml-model.bin` and the size is in the repository name — sadly I cannot write Rust yet, so I don't think I can add that myself without causing chaos.