### PR TITLE
Adds a section to the README on how to start development

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -22,7 +22,7 @@ Make sure to install XCode from the AppStore and open it once so it will downloa
 Run the pre-build script (downloads the sona sidecar binary and sets up platform deps):
 
 ```console
-uv run --script scripts/pre_build.py
+uv run scripts/pre_build.py
 ```
 
 Install frontend dependencies from `desktop` folder:
@@ -48,6 +48,14 @@ You can also do it all in one step:
 
 ```console
 uv run scripts/pre_build.py --dev   # or --build
+```
+
+## Build sona locally (dev)
+
+Download prebuilt whisper.cpp libs (one-time):
+
+```console
+uv run sona/scripts/download-libs.py
 ```
 
 **Windows only** — install [MSYS2](https://www.msys2.org/), then install MinGW and Vulkan headers:


### PR DESCRIPTION
## Summary

- Add a **Developers** link in the `README.md` Contribute section pointing to `docs/building.md`, so contributors can find setup instructions without digging through the repo
- Fix `uv run` command: add missing `--script` flag required for PEP 723 inline-metadata scripts
- Remove the **"Build sona locally (dev)"** section from `docs/building.md` — `sona/scripts/download-libs.py` no longer exists in the repository, and `scripts/pre_build.py` already handles downloading prebuilt sona binaries from GitHub Releases, making the old build-from-source instructions obsolete