### PR TITLE
fix: update supported languages dict to match available locales

### DIFF
--- a/desktop/src/lib/i18n.ts
+++ b/desktop/src/lib/i18n.ts
@@ -8,6 +8,7 @@ import { initReactI18next } from 'react-i18next/initReactI18next'
 // See src-tauri/locales/ for the list of supported languages
 // Please keep the list sorted alphabetically
 export const supportedLanguages: { [key: string]: string } = {
+	'ca-AD': 'catalan', // Catalan
 	'en-US': 'english', // English
 	'es-ES': 'spanish (ES)', // Spanish (ES)
 	'es-MX': 'spanish (MX)', // Spanish (MX)
@@ -22,7 +23,7 @@ export const supportedLanguages: { [key: string]: string } = {
 	'pt-BR': 'portuguese', // Portuguese (BR)
 	'ru-RU': 'russian', // Russian
 	'sv-SE': 'swedish', // Swedish
-	'ta-IN': 'tamil', // Tamil
+	'tr-TR': 'turkish', // Turkish
 	'vi-VN': 'vietnamese', // Vietnamese
 	'zh-CN': 'chinese', // Chinese (Simplified)
 	'zh-HK': 'chinese (HK)', // Chinese (Traditional)


### PR DESCRIPTION
This PR updates `desktop/src/lib/i18n.ts` so the `supportedLanguages` map matches the actual locales shipped in `desktop/src-tauri/locales`.

- Added missing locales: `ca-AD` (Catalan) and `tr-TR` (Turkish)
- Removed unsupported locale: `ta-IN` (Tamil), which no longer exists in the locales folder
- Kept the language map sorted by locale key for maintainability

This prevents the app from advertising unsupported locales and ensures all available locale bundles are represented.