### PR TITLE
perf(macos): refactor screencapture audio path to direct WAV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,9 +705,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -1512,7 +1512,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.5",
 ]
 
 [[package]]
@@ -3133,7 +3133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6992,6 +6992,7 @@ version = "0.0.6"
 dependencies = [
  "ash",
  "axum",
+ "bytemuck",
  "chrono",
  "clap",
  "cocoa",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ glob = "0.3.1"
 chrono = "0.4.38"
 crash-handler = "0.6.2"
 urlencoding = "2.1.3"
+bytemuck = "1.24.0"
 
 
 # Linux


### PR DESCRIPTION
### Summary
Refactored the macOS screencapture audio flow to write directly to WAV
instead of producing intermediate raw PCM files.

### Motivation
Previously the pipeline dumped *.raw data and then converted it to WAV.
This consumed extra disk space and added post-processing time.

### Approach
- Receive f32 samples from ScreenCaptureKit.  
- Cast directly to i16.  
- Write samples with `hound::WavWriter` (no intermediate *.raw step).

### Impact
- Eliminates temporary *.raw files, reducing disk usage.  
- Removes PCM → WAV conversion step, reducing overall processing time.  
- Final output remains a standard WAV file.

### Open Questions
- I have not benchmarked the performance yet.  
- If there is an existing benchmark script or preferred method, I can run it
  and update this PR with results.