### PR TITLE
Fix: Add WMA to audio extensions

### DIFF
--- a/desktop/src/lib/config.ts
+++ b/desktop/src/lib/config.ts
@@ -44,5 +44,5 @@ export const ytDlpConfig = {
 }
 
 export const videoExtensions = ['mp4', 'mkv', 'avi', 'mov', 'wmv', 'webm']
-export const audioExtensions = ['mp3', 'wav', 'aac', 'flac', 'oga', 'ogg', 'opic', 'opus', 'm4a']
+export const audioExtensions = ['mp3', 'wav', 'aac', 'flac', 'oga', 'ogg', 'opic', 'opus', 'm4a', 'wma']
 export const themes = ['light', 'dark']


### PR DESCRIPTION
Currently, the program doesn't let users easily open WMA audio files. However, after dragging and dropping such files to the file dialog on Linux, one can observe that the files are just as well supported.

Fix this by adding the WMA file extension to the supported audio extensions, so that opening such files is possible without workarounds.