### PR TITLE
Add Rust Sona-compatible sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.exe
 *.dylib
 target/
+.models/
 *.old.json
 ffmpeg.framework/
 ffmpeg*-default/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +78,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f109ee76f68b4767848cb5dc93bfcc7c425deca849c4c81fa11cdce525e3d2"
 dependencies = [
  "apple-sdk",
- "bindgen",
+ "bindgen 0.63.0",
  "derive_more",
  "regex",
  "serde",
@@ -393,6 +457,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +526,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -424,6 +553,26 @@ dependencies = [
  "shlex",
  "syn 1.0.109",
  "which 4.4.2",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -603,6 +752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +846,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +917,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -957,6 +1176,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1265,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -1047,6 +1295,20 @@ dependencies = [
  "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1076,6 +1338,17 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
@@ -1083,6 +1356,15 @@ dependencies = [
  "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1096,6 +1378,16 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1135,7 +1427,16 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f59169f400d8087f238c5c0c7db6a28af18681717f3b623227d92f397e938c7"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.13.1",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro 0.20.2",
 ]
 
 [[package]]
@@ -1151,13 +1452,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870368c3fb35b8031abb378861d4460f573b92238ec2152c927a21f77e3e0127"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.13.1",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core 0.20.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1431,6 +1754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1795,16 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1563,6 +1902,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2193,6 +2533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,6 +2611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2630,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2600,6 +2953,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,7 +3078,7 @@ dependencies = [
  "apple-sys",
  "cfg-if",
  "core-foundation 0.9.4",
- "derive_builder",
+ "derive_builder 0.13.1",
  "thiserror 1.0.69",
  "windows 0.52.0",
  "zbus 3.15.2",
@@ -2872,6 +3249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +3300,22 @@ dependencies = [
  "windows-registry 0.6.1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "malloc_buf"
@@ -2966,6 +3365,22 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "memchr"
@@ -3050,6 +3465,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,6 +3518,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +3549,21 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -3216,6 +3685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3708,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3652,6 +4139,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,6 +4259,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +4348,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "parakeet-rs"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c54ec33ff53d2078cc6a48dcdd9c50c229905e392743375e29652a2b9a369e"
+dependencies = [
+ "eyre 0.6.12",
+ "hound",
+ "ndarray",
+ "ort",
+ "realfft",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,6 +4393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,6 +4409,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4105,6 +4675,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4142,6 +4727,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -4461,6 +5055,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,6 +5307,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,6 +5391,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -5040,6 +5728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,6 +5952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5301,6 +6011,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,6 +6039,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -5928,7 +6662,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -6060,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.4.2",
@@ -6211,6 +6945,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder 0.20.2",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6220,6 +6987,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -6253,6 +7021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -6421,6 +7200,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6434,11 +7214,13 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6526,6 +7308,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -6644,6 +7436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6656,10 +7457,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -6699,10 +7536,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip 3.0.0",
+]
 
 [[package]]
 name = "uuid"
@@ -6749,7 +7640,7 @@ dependencies = [
  "cpal",
  "crash-handler",
  "enigo",
- "eyre",
+ "eyre 1.0.0",
  "futures",
  "futures-util",
  "glob",
@@ -6793,6 +7684,27 @@ dependencies = [
  "which 8.0.0",
  "windows 0.62.2",
  "winreg",
+]
+
+[[package]]
+name = "vibe-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "hound",
+ "parakeet-rs",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tower-http",
+ "utoipa",
+ "utoipa-swagger-ui",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -7191,6 +8103,24 @@ dependencies = [
  "env_home",
  "rustix 1.1.4",
  "winsafe",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "cmake",
 ]
 
 [[package]]
@@ -8347,6 +9277,20 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -8358,10 +9302,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["desktop/src-tauri"]
+members = [
+	"crates/vibe-server",
+	"crates/whisper-rs",
+	"crates/whisper-rs-sys",
+	"desktop/src-tauri",
+]
 resolver = "2"
 
 [workspace.dependencies]
@@ -7,6 +12,8 @@ eyre = { git = "https://github.com/thewh1teagle/eyre", branch = "feat/report-ser
 	"serialize",
 ] }
 serde_json = "1.0"
+whisper-rs = { path = "crates/whisper-rs" }
+whisper-rs-sys = { path = "crates/whisper-rs-sys" }
 
 # https://v1.tauri.app/v1/guides/building/app-size/#rust-build-time-optimizations
 [profile.release]

--- a/crates/vibe-server/Cargo.toml
+++ b/crates/vibe-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vibe-server"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "vibe-server"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.100"
+axum = { version = "0.8.7", features = ["multipart"] }
+clap = { version = "4.5.53", features = ["derive"] }
+hound = "3.5.1"
+parakeet-rs = { version = "0.3.2", features = ["sortformer"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+tokio = { version = "1.48.0", features = ["fs", "macros", "net", "rt-multi-thread", "signal", "time"] }
+tokio-stream = "0.1.17"
+tower-http = { version = "0.6.7", features = ["catch-panic", "cors", "trace"] }
+utoipa = { version = "5.4.0", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
+whisper-rs = { workspace = true }

--- a/crates/vibe-server/src/audio.rs
+++ b/crates/vibe-server/src/audio.rs
@@ -1,0 +1,147 @@
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+pub fn read_audio_mono_f32(path: &Path, enhance_audio: bool) -> Result<Vec<f32>> {
+    if !enhance_audio {
+        if let Ok(samples) = read_wav_mono_f32(path) {
+            return Ok(samples);
+        }
+    }
+
+    let native_wav = tempfile::Builder::new()
+        .prefix("vibe-audio-")
+        .suffix(".wav")
+        .tempfile()
+        .context("create converted wav")?;
+    convert_to_native_wav(path, native_wav.path(), enhance_audio)?;
+    read_wav_mono_f32(native_wav.path())
+}
+
+pub fn read_wav_mono_f32(path: &Path) -> Result<Vec<f32>> {
+    let mut reader = hound::WavReader::open(path).context("open wav")?;
+    let spec = reader.spec();
+    if spec.channels == 0 {
+        bail!("wav has no channels");
+    }
+
+    let channels = spec.channels as usize;
+    let mut frames = Vec::new();
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            let samples = reader.samples::<f32>().collect::<Result<Vec<_>, _>>()?;
+            mix_channels(samples, channels, &mut frames);
+        }
+        hound::SampleFormat::Int => {
+            if spec.bits_per_sample <= 16 {
+                let samples = reader
+                    .samples::<i16>()
+                    .map(|sample| sample.map(|value| value as f32 / i16::MAX as f32))
+                    .collect::<Result<Vec<_>, _>>()?;
+                mix_channels(samples, channels, &mut frames);
+            } else {
+                let scale = ((1_i64 << (spec.bits_per_sample - 1)) - 1) as f32;
+                let samples = reader
+                    .samples::<i32>()
+                    .map(|sample| sample.map(|value| value as f32 / scale))
+                    .collect::<Result<Vec<_>, _>>()?;
+                mix_channels(samples, channels, &mut frames);
+            }
+        }
+    }
+
+    if spec.sample_rate == 16_000 {
+        Ok(frames)
+    } else {
+        Ok(resample_linear(&frames, spec.sample_rate, 16_000))
+    }
+}
+
+fn convert_to_native_wav(input: &Path, output: &Path, enhance_audio: bool) -> Result<()> {
+    let ffmpeg = find_ffmpeg()?;
+    let mut args = vec![
+        "-i".to_string(),
+        input.display().to_string(),
+        "-ar".to_string(),
+        "16000".to_string(),
+        "-ac".to_string(),
+        "1".to_string(),
+    ];
+    if enhance_audio {
+        args.extend([
+            "-af".to_string(),
+            "silenceremove=stop_periods=-1:stop_duration=0.7:stop_threshold=-45dB".to_string(),
+        ]);
+    }
+    args.extend([
+        "-acodec".to_string(),
+        "pcm_s16le".to_string(),
+        "-y".to_string(),
+        output.display().to_string(),
+    ]);
+
+    let output = Command::new(ffmpeg).args(args).output().context("run ffmpeg")?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = if stderr.len() > 500 { &stderr[..500] } else { &stderr };
+    bail!("ffmpeg WAV conversion failed: {stderr}")
+}
+
+fn find_ffmpeg() -> Result<std::path::PathBuf> {
+    if let Some(path) = find_executable_in_path("ffmpeg") {
+        return Ok(path);
+    }
+    for key in ["VIBE_FFMPEG_PATH", "SONA_FFMPEG_PATH"] {
+        if let Some(path) = std::env::var_os(key).map(std::path::PathBuf::from) {
+            if path.exists() {
+                return Ok(path);
+            }
+        }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            for name in ["ffmpeg", "ffmpeg.exe"] {
+                let candidate = dir.join(name);
+                if candidate.exists() {
+                    return Ok(candidate);
+                }
+            }
+        }
+    }
+    bail!("ffmpeg not found")
+}
+
+fn find_executable_in_path(name: &str) -> Option<std::path::PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .map(|path| path.join(name))
+            .find(|path| path.exists())
+    })
+}
+
+fn mix_channels(samples: Vec<f32>, channels: usize, out: &mut Vec<f32>) {
+    out.reserve(samples.len() / channels);
+    for frame in samples.chunks(channels) {
+        out.push(frame.iter().copied().sum::<f32>() / frame.len() as f32);
+    }
+}
+
+fn resample_linear(input: &[f32], from: u32, to: u32) -> Vec<f32> {
+    if input.is_empty() || from == to {
+        return input.to_vec();
+    }
+    let output_len = input.len() * to as usize / from as usize;
+    let ratio = from as f64 / to as f64;
+    let mut output = Vec::with_capacity(output_len);
+    for index in 0..output_len {
+        let position = index as f64 * ratio;
+        let left = position.floor() as usize;
+        let right = (left + 1).min(input.len() - 1);
+        let frac = (position - left as f64) as f32;
+        output.push(input[left] * (1.0 - frac) + input[right] * frac);
+    }
+    output
+}

--- a/crates/vibe-server/src/cli.rs
+++ b/crates/vibe-server/src/cli.rs
@@ -1,0 +1,99 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{ArgAction, Parser, Subcommand};
+use whisper_rs::{TranscribeOptions, WhisperContext, list_gpu_devices};
+
+use crate::audio::read_audio_mono_f32;
+use crate::parent::watch_parent;
+use crate::server::listen_and_serve;
+use crate::state::ServerState;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const COMMIT: &str = match option_env!("VIBE_COMMIT") {
+    Some(commit) => commit,
+    None => "dev",
+};
+
+#[derive(Debug, Parser)]
+#[command(name = "vibe-server", version = VERSION, about = "Vibe local transcription sidecar")]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Serve {
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+        #[arg(long, short, default_value_t = 0)]
+        port: u16,
+        #[arg(long, default_value_t = true, action = ArgAction::Set)]
+        exit_with_parent: bool,
+        model: Option<PathBuf>,
+    },
+    Transcribe {
+        model: PathBuf,
+        audio: PathBuf,
+        #[arg(long, short, default_value = "")]
+        language: String,
+        #[arg(long)]
+        translate: bool,
+        #[arg(long)]
+        detect_language: bool,
+        #[arg(long, default_value_t = -1)]
+        gpu_device: i32,
+        #[arg(long)]
+        no_gpu: bool,
+    },
+    Devices,
+}
+
+pub async fn run() -> Result<()> {
+    match Args::parse().command {
+        Command::Serve {
+            host,
+            port,
+            exit_with_parent,
+            model,
+        } => {
+            if exit_with_parent {
+                tokio::spawn(watch_parent());
+            }
+            let state = ServerState::new(VERSION, COMMIT);
+            if let Some(path) = model {
+                state.load_model(path.to_string_lossy().as_ref(), None, false).await?;
+            }
+            listen_and_serve(&host, port, state).await
+        }
+        Command::Transcribe {
+            model,
+            audio,
+            language,
+            translate,
+            detect_language,
+            gpu_device,
+            no_gpu,
+        } => {
+            let samples = read_audio_mono_f32(&audio, false).context("read audio")?;
+            let device = (gpu_device >= 0).then_some(gpu_device);
+            let mut ctx = WhisperContext::new(model.to_string_lossy().as_ref(), device, no_gpu)?;
+            let result = ctx.transcribe(
+                &samples,
+                TranscribeOptions {
+                    language,
+                    translate,
+                    detect_language,
+                    ..Default::default()
+                },
+            )?;
+            println!("{}", result.text());
+            Ok(())
+        }
+        Command::Devices => {
+            println!("{}", serde_json::to_string_pretty(&list_gpu_devices())?);
+            Ok(())
+        }
+    }
+}

--- a/crates/vibe-server/src/diarization.rs
+++ b/crates/vibe-server/src/diarization.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use parakeet_rs::sortformer::{DiarizationConfig, Sortformer};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpeakerSegment {
+    pub start: f64,
+    pub end: f64,
+    pub speaker_id: i32,
+}
+
+pub fn diarize(model_path: &str, samples: &[f32]) -> Result<Vec<SpeakerSegment>> {
+    let mut sortformer = Sortformer::with_config(model_path, None, DiarizationConfig::callhome())?;
+    let segments = sortformer.diarize(samples.to_vec(), 16_000, 1)?;
+    Ok(segments
+        .into_iter()
+        .map(|segment| SpeakerSegment {
+            start: segment.start as f64 / 16_000.0,
+            end: segment.end as f64 / 16_000.0,
+            speaker_id: segment.speaker_id as i32,
+        })
+        .collect())
+}
+
+pub fn match_speaker(start: f64, end: f64, segments: &[SpeakerSegment]) -> Option<i32> {
+    segments
+        .iter()
+        .filter_map(|segment| {
+            let overlap_start = start.max(segment.start);
+            let overlap_end = end.min(segment.end);
+            let overlap = overlap_end - overlap_start;
+            (overlap > 0.0).then_some((overlap, segment.speaker_id))
+        })
+        .max_by(|left, right| left.0.total_cmp(&right.0))
+        .map(|(_, speaker)| speaker)
+}

--- a/crates/vibe-server/src/docs.rs
+++ b/crates/vibe-server/src/docs.rs
@@ -1,0 +1,195 @@
+#![allow(dead_code)]
+
+use utoipa::OpenApi;
+
+use crate::server::requests::LoadModelRequest;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        health,
+        ready,
+        models,
+        load_model,
+        unload_model,
+        transcriptions,
+        devices,
+    ),
+    components(schemas(
+        LoadModelRequest,
+        ModelLoadResponse,
+        ModelListResponse,
+        ReadyResponse,
+        StatusResponse,
+        TextResponse,
+        TranscriptionForm,
+        VerboseJsonResponse,
+        VerboseSegmentResponse,
+        GpuDeviceResponse,
+    )),
+    tags(
+        (name = "vibe-server", description = "Local Vibe transcription sidecar")
+    )
+)]
+pub struct ApiDoc;
+
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses((status = 200, description = "Process is alive", body = StatusResponse))
+)]
+fn health() {}
+
+#[utoipa::path(
+    get,
+    path = "/ready",
+    responses(
+        (status = 200, description = "Model loaded", body = ReadyResponse),
+        (status = 503, description = "No model loaded", body = ReadyResponse)
+    )
+)]
+fn ready() {}
+
+#[utoipa::path(
+    get,
+    path = "/v1/models",
+    responses((status = 200, description = "Loaded models", body = ModelListResponse))
+)]
+fn models() {}
+
+#[utoipa::path(
+    post,
+    path = "/v1/models/load",
+    request_body = LoadModelRequest,
+    responses((status = 200, description = "Model loaded", body = ModelLoadResponse))
+)]
+fn load_model() {}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/models",
+    responses((status = 200, description = "Model unloaded", body = StatusResponse))
+)]
+fn unload_model() {}
+
+#[utoipa::path(
+    post,
+    path = "/v1/audio/transcriptions",
+    request_body(content = TranscriptionForm, content_type = "multipart/form-data"),
+    responses(
+        (status = 200, description = "Transcription result. Body depends on response_format: json, verbose_json, text, srt, vtt, or application/x-ndjson when stream=true."),
+        (status = 400, description = "Invalid request or audio"),
+        (status = 429, description = "Server is busy"),
+        (status = 503, description = "No model loaded")
+    )
+)]
+fn transcriptions() {}
+
+#[utoipa::path(
+    get,
+    path = "/v1/devices",
+    responses((status = 200, description = "GPU devices", body = Vec<GpuDeviceResponse>))
+)]
+fn devices() {}
+
+#[derive(utoipa::ToSchema)]
+struct TranscriptionForm {
+    #[schema(value_type = String, format = Binary)]
+    file: String,
+    language: Option<String>,
+    prompt: Option<String>,
+    detect_language: Option<bool>,
+    enhance_audio: Option<bool>,
+    response_format: Option<ResponseFormat>,
+    stream: Option<bool>,
+    model: Option<String>,
+    beam_size: Option<i32>,
+    best_of: Option<i32>,
+    diarize_model: Option<String>,
+    max_segment_len: Option<i32>,
+    max_text_ctx: Option<i32>,
+    n_threads: Option<i32>,
+    sampling_strategy: Option<SamplingStrategy>,
+    stable_timestamps: Option<bool>,
+    temperature: Option<f32>,
+    translate: Option<bool>,
+    vad_model: Option<String>,
+    word_timestamps: Option<bool>,
+}
+
+#[derive(utoipa::ToSchema)]
+#[schema(rename_all = "snake_case")]
+enum ResponseFormat {
+    Json,
+    VerboseJson,
+    Text,
+    Srt,
+    Vtt,
+}
+
+#[derive(utoipa::ToSchema)]
+#[schema(rename_all = "snake_case")]
+enum SamplingStrategy {
+    Greedy,
+    BeamSearch,
+}
+
+#[derive(utoipa::ToSchema)]
+struct StatusResponse {
+    status: String,
+}
+
+#[derive(utoipa::ToSchema)]
+struct ReadyResponse {
+    status: String,
+    model: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(utoipa::ToSchema)]
+struct ModelLoadResponse {
+    status: String,
+    model: String,
+}
+
+#[derive(utoipa::ToSchema)]
+struct ModelListResponse {
+    object: String,
+    data: Vec<ModelItemResponse>,
+}
+
+#[derive(utoipa::ToSchema)]
+struct ModelItemResponse {
+    id: String,
+    object: String,
+    created: i64,
+    owned_by: String,
+}
+
+#[derive(utoipa::ToSchema)]
+struct TextResponse {
+    text: String,
+}
+
+#[derive(utoipa::ToSchema)]
+struct VerboseJsonResponse {
+    text: String,
+    segments: Vec<VerboseSegmentResponse>,
+}
+
+#[derive(utoipa::ToSchema)]
+struct VerboseSegmentResponse {
+    start: f64,
+    end: f64,
+    text: String,
+    speaker: Option<i32>,
+}
+
+#[derive(utoipa::ToSchema)]
+struct GpuDeviceResponse {
+    index: i32,
+    name: String,
+    description: String,
+    #[schema(rename = "type")]
+    device_type: String,
+}

--- a/crates/vibe-server/src/errors.rs
+++ b/crates/vibe-server/src/errors.rs
@@ -1,0 +1,65 @@
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ErrorCode {
+    InvalidRequest,
+    InvalidAudio,
+    NoModel,
+    Busy,
+    InternalError,
+}
+
+impl ErrorCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::InvalidAudio => "invalid_audio",
+            Self::NoModel => "no_model",
+            Self::Busy => "busy",
+            Self::InternalError => "internal_error",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(status: StatusCode, code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ErrorEnvelope {
+            error: ErrorBody {
+                code: self.code.as_str(),
+                message: &self.message,
+            },
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorEnvelope<'a> {
+    error: ErrorBody<'a>,
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    code: &'a str,
+    message: &'a str,
+}

--- a/crates/vibe-server/src/formats.rs
+++ b/crates/vibe-server/src/formats.rs
@@ -1,0 +1,93 @@
+use serde::Serialize;
+use whisper_rs::{Segment, TranscribeResult};
+
+use crate::diarization::{SpeakerSegment, match_speaker};
+
+pub fn seconds(cs: i64) -> f64 {
+    cs as f64 / 100.0
+}
+
+pub fn srt(segments: &[Segment]) -> String {
+    let mut out = String::new();
+    for (index, segment) in segments.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "{}\n{} --> {}\n{}\n",
+            index + 1,
+            srt_time(segment.start_cs),
+            srt_time(segment.end_cs),
+            segment.text.trim()
+        ));
+    }
+    out
+}
+
+pub fn vtt(segments: &[Segment]) -> String {
+    let mut out = String::from("WEBVTT\n\n");
+    for (index, segment) in segments.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "{} --> {}\n{}\n",
+            vtt_time(segment.start_cs),
+            vtt_time(segment.end_cs),
+            segment.text.trim()
+        ));
+    }
+    out
+}
+
+pub fn verbose_json_with_speakers(result: &TranscribeResult, speaker_segments: &[SpeakerSegment]) -> VerboseJson {
+    VerboseJson {
+        text: result.text(),
+        segments: result
+            .segments
+            .iter()
+            .map(|segment| VerboseSegment {
+                start: seconds(segment.start_cs),
+                end: seconds(segment.end_cs),
+                text: segment.text.clone(),
+                speaker: match_speaker(seconds(segment.start_cs), seconds(segment.end_cs), speaker_segments),
+            })
+            .collect(),
+    }
+}
+
+#[derive(Serialize)]
+pub struct VerboseJson {
+    pub text: String,
+    pub segments: Vec<VerboseSegment>,
+}
+
+#[derive(Serialize)]
+pub struct VerboseSegment {
+    pub start: f64,
+    pub end: f64,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<i32>,
+}
+
+fn srt_time(cs: i64) -> String {
+    let (h, m, s, ms) = split_time(cs);
+    format!("{h:02}:{m:02}:{s:02},{ms:03}")
+}
+
+fn vtt_time(cs: i64) -> String {
+    let (h, m, s, ms) = split_time(cs);
+    format!("{h:02}:{m:02}:{s:02}.{ms:03}")
+}
+
+fn split_time(cs: i64) -> (i64, i64, i64, i64) {
+    let total_ms = cs * 10;
+    let total_s = total_ms / 1000;
+    let ms = total_ms % 1000;
+    let s = total_s % 60;
+    let total_m = total_s / 60;
+    let m = total_m % 60;
+    let h = total_m / 60;
+    (h, m, s, ms)
+}

--- a/crates/vibe-server/src/main.rs
+++ b/crates/vibe-server/src/main.rs
@@ -1,0 +1,18 @@
+mod audio;
+mod cli;
+mod diarization;
+mod docs;
+mod errors;
+mod formats;
+mod parent;
+mod server;
+mod state;
+mod transcription;
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = cli::run().await {
+        eprintln!("{err:#}");
+        std::process::exit(1);
+    }
+}

--- a/crates/vibe-server/src/parent.rs
+++ b/crates/vibe-server/src/parent.rs
@@ -1,0 +1,19 @@
+pub async fn watch_parent() {
+    loop {
+        #[cfg(unix)]
+        {
+            if unsafe { libc_parent_pid() } == 1 {
+                std::process::exit(0);
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+}
+
+#[cfg(unix)]
+unsafe fn libc_parent_pid() -> i32 {
+    unsafe extern "C" {
+        fn getppid() -> i32;
+    }
+    unsafe { getppid() }
+}

--- a/crates/vibe-server/src/server/handlers/devices.rs
+++ b/crates/vibe-server/src/server/handlers/devices.rs
@@ -1,0 +1,6 @@
+use axum::Json;
+use whisper_rs::{GpuDevice, list_gpu_devices};
+
+pub async fn devices() -> Json<Vec<GpuDevice>> {
+    Json(list_gpu_devices())
+}

--- a/crates/vibe-server/src/server/handlers/health.rs
+++ b/crates/vibe-server/src/server/handlers/health.rs
@@ -1,0 +1,11 @@
+use axum::Json;
+use serde::Serialize;
+
+pub async fn health() -> Json<StatusBody> {
+    Json(StatusBody { status: "ok" })
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct StatusBody {
+    pub status: &'static str,
+}

--- a/crates/vibe-server/src/server/handlers/mod.rs
+++ b/crates/vibe-server/src/server/handlers/mod.rs
@@ -1,0 +1,11 @@
+mod devices;
+mod health;
+mod models;
+mod ready;
+mod transcription;
+
+pub use devices::devices;
+pub use health::health;
+pub use models::{load_model, models, unload_model};
+pub use ready::ready;
+pub use transcription::transcribe;

--- a/crates/vibe-server/src/server/handlers/models.rs
+++ b/crates/vibe-server/src/server/handlers/models.rs
@@ -1,0 +1,78 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use crate::errors::{ApiError, ErrorCode};
+use crate::server::requests::LoadModelRequest;
+use crate::state::SharedState;
+
+pub async fn load_model(
+    State(state): State<SharedState>,
+    Json(request): Json<LoadModelRequest>,
+) -> Result<Json<ModelLoadedBody>, ApiError> {
+    request.validate()?;
+    let model = state
+        .load_model(&request.path, request.gpu_device, request.no_gpu)
+        .await
+        .map_err(|err| {
+            ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorCode::InternalError,
+                format!("failed to load model: {err}"),
+            )
+        })?;
+    Ok(Json(ModelLoadedBody { status: "loaded", model }))
+}
+
+pub async fn unload_model(State(state): State<SharedState>) -> Json<StatusBody> {
+    state.unload_model().await;
+    Json(StatusBody { status: "unloaded" })
+}
+
+pub async fn models(State(state): State<SharedState>) -> Json<ModelList> {
+    let status = state.status().await;
+    let data = if status.loaded {
+        vec![ModelItem {
+            id: status.model_name,
+            object: "model",
+            created: current_unix_time(),
+            owned_by: "local",
+        }]
+    } else {
+        Vec::new()
+    };
+    Json(ModelList { object: "list", data })
+}
+
+fn current_unix_time() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct ModelLoadedBody {
+    pub status: &'static str,
+    pub model: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct StatusBody {
+    pub status: &'static str,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct ModelList {
+    pub object: &'static str,
+    pub data: Vec<ModelItem>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct ModelItem {
+    pub id: String,
+    pub object: &'static str,
+    pub created: i64,
+    pub owned_by: &'static str,
+}

--- a/crates/vibe-server/src/server/handlers/ready.rs
+++ b/crates/vibe-server/src/server/handlers/ready.rs
@@ -1,0 +1,38 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use crate::state::SharedState;
+
+pub async fn ready(State(state): State<SharedState>) -> (StatusCode, Json<ReadyBody>) {
+    let status = state.status().await;
+    if status.loaded {
+        (
+            StatusCode::OK,
+            Json(ReadyBody {
+                status: "ready",
+                model: Some(status.model_name),
+                message: None,
+            }),
+        )
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ReadyBody {
+                status: "not_ready",
+                model: None,
+                message: Some("no model loaded"),
+            }),
+        )
+    }
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct ReadyBody {
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<&'static str>,
+}

--- a/crates/vibe-server/src/server/handlers/transcription.rs
+++ b/crates/vibe-server/src/server/handlers/transcription.rs
@@ -1,0 +1,10 @@
+use axum::extract::{Multipart, State};
+use axum::response::Response;
+
+use crate::errors::ApiError;
+use crate::state::SharedState;
+use crate::transcription;
+
+pub async fn transcribe(State(state): State<SharedState>, multipart: Multipart) -> Result<Response, ApiError> {
+    transcription::transcribe(state, multipart).await
+}

--- a/crates/vibe-server/src/server/mod.rs
+++ b/crates/vibe-server/src/server/mod.rs
@@ -1,0 +1,17 @@
+mod ready_signal;
+pub(crate) mod requests;
+mod routes;
+
+mod handlers;
+
+use anyhow::Result;
+use tokio::net::TcpListener;
+
+use crate::state::SharedState;
+
+pub async fn listen_and_serve(host: &str, port: u16, state: SharedState) -> Result<()> {
+    let listener = TcpListener::bind(format!("{host}:{port}")).await?;
+    ready_signal::print(listener.local_addr()?.port(), &state).await?;
+    axum::serve(listener, routes::router(state).into_make_service()).await?;
+    Ok(())
+}

--- a/crates/vibe-server/src/server/ready_signal.rs
+++ b/crates/vibe-server/src/server/ready_signal.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::state::SharedState;
+
+pub async fn print(port: u16, state: &SharedState) -> Result<()> {
+    let status = state.status().await;
+    let signal = ReadySignal {
+        status: "ready",
+        port,
+        version: &status.version,
+        commit: &status.commit,
+    };
+    println!("{}", serde_json::to_string(&signal)?);
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct ReadySignal<'a> {
+    status: &'a str,
+    port: u16,
+    version: &'a str,
+    commit: &'a str,
+}

--- a/crates/vibe-server/src/server/requests.rs
+++ b/crates/vibe-server/src/server/requests.rs
@@ -1,0 +1,26 @@
+use axum::http::StatusCode;
+use serde::Deserialize;
+
+use crate::errors::{ApiError, ErrorCode};
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct LoadModelRequest {
+    pub path: String,
+    pub gpu_device: Option<i32>,
+    #[serde(default)]
+    pub no_gpu: bool,
+}
+
+impl LoadModelRequest {
+    pub fn validate(&self) -> Result<(), ApiError> {
+        if self.path.is_empty() {
+            Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                "request body must contain {\"path\":\"...\"}",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crates/vibe-server/src/server/routes.rs
+++ b/crates/vibe-server/src/server/routes.rs
@@ -1,0 +1,27 @@
+use axum::Router;
+use axum::extract::DefaultBodyLimit;
+use axum::routing::{get, post};
+use tower_http::catch_panic::CatchPanicLayer;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+use utoipa::OpenApi;
+
+use crate::docs::ApiDoc;
+use crate::server::handlers::{devices, health, load_model, models, ready, transcribe, unload_model};
+use crate::state::SharedState;
+
+pub fn router(state: SharedState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/ready", get(ready))
+        .route("/v1/models", get(models).delete(unload_model))
+        .route("/v1/models/load", post(load_model))
+        .route("/v1/audio/transcriptions", post(transcribe))
+        .route("/v1/devices", get(devices))
+        .merge(utoipa_swagger_ui::SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))
+        .layer(DefaultBodyLimit::max(15 << 30))
+        .layer(CorsLayer::permissive())
+        .layer(TraceLayer::new_for_http())
+        .layer(CatchPanicLayer::new())
+        .with_state(state)
+}

--- a/crates/vibe-server/src/state.rs
+++ b/crates/vibe-server/src/state.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use serde::Serialize;
+use tokio::sync::{Mutex, OwnedMutexGuard, TryLockError};
+use whisper_rs::WhisperContext;
+
+pub type SharedState = Arc<ServerState>;
+
+pub struct ServerState {
+    inner: Arc<Mutex<InnerState>>,
+    version: String,
+    commit: String,
+}
+
+struct InnerState {
+    context: Option<WhisperContext>,
+    model_name: String,
+    model_path: String,
+}
+
+impl ServerState {
+    pub fn new(version: &str, commit: &str) -> SharedState {
+        Arc::new(Self {
+            inner: Arc::new(Mutex::new(InnerState {
+                context: None,
+                model_name: String::new(),
+                model_path: String::new(),
+            })),
+            version: version.to_string(),
+            commit: commit.to_string(),
+        })
+    }
+
+    pub async fn load_model(&self, path: &str, gpu_device: Option<i32>, no_gpu: bool) -> Result<String> {
+        let mut state = self.inner.lock().await;
+        let context = WhisperContext::new(path, gpu_device, no_gpu)?;
+        state.context = Some(context);
+        state.model_path = path.to_string();
+        state.model_name = std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(path)
+            .to_string();
+        Ok(state.model_name.clone())
+    }
+
+    pub async fn unload_model(&self) {
+        let mut state = self.inner.lock().await;
+        state.context = None;
+        state.model_name.clear();
+        state.model_path.clear();
+    }
+
+    pub async fn status(&self) -> ModelStatus {
+        let state = self.inner.lock().await;
+        ModelStatus {
+            loaded: state.context.is_some(),
+            model_name: state.model_name.clone(),
+            model_path: state.model_path.clone(),
+            version: self.version.clone(),
+            commit: self.commit.clone(),
+        }
+    }
+
+    pub fn try_transcriber(&self) -> Result<TranscriberGuard<'_>, TryLockError> {
+        self.inner.try_lock().map(|guard| TranscriberGuard { guard })
+    }
+
+    pub fn try_transcriber_owned(&self) -> Result<OwnedTranscriberGuard, TryLockError> {
+        self.inner
+            .clone()
+            .try_lock_owned()
+            .map(|guard| OwnedTranscriberGuard { guard })
+    }
+}
+
+pub struct TranscriberGuard<'a> {
+    guard: tokio::sync::MutexGuard<'a, InnerState>,
+}
+
+impl TranscriberGuard<'_> {
+    pub fn context(&mut self) -> Result<&mut WhisperContext> {
+        self.guard.context.as_mut().ok_or_else(|| anyhow!("no model loaded"))
+    }
+}
+
+pub struct OwnedTranscriberGuard {
+    guard: OwnedMutexGuard<InnerState>,
+}
+
+impl OwnedTranscriberGuard {
+    pub fn context(&mut self) -> Result<&mut WhisperContext> {
+        self.guard.context.as_mut().ok_or_else(|| anyhow!("no model loaded"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelStatus {
+    pub loaded: bool,
+    pub model_name: String,
+    pub model_path: String,
+    pub version: String,
+    pub commit: String,
+}

--- a/crates/vibe-server/src/transcription/form.rs
+++ b/crates/vibe-server/src/transcription/form.rs
@@ -1,0 +1,119 @@
+use std::io::Write;
+
+use axum::extract::Multipart;
+use axum::http::StatusCode;
+use tempfile::NamedTempFile;
+
+use crate::audio::read_audio_mono_f32;
+use crate::errors::{ApiError, ErrorCode};
+
+#[derive(Debug, Default)]
+pub struct RequestForm {
+    pub audio: Option<Vec<u8>>,
+    pub language: String,
+    pub prompt: String,
+    pub detect_language: bool,
+    pub enhance_audio: bool,
+    pub response_format: String,
+    pub stream: bool,
+    pub translate: bool,
+    pub word_timestamps: bool,
+    pub n_threads: i32,
+    pub max_segment_len: i32,
+    pub max_text_ctx: i32,
+    pub best_of: i32,
+    pub beam_size: i32,
+    pub temperature: f32,
+    pub sampling_strategy: String,
+    pub stable_timestamps: bool,
+    pub vad_model: String,
+    pub diarize_model: String,
+}
+
+impl RequestForm {
+    pub async fn from_multipart(mut multipart: Multipart) -> Result<Self, ApiError> {
+        let mut form = Self {
+            response_format: "json".to_string(),
+            ..Default::default()
+        };
+        while let Some(field) = multipart.next_field().await.map_err(invalid_form)? {
+            let name = field.name().unwrap_or("").to_string();
+            if name == "file" {
+                form.audio = Some(field.bytes().await.map_err(invalid_form)?.to_vec());
+            } else {
+                let value = field.text().await.map_err(invalid_form)?;
+                form.set_value(&name, value);
+            }
+        }
+        Ok(form)
+    }
+
+    pub fn read_samples(&self) -> Result<Vec<f32>, ApiError> {
+        let audio = self
+            .audio
+            .as_ref()
+            .ok_or_else(|| ApiError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, "missing file field"))?;
+        let mut temp = NamedTempFile::new().map_err(internal_error)?;
+        temp.write_all(audio).map_err(internal_error)?;
+        self.validate()?;
+        read_audio_mono_f32(temp.path(), self.enhance_audio).map_err(|err| {
+            ApiError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidAudio,
+                format!("invalid audio file: {err:#}"),
+            )
+        })
+    }
+
+    fn set_value(&mut self, name: &str, value: String) {
+        match name {
+            "language" => self.language = value,
+            "prompt" => self.prompt = value,
+            "detect_language" => self.detect_language = parse_bool(&value),
+            "enhance_audio" => self.enhance_audio = parse_bool(&value),
+            "response_format" => self.response_format = value,
+            "stream" => self.stream = parse_bool(&value),
+            "translate" => self.translate = parse_bool(&value),
+            "word_timestamps" => self.word_timestamps = parse_bool(&value),
+            "n_threads" => self.n_threads = parse_i32(&value),
+            "max_segment_len" => self.max_segment_len = parse_i32(&value),
+            "max_text_ctx" => self.max_text_ctx = parse_i32(&value),
+            "best_of" => self.best_of = parse_i32(&value),
+            "beam_size" => self.beam_size = parse_i32(&value),
+            "temperature" => self.temperature = value.parse().unwrap_or(0.0),
+            "sampling_strategy" => self.sampling_strategy = value,
+            "stable_timestamps" => self.stable_timestamps = parse_bool(&value),
+            "vad_model" => self.vad_model = value,
+            "diarize_model" => self.diarize_model = value,
+            _ => {}
+        }
+    }
+
+    fn validate(&self) -> Result<(), ApiError> {
+        if self.stable_timestamps && self.vad_model.is_empty() {
+            Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                "'vad_model' is required when 'stable_timestamps' is true",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn invalid_form(err: impl std::fmt::Display) -> ApiError {
+    ApiError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, err.to_string())
+}
+
+fn internal_error(err: impl std::fmt::Display) -> ApiError {
+    ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, ErrorCode::InternalError, err.to_string())
+}
+
+fn parse_bool(value: &str) -> bool {
+    value.parse::<bool>().unwrap_or(false)
+}
+
+fn parse_i32(value: &str) -> i32 {
+    value.parse().unwrap_or(0)
+}

--- a/crates/vibe-server/src/transcription/mod.rs
+++ b/crates/vibe-server/src/transcription/mod.rs
@@ -1,0 +1,28 @@
+mod form;
+mod options;
+mod response;
+mod runner;
+
+use axum::extract::Multipart;
+use axum::http::StatusCode;
+use axum::response::Response;
+
+use crate::errors::{ApiError, ErrorCode};
+use crate::state::SharedState;
+
+pub async fn transcribe(state: SharedState, multipart: Multipart) -> Result<Response, ApiError> {
+    let form = form::RequestForm::from_multipart(multipart).await?;
+    let samples = form.read_samples()?;
+    if samples.is_empty() {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::InvalidAudio,
+            "audio file contains no samples",
+        ));
+    }
+    if form.stream {
+        runner::stream(state, samples, form).await
+    } else {
+        runner::once(state, samples, form).await
+    }
+}

--- a/crates/vibe-server/src/transcription/options.rs
+++ b/crates/vibe-server/src/transcription/options.rs
@@ -1,0 +1,23 @@
+use whisper_rs::TranscribeOptions;
+
+use crate::transcription::form::RequestForm;
+
+pub fn from_form(form: &RequestForm) -> TranscribeOptions {
+    TranscribeOptions {
+        language: form.language.clone(),
+        detect_language: form.detect_language,
+        translate: form.translate,
+        threads: form.n_threads,
+        prompt: form.prompt.clone(),
+        temperature: form.temperature,
+        max_text_ctx: form.max_text_ctx,
+        word_timestamps: form.word_timestamps,
+        max_segment_len: form.max_segment_len,
+        sampling_greedy: form.sampling_strategy != "beam_search",
+        best_of: form.best_of,
+        beam_size: form.beam_size,
+        stable_timestamps: form.stable_timestamps,
+        vad_model_path: form.vad_model.clone(),
+        ..Default::default()
+    }
+}

--- a/crates/vibe-server/src/transcription/response.rs
+++ b/crates/vibe-server/src/transcription/response.rs
@@ -1,0 +1,84 @@
+use std::convert::Infallible;
+
+use axum::body::{Body, Bytes};
+use axum::http::{HeaderMap, HeaderValue};
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use whisper_rs::TranscribeResult;
+
+use crate::diarization::{SpeakerSegment, match_speaker};
+use crate::formats::{seconds, srt, verbose_json_with_speakers, vtt};
+
+pub fn complete(result: &TranscribeResult, response_format: &str, speaker_segments: &[SpeakerSegment]) -> Response {
+    match response_format {
+        "text" => ([(axum::http::header::CONTENT_TYPE, "text/plain")], result.text()).into_response(),
+        "srt" => ([(axum::http::header::CONTENT_TYPE, "text/plain")], srt(&result.segments)).into_response(),
+        "vtt" => ([(axum::http::header::CONTENT_TYPE, "text/plain")], vtt(&result.segments)).into_response(),
+        "verbose_json" => axum::Json(verbose_json_with_speakers(result, speaker_segments)).into_response(),
+        _ => axum::Json(JsonText { text: result.text() }).into_response(),
+    }
+}
+
+pub type StreamSender = mpsc::UnboundedSender<Result<Bytes, Infallible>>;
+pub type StreamReceiver = mpsc::UnboundedReceiver<Result<Bytes, Infallible>>;
+
+pub fn stream(rx: StreamReceiver) -> Response {
+    let mut headers = HeaderMap::new();
+    headers.insert("content-type", HeaderValue::from_static("application/x-ndjson"));
+    headers.insert("cache-control", HeaderValue::from_static("no-cache"));
+    headers.insert("connection", HeaderValue::from_static("keep-alive"));
+    (headers, Body::from_stream(UnboundedReceiverStream::new(rx))).into_response()
+}
+
+pub fn channel() -> (StreamSender, StreamReceiver) {
+    mpsc::unbounded_channel()
+}
+
+pub fn send(sender: &StreamSender, event: StreamEvent) {
+    let _ = sender.send(Ok(Bytes::from(line(event))));
+}
+
+pub fn line(event: StreamEvent) -> String {
+    format!("{}\n", serde_json::to_string(&event).unwrap())
+}
+
+#[derive(Serialize)]
+struct JsonText {
+    text: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamEvent {
+    Progress {
+        progress: i32,
+    },
+    Segment {
+        start: f64,
+        end: f64,
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        speaker: Option<i32>,
+    },
+    Result {
+        text: String,
+    },
+    Error {
+        message: String,
+    },
+}
+
+impl StreamEvent {
+    pub fn segment(segment: whisper_rs::Segment, speaker_segments: &[SpeakerSegment]) -> Self {
+        let start = seconds(segment.start_cs);
+        let end = seconds(segment.end_cs);
+        Self::Segment {
+            start,
+            end,
+            text: segment.text,
+            speaker: match_speaker(start, end, speaker_segments),
+        }
+    }
+}

--- a/crates/vibe-server/src/transcription/runner.rs
+++ b/crates/vibe-server/src/transcription/runner.rs
@@ -1,0 +1,120 @@
+use axum::http::StatusCode;
+use axum::response::Response;
+use whisper_rs::StreamCallbacks;
+
+use crate::errors::{ApiError, ErrorCode};
+use crate::state::SharedState;
+use crate::transcription::form::RequestForm;
+use crate::transcription::{options, response};
+
+pub async fn once(state: SharedState, samples: Vec<f32>, form: RequestForm) -> Result<Response, ApiError> {
+    let mut guard = transcriber(&state)?;
+    let result = guard
+        .context()
+        .map_err(no_model)?
+        .transcribe(&samples, options::from_form(&form))
+        .map_err(internal_error)?;
+    let speaker_segments = diarize_if_requested(&form, &samples);
+    Ok(response::complete(&result, &form.response_format, &speaker_segments))
+}
+
+pub async fn stream(state: SharedState, samples: Vec<f32>, form: RequestForm) -> Result<Response, ApiError> {
+    let mut guard = transcriber_owned(&state)?;
+    guard.context().map_err(no_model)?;
+    let speaker_segments = diarize_if_requested(&form, &samples);
+    let (tx, rx) = response::channel();
+    let response = response::stream(rx);
+
+    tokio::task::spawn_blocking(move || run_streaming_transcription(guard, samples, form, speaker_segments, tx));
+    Ok(response)
+}
+
+fn run_streaming_transcription(
+    mut guard: crate::state::OwnedTranscriberGuard,
+    samples: Vec<f32>,
+    form: RequestForm,
+    speaker_segments: Vec<crate::diarization::SpeakerSegment>,
+    tx: response::StreamSender,
+) {
+    let progress_tx = tx.clone();
+    let segment_tx = tx.clone();
+    let abort_tx = tx.clone();
+
+    let result = match guard.context() {
+        Ok(ctx) => ctx.transcribe_with_callbacks(
+            &samples,
+            options::from_form(&form),
+            StreamCallbacks {
+                on_progress: Some(Box::new(move |progress| {
+                    response::send(&progress_tx, response::StreamEvent::Progress { progress });
+                })),
+                on_segment: Some(Box::new(move |segment| {
+                    response::send(&segment_tx, response::StreamEvent::segment(segment, &speaker_segments));
+                })),
+                should_abort: Some(Box::new(move || abort_tx.is_closed())),
+            },
+        ),
+        Err(err) => {
+            response::send(
+                &tx,
+                response::StreamEvent::Error {
+                    message: err.to_string(),
+                },
+            );
+            return;
+        }
+    };
+
+    send_final_event(&tx, result);
+}
+
+fn diarize_if_requested(form: &RequestForm, samples: &[f32]) -> Vec<crate::diarization::SpeakerSegment> {
+    if form.diarize_model.is_empty() {
+        return Vec::new();
+    }
+    match crate::diarization::diarize(&form.diarize_model, samples) {
+        Ok(segments) => segments,
+        Err(err) => {
+            eprintln!("diarization failed (skipping): {err:#}");
+            Vec::new()
+        }
+    }
+}
+
+fn transcriber_owned(state: &SharedState) -> Result<crate::state::OwnedTranscriberGuard, ApiError> {
+    state.try_transcriber_owned().map_err(|_| {
+        ApiError::new(
+            StatusCode::TOO_MANY_REQUESTS,
+            ErrorCode::Busy,
+            "server is busy with another transcription",
+        )
+    })
+}
+
+fn transcriber(state: &SharedState) -> Result<crate::state::TranscriberGuard<'_>, ApiError> {
+    state.try_transcriber().map_err(|_| {
+        ApiError::new(
+            StatusCode::TOO_MANY_REQUESTS,
+            ErrorCode::Busy,
+            "server is busy with another transcription",
+        )
+    })
+}
+
+fn send_final_event(tx: &response::StreamSender, result: whisper_rs::Result<whisper_rs::TranscribeResult>) {
+    let event = match result {
+        Ok(result) => response::StreamEvent::Result { text: result.text() },
+        Err(err) => response::StreamEvent::Error {
+            message: err.to_string(),
+        },
+    };
+    response::send(tx, event);
+}
+
+fn no_model(_err: anyhow::Error) -> ApiError {
+    ApiError::new(StatusCode::SERVICE_UNAVAILABLE, ErrorCode::NoModel, "no model loaded")
+}
+
+fn internal_error(err: impl std::fmt::Display) -> ApiError {
+    ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, ErrorCode::InternalError, err.to_string())
+}

--- a/crates/whisper-rs-sys/Cargo.toml
+++ b/crates/whisper-rs-sys/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "whisper-rs-sys"
+version = "0.1.0"
+edition = "2024"
+links = "whisper"
+
+[features]
+default = []
+metal = []
+vulkan = []
+
+[build-dependencies]
+bindgen = "0.72.1"
+cc = { version = "1.2.47", features = ["parallel"] }
+cmake = "0.1.54"
+

--- a/crates/whisper-rs-sys/build.rs
+++ b/crates/whisper-rs-sys/build.rs
@@ -1,0 +1,173 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+const WHISPER_CPP_TAG: &str = "v1.7.6";
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=WHISPER_CPP_DIR");
+    println!("cargo:rerun-if-env-changed=WHISPER_CPP_TAG");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let source = whisper_source();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let enable_metal = target_os == "macos" || env::var_os("CARGO_FEATURE_METAL").is_some();
+    let enable_vulkan = matches!(target_os.as_str(), "windows" | "linux") || env::var_os("CARGO_FEATURE_VULKAN").is_some();
+
+    let mut config = cmake::Config::new(&source);
+    config
+        .profile("Release")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("WHISPER_ALL_WARNINGS", "OFF")
+        .define("WHISPER_ALL_WARNINGS_3RD_PARTY", "OFF")
+        .define("WHISPER_BUILD_TESTS", "OFF")
+        .define("WHISPER_BUILD_EXAMPLES", "OFF")
+        .define("WHISPER_BUILD_SERVER", "OFF")
+        .define("WHISPER_BUILD_SHARED_LIBS", "OFF")
+        .define("GGML_STATIC", "ON")
+        .define("GGML_NATIVE", "OFF")
+        .define("GGML_OPENMP", "OFF");
+
+    if target_os == "macos" {
+        config.define("CMAKE_OSX_DEPLOYMENT_TARGET", "11.0");
+    }
+
+    if enable_metal {
+        config
+            .define("GGML_METAL", "ON")
+            .define("GGML_METAL_NDEBUG", "ON")
+            .define("GGML_METAL_EMBED_LIBRARY", "ON");
+    } else {
+        config.define("GGML_METAL", "OFF");
+    }
+
+    if enable_vulkan {
+        config.define("GGML_VULKAN", "ON");
+        if target_os == "windows" {
+            println!("cargo:rerun-if-env-changed=VULKAN_SDK");
+            let vulkan_sdk = env::var("VULKAN_SDK").expect("VULKAN_SDK must be set when building Vulkan on Windows");
+            println!(
+                "cargo:rustc-link-search=native={}",
+                PathBuf::from(vulkan_sdk).join("Lib").display()
+            );
+        }
+    } else {
+        config.define("GGML_VULKAN", "OFF");
+    }
+
+    for (key, value) in env::vars() {
+        let is_whisper_flag = key.starts_with("WHISPER_") && key != "WHISPER_CPP_DIR" && key != "WHISPER_CPP_TAG";
+        if is_whisper_flag || key.starts_with("GGML_") || key.starts_with("CMAKE_") {
+            println!("cargo:rerun-if-env-changed={key}");
+            config.define(&key, &value);
+        }
+    }
+
+    let dst = config.build();
+    let lib_dir = dst.join("lib");
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=whisper");
+    println!("cargo:rustc-link-lib=static=ggml");
+    println!("cargo:rustc-link-lib=static=ggml-base");
+    println!("cargo:rustc-link-lib=static=ggml-cpu");
+    println!("cargo:rustc-link-lib=static=ggml-blas");
+
+    if enable_metal {
+        println!("cargo:rustc-link-lib=static=ggml-metal");
+        println!("cargo:rustc-link-lib=framework=Accelerate");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=MetalKit");
+    }
+    if enable_vulkan {
+        println!("cargo:rustc-link-lib=static=ggml-vulkan");
+        if target_os == "windows" {
+            println!("cargo:rustc-link-lib=dylib=vulkan-1");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=vulkan");
+        }
+    }
+    if target_os == "linux" {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        println!("cargo:rustc-link-lib=dylib=pthread");
+        println!("cargo:rustc-link-lib=dylib=dl");
+        println!("cargo:rustc-link-lib=dylib=m");
+    } else if target_os == "macos" {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else if target_os == "windows" {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        println!("cargo:rustc-link-lib=dylib=advapi32");
+    }
+
+    generate_bindings(&source);
+}
+
+fn whisper_source() -> PathBuf {
+    if let Some(path) = env::var_os("WHISPER_CPP_DIR") {
+        return PathBuf::from(path);
+    }
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR"));
+    let tag = env::var("WHISPER_CPP_TAG").unwrap_or_else(|_| WHISPER_CPP_TAG.to_string());
+    let source = out_dir.join(format!("whisper.cpp-{}", tag.trim_start_matches('v')));
+    if source.join("include/whisper.h").exists() {
+        return source;
+    }
+
+    let archive = out_dir.join(format!("{tag}.tar.gz"));
+    let url = format!("https://github.com/ggerganov/whisper.cpp/archive/refs/tags/{tag}.tar.gz");
+    run("curl", &["-L", "-o", archive.to_str().unwrap(), &url], None);
+    run(
+        "tar",
+        &["-xzf", archive.to_str().unwrap(), "-C", out_dir.to_str().unwrap()],
+        None,
+    );
+    source
+}
+
+fn generate_bindings(source: &Path) {
+    let header = source.join("include/whisper.h");
+    let mut builder = bindgen::Builder::default()
+        .header(header.to_string_lossy())
+        .allowlist_function("whisper_.*")
+        .allowlist_function("ggml_log_set")
+        .allowlist_function("ggml_backend_dev_.*")
+        .allowlist_type("ggml_log_.*")
+        .allowlist_type("ggml_backend_dev.*")
+        .allowlist_type("ggml_backend_device.*")
+        .allowlist_var("GGML_LOG_LEVEL_.*")
+        .allowlist_var("GGML_BACKEND_DEVICE_TYPE_.*")
+        .allowlist_type("whisper_.*")
+        .allowlist_var("WHISPER_.*")
+        .clang_arg(format!("-I{}", source.join("include").display()))
+        .clang_arg(format!("-I{}", source.join("ggml/include").display()));
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        let sdk = std::process::Command::new("xcrun")
+            .args(["--sdk", "macosx", "--show-sdk-path"])
+            .output()
+            .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        if let Some(sdk) = sdk {
+            builder = builder.clang_arg("-isysroot").clang_arg(sdk);
+        }
+    }
+
+    let bindings = builder.generate().expect("generate whisper bindings");
+
+    let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR")).join("bindings.rs");
+    bindings.write_to_file(out).expect("write whisper bindings");
+}
+
+fn run(program: &str, args: &[&str], cwd: Option<&Path>) {
+    let mut command = std::process::Command::new(program);
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let status = command
+        .status()
+        .unwrap_or_else(|err| panic!("failed to run {program}: {err}"));
+    assert!(status.success(), "{program} failed with {status}");
+}

--- a/crates/whisper-rs-sys/src/lib.rs
+++ b/crates/whisper-rs-sys/src/lib.rs
@@ -1,0 +1,6 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(clippy::all)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/whisper-rs-sys/wrapper.h
+++ b/crates/whisper-rs-sys/wrapper.h
@@ -1,0 +1,2 @@
+#include "whisper.h"
+#include "ggml-backend.h"

--- a/crates/whisper-rs/Cargo.toml
+++ b/crates/whisper-rs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "whisper-rs"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+thiserror = "2.0.18"
+whisper-rs-sys = { workspace = true }

--- a/crates/whisper-rs/src/context.rs
+++ b/crates/whisper-rs/src/context.rs
@@ -1,0 +1,176 @@
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
+use std::ptr::NonNull;
+
+use whisper_rs_sys as sys;
+
+use crate::error::{Result, WhisperError};
+use crate::options::{Segment, StreamCallbacks, TranscribeOptions, TranscribeResult};
+
+pub struct WhisperContext {
+    ctx: NonNull<sys::whisper_context>,
+}
+
+unsafe impl Send for WhisperContext {}
+
+impl WhisperContext {
+    pub fn new(path: &str, gpu_device: Option<i32>, no_gpu: bool) -> Result<Self> {
+        crate::logging::suppress_native_logs();
+        let path = CString::new(path).map_err(|_| WhisperError::InvalidModelPath)?;
+        let mut params = unsafe { sys::whisper_context_default_params() };
+        params.use_gpu = !no_gpu;
+        if let Some(device) = gpu_device {
+            params.gpu_device = device;
+        }
+        let ctx = unsafe { sys::whisper_init_from_file_with_params(path.as_ptr(), params) };
+        let ctx = NonNull::new(ctx).ok_or(WhisperError::ContextInit)?;
+        Ok(Self { ctx })
+    }
+
+    pub fn transcribe(&mut self, samples: &[f32], options: TranscribeOptions) -> Result<TranscribeResult> {
+        self.transcribe_with_callbacks(samples, options, StreamCallbacks::default())
+    }
+
+    pub fn transcribe_with_callbacks(
+        &mut self,
+        samples: &[f32],
+        options: TranscribeOptions,
+        callbacks: StreamCallbacks<'_>,
+    ) -> Result<TranscribeResult> {
+        let language = optional_cstring(&options.language)?;
+        let prompt = optional_cstring(&options.prompt)?;
+        let vad_model = optional_cstring(&options.vad_model_path)?;
+        let mut state = CallbackState {
+            callbacks,
+            emitted_segments: 0,
+        };
+        let mut params = unsafe { sys::whisper_full_default_params(sys::whisper_sampling_strategy_WHISPER_SAMPLING_GREEDY) };
+
+        if !options.sampling_greedy {
+            params.strategy = sys::whisper_sampling_strategy_WHISPER_SAMPLING_BEAM_SEARCH;
+        }
+        params.n_threads = if options.threads > 0 {
+            options.threads
+        } else {
+            std::thread::available_parallelism().map(|n| n.get() as i32).unwrap_or(4)
+        };
+        params.translate = options.translate;
+        params.detect_language = options.detect_language;
+        params.language = language.as_ref().map_or(std::ptr::null(), |value| value.as_ptr());
+        params.initial_prompt = prompt.as_ref().map_or(std::ptr::null(), |value| value.as_ptr());
+        params.temperature = options.temperature;
+        if options.max_text_ctx > 0 {
+            params.n_max_text_ctx = options.max_text_ctx;
+        }
+        params.token_timestamps = options.word_timestamps;
+        params.max_len = options.max_segment_len;
+        if options.best_of > 0 {
+            params.greedy.best_of = options.best_of;
+        }
+        if options.beam_size > 0 {
+            params.beam_search.beam_size = options.beam_size;
+        }
+        params.print_progress = options.print_progress;
+        params.print_special = options.print_special;
+        params.print_realtime = options.print_realtime;
+        params.print_timestamps = options.print_timestamps;
+        params.vad = options.stable_timestamps;
+        params.vad_model_path = vad_model.as_ref().map_or(std::ptr::null(), |value| value.as_ptr());
+        params.progress_callback = Some(progress_callback);
+        params.progress_callback_user_data = &mut state as *mut _ as *mut c_void;
+        params.new_segment_callback = Some(new_segment_callback);
+        params.new_segment_callback_user_data = &mut state as *mut _ as *mut c_void;
+        params.abort_callback = Some(abort_callback);
+        params.abort_callback_user_data = &mut state as *mut _ as *mut c_void;
+
+        let code = unsafe { sys::whisper_full(self.ctx.as_ptr(), params, samples.as_ptr(), samples.len() as c_int) };
+        if code != 0 {
+            return if code == -2 {
+                Err(WhisperError::Cancelled)
+            } else {
+                Err(WhisperError::TranscriptionFailed(code))
+            };
+        }
+        collect_segments(self.ctx.as_ptr())
+    }
+}
+
+impl Drop for WhisperContext {
+    fn drop(&mut self) {
+        unsafe { sys::whisper_free(self.ctx.as_ptr()) }
+    }
+}
+
+struct CallbackState<'a> {
+    callbacks: StreamCallbacks<'a>,
+    emitted_segments: i32,
+}
+
+unsafe extern "C" fn progress_callback(
+    _ctx: *mut sys::whisper_context,
+    _state: *mut sys::whisper_state,
+    progress: c_int,
+    data: *mut c_void,
+) {
+    let state = unsafe { &mut *(data as *mut CallbackState<'_>) };
+    if let Some(callback) = state.callbacks.on_progress.as_mut() {
+        callback(progress);
+    }
+}
+
+unsafe extern "C" fn new_segment_callback(
+    ctx: *mut sys::whisper_context,
+    _state: *mut sys::whisper_state,
+    count: c_int,
+    data: *mut c_void,
+) {
+    let state = unsafe { &mut *(data as *mut CallbackState<'_>) };
+    let Some(callback) = state.callbacks.on_segment.as_mut() else {
+        return;
+    };
+    let total = unsafe { sys::whisper_full_n_segments(ctx) };
+    let start = total.saturating_sub(count);
+    for index in start..total {
+        if index >= state.emitted_segments {
+            if let Ok(segment) = read_segment(ctx, index) {
+                callback(segment);
+                state.emitted_segments = index + 1;
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn abort_callback(data: *mut c_void) -> bool {
+    let state = unsafe { &mut *(data as *mut CallbackState<'_>) };
+    state.callbacks.should_abort.as_mut().is_some_and(|callback| callback())
+}
+
+fn collect_segments(ctx: *mut sys::whisper_context) -> Result<TranscribeResult> {
+    let count = unsafe { sys::whisper_full_n_segments(ctx) };
+    let mut segments = Vec::with_capacity(count.max(0) as usize);
+    for index in 0..count {
+        segments.push(read_segment(ctx, index)?);
+    }
+    Ok(TranscribeResult { segments })
+}
+
+fn read_segment(ctx: *mut sys::whisper_context, index: c_int) -> Result<Segment> {
+    let text = unsafe { sys::whisper_full_get_segment_text(ctx, index) };
+    if text.is_null() {
+        return Err(WhisperError::InvalidText);
+    }
+    let text = unsafe { CStr::from_ptr(text as *const c_char) }
+        .to_str()
+        .map_err(|_| WhisperError::InvalidText)?
+        .to_string();
+    let start_cs = unsafe { sys::whisper_full_get_segment_t0(ctx, index) };
+    let end_cs = unsafe { sys::whisper_full_get_segment_t1(ctx, index) };
+    Ok(Segment { start_cs, end_cs, text })
+}
+
+fn optional_cstring(value: &str) -> Result<Option<CString>> {
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        CString::new(value).map(Some).map_err(|_| WhisperError::InvalidModelPath)
+    }
+}

--- a/crates/whisper-rs/src/devices.rs
+++ b/crates/whisper-rs/src/devices.rs
@@ -1,0 +1,48 @@
+use std::ffi::CStr;
+
+use whisper_rs_sys as sys;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GpuDevice {
+    pub index: i32,
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "type")]
+    pub device_type: String,
+}
+
+pub fn list_gpu_devices() -> Vec<GpuDevice> {
+    let count = unsafe { sys::ggml_backend_dev_count() };
+    let mut devices = Vec::new();
+    for index in 0..count {
+        let device = unsafe { sys::ggml_backend_dev_get(index) };
+        if device.is_null() {
+            continue;
+        }
+        let Some(device_type) = device_type_name(unsafe { sys::ggml_backend_dev_type(device) }) else {
+            continue;
+        };
+        devices.push(GpuDevice {
+            index: index as i32,
+            name: read_native_string(unsafe { sys::ggml_backend_dev_name(device) }),
+            description: read_native_string(unsafe { sys::ggml_backend_dev_description(device) }),
+            device_type: device_type.to_string(),
+        });
+    }
+    devices
+}
+
+fn device_type_name(kind: sys::ggml_backend_dev_type) -> Option<&'static str> {
+    match kind {
+        sys::ggml_backend_dev_type_GGML_BACKEND_DEVICE_TYPE_GPU => Some("gpu"),
+        _ => None,
+    }
+}
+
+fn read_native_string(value: *const std::ffi::c_char) -> String {
+    if value.is_null() {
+        String::new()
+    } else {
+        unsafe { CStr::from_ptr(value) }.to_string_lossy().into_owned()
+    }
+}

--- a/crates/whisper-rs/src/error.rs
+++ b/crates/whisper-rs/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum WhisperError {
+    #[error("model path contains an interior null byte")]
+    InvalidModelPath,
+    #[error("failed to initialize whisper context")]
+    ContextInit,
+    #[error("failed to convert text from whisper")]
+    InvalidText,
+    #[error("transcription failed with code {0}")]
+    TranscriptionFailed(i32),
+    #[error("operation was cancelled")]
+    Cancelled,
+}
+
+pub type Result<T> = std::result::Result<T, WhisperError>;

--- a/crates/whisper-rs/src/lib.rs
+++ b/crates/whisper-rs/src/lib.rs
@@ -1,0 +1,10 @@
+mod context;
+mod devices;
+mod error;
+mod logging;
+mod options;
+
+pub use context::WhisperContext;
+pub use devices::{GpuDevice, list_gpu_devices};
+pub use error::{Result, WhisperError};
+pub use options::{Segment, StreamCallbacks, TranscribeOptions, TranscribeResult};

--- a/crates/whisper-rs/src/logging.rs
+++ b/crates/whisper-rs/src/logging.rs
@@ -1,0 +1,15 @@
+use std::ffi::{c_char, c_void};
+use std::sync::Once;
+
+use whisper_rs_sys as sys;
+
+static INSTALL_LOG_SUPPRESSION: Once = Once::new();
+
+pub(crate) fn suppress_native_logs() {
+    INSTALL_LOG_SUPPRESSION.call_once(|| unsafe {
+        sys::whisper_log_set(Some(discard_log), std::ptr::null_mut());
+        sys::ggml_log_set(Some(discard_log), std::ptr::null_mut());
+    });
+}
+
+unsafe extern "C" fn discard_log(_level: sys::ggml_log_level, _text: *const c_char, _user_data: *mut c_void) {}

--- a/crates/whisper-rs/src/options.rs
+++ b/crates/whisper-rs/src/options.rs
@@ -1,0 +1,71 @@
+#[derive(Debug, Clone)]
+pub struct TranscribeOptions {
+    pub language: String,
+    pub detect_language: bool,
+    pub translate: bool,
+    pub threads: i32,
+    pub prompt: String,
+    pub temperature: f32,
+    pub max_text_ctx: i32,
+    pub word_timestamps: bool,
+    pub max_segment_len: i32,
+    pub sampling_greedy: bool,
+    pub best_of: i32,
+    pub beam_size: i32,
+    pub print_progress: bool,
+    pub print_special: bool,
+    pub print_realtime: bool,
+    pub print_timestamps: bool,
+    pub stable_timestamps: bool,
+    pub vad_model_path: String,
+}
+
+impl Default for TranscribeOptions {
+    fn default() -> Self {
+        Self {
+            language: String::new(),
+            detect_language: false,
+            translate: false,
+            threads: 0,
+            prompt: String::new(),
+            temperature: 0.0,
+            max_text_ctx: 0,
+            word_timestamps: false,
+            max_segment_len: 0,
+            sampling_greedy: true,
+            best_of: 0,
+            beam_size: 0,
+            print_progress: false,
+            print_special: false,
+            print_realtime: false,
+            print_timestamps: false,
+            stable_timestamps: false,
+            vad_model_path: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Segment {
+    pub start_cs: i64,
+    pub end_cs: i64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscribeResult {
+    pub segments: Vec<Segment>,
+}
+
+impl TranscribeResult {
+    pub fn text(&self) -> String {
+        self.segments.iter().map(|segment| segment.text.as_str()).collect()
+    }
+}
+
+#[derive(Default)]
+pub struct StreamCallbacks<'a> {
+    pub on_progress: Option<Box<dyn FnMut(i32) + Send + 'a>>,
+    pub on_segment: Option<Box<dyn FnMut(Segment) + Send + 'a>>,
+    pub should_abort: Option<Box<dyn FnMut() -> bool + Send + 'a>>,
+}

--- a/docs/sidecar/rust-sidecar.md
+++ b/docs/sidecar/rust-sidecar.md
@@ -1,0 +1,69 @@
+# Rust transcription sidecar
+
+Vibe now has a Rust sidecar workspace under `crates/`:
+
+- `crates/whisper-rs-sys`: builds whisper.cpp from source and links the static whisper/ggml archives.
+- `crates/whisper-rs`: safe Rust wrapper around the whisper.cpp C API.
+- `crates/vibe-server`: local HTTP sidecar compatible with the Sona runner shape.
+
+The sys crate enables Metal on macOS and Vulkan on Linux/Windows by default. Set `WHISPER_CPP_DIR` to use a local whisper.cpp checkout, or `WHISPER_CPP_TAG` to build another upstream tag.
+
+## Build
+
+```bash
+cargo build -p vibe-server --release
+```
+
+The binary is:
+
+```bash
+target/release/vibe-server
+```
+
+## Run as sidecar
+
+```bash
+target/release/vibe-server serve --port 0
+```
+
+The first stdout line is machine-readable and matches the current parent-process contract:
+
+```json
+{"status":"ready","port":12345,"version":"0.1.0","commit":"dev"}
+```
+
+## HTTP API
+
+- `GET /health`
+- `GET /ready`
+- `GET /docs`
+- `GET /openapi.json`
+- `GET /v1/models`
+- `POST /v1/models/load`
+- `DELETE /v1/models`
+- `POST /v1/audio/transcriptions`
+- `GET /v1/devices`
+
+Model load body:
+
+```json
+{"path":"/path/to/ggml-model.bin","gpu_device":0,"no_gpu":false}
+```
+
+Transcription uses OpenAI-style multipart form input:
+
+```bash
+curl -F file=@samples/short.wav \
+  -F response_format=verbose_json \
+  http://127.0.0.1:12345/v1/audio/transcriptions
+```
+
+Supported `response_format` values are `json`, `verbose_json`, `text`, `srt`, and `vtt`. Streaming uses newline-delimited JSON when `stream=true`.
+
+## Validate with sample audio
+
+```bash
+uv run plans/rust-sidecar/rust-sidecar_001.py
+```
+
+The script downloads `ggml-tiny.en.bin` into `.models/`, builds `vibe-server`, starts it on an ephemeral port, loads the model, and transcribes `samples/short.wav`.

--- a/docs/sidecar/sona-parity-audit.md
+++ b/docs/sidecar/sona-parity-audit.md
@@ -1,0 +1,38 @@
+# Sona parity audit
+
+This audit compares `crates/vibe-server` with the vendored Go Sona server in `sona/internal/server`.
+
+## Matches Sona
+
+- Sidecar process prints one ready JSON line with `status`, `port`, `version`, and `commit`.
+- `GET /health`.
+- `GET /ready`, including `503` and `"message":"no model loaded"` when no model is loaded.
+- `POST /v1/models/load` with `path`, `gpu_device`, and `no_gpu`.
+- `DELETE /v1/models`.
+- `GET /v1/models`.
+- `POST /v1/audio/transcriptions`.
+- Rejects concurrent transcriptions with `429 busy`.
+- Rejects missing model with `503 no_model` before streaming starts.
+- Supports `json`, `verbose_json`, `text`, `srt`, and `vtt` response formats.
+- Supports live `application/x-ndjson` streaming for progress, segment, error, and result events.
+- Aborts streaming inference when the client disconnects.
+- Supports in-process Sortformer diarization with `diarize_model`, adding `speaker` to `verbose_json` segments and streaming segment events.
+- Supports ffmpeg fallback for non-native audio and `enhance_audio`.
+- Raises the upload limit to Sona's 15 GB limit.
+- Supports `language`, `detect_language`, `translate`, `prompt`, `n_threads`, `temperature`, `max_text_ctx`, `word_timestamps`, `max_segment_len`, `sampling_strategy`, `best_of`, and `beam_size`.
+- Supports Sona-style `stable_timestamps=true` validation and forwards `vad_model` to whisper.cpp.
+- Supports `devices` with ggml backend GPU enumeration.
+
+## Remaining Gaps
+
+- No known runtime feature gaps against Sona's current local server contract.
+
+## Validation
+
+Run:
+
+```bash
+uv run plans/rust-sidecar/rust-sidecar_001.py
+```
+
+This validates model load, normal transcription, live NDJSON streaming, missing-VAD validation for stable timestamps, and ffmpeg conversion for `samples/short.mp4` when ffmpeg is installed.

--- a/docs/sidecar/whisper-rs-codeberg-comparison.md
+++ b/docs/sidecar/whisper-rs-codeberg-comparison.md
@@ -1,0 +1,31 @@
+# Codeberg whisper-rs comparison
+
+Reference clone:
+
+```text
+third_party/whisper-rs-codeberg
+```
+
+Compared against our crates:
+
+- `crates/whisper-rs-sys`
+- `crates/whisper-rs`
+
+## Adopted
+
+- Suppress whisper.cpp and third-party warning noise in CMake with `WHISPER_ALL_WARNINGS=OFF` and `WHISPER_ALL_WARNINGS_3RD_PARTY=OFF`.
+- Build whisper.cpp with CMake `Release` profile even when the Rust crate is checked in debug mode. Debug whisper.cpp builds are too slow for practical local validation.
+- Disable `GGML_OPENMP` explicitly so builds do not accidentally depend on OpenMP runtime availability.
+- Enable `GGML_METAL_NDEBUG` with Metal to reduce Metal backend debug overhead and log noise.
+- Pass through explicit `WHISPER_*`, `GGML_*`, and `CMAKE_*` environment overrides to CMake for advanced build debugging.
+- Add Windows Vulkan SDK link-path handling and link `vulkan-1`.
+- Add Windows `advapi32` system library link.
+- Generate bindings for `ggml_log_set` and `ggml_log_level`.
+- Install a native log sink in `whisper-rs` that discards whisper.cpp and ggml logs by default, keeping sidecar stdout/stderr clean.
+
+## Not Adopted
+
+- CUDA, HIP, OpenBLAS, CoreML, OpenMP, and SYCL features. The sidecar target is Metal on macOS and Vulkan on Linux/Windows.
+- Bundled fallback bindings. Our sys crate downloads and builds a pinned whisper.cpp tag, so generated bindings are preferred for now.
+- Full upstream wrapper surface such as grammar, token iteration, VAD wrappers, and tracing/log crate backends. The sidecar currently needs model loading, transcription, progress/segment callbacks, and quiet logs.
+

--- a/plans/rust-sidecar/rust-sidecar_001.md
+++ b/plans/rust-sidecar/rust-sidecar_001.md
@@ -1,0 +1,19 @@
+# Rust sidecar validation
+
+Runs a self-contained validation of the Rust sidecar:
+
+```bash
+uv run plans/rust-sidecar/rust-sidecar_001.py
+```
+
+Checks:
+
+- downloads a GGML whisper model into `.models/`
+- builds `vibe-server`
+- starts `vibe-server serve --port 0`
+- loads the model over `POST /v1/models/load`
+- transcribes `samples/short.wav` over `POST /v1/audio/transcriptions`
+- verifies `stream=true` returns `application/x-ndjson` events, including a final result event
+- verifies Sona-compatible `stable_timestamps=true` validation when `vad_model` is missing
+- verifies non-WAV ffmpeg conversion with `samples/short.mp4` when ffmpeg is installed
+- verifies in-process diarization returns speaker labels when `.models/diar_streaming_sortformer_4spk-v2.1.onnx` is present

--- a/plans/rust-sidecar/rust-sidecar_001.py
+++ b/plans/rust-sidecar/rust-sidecar_001.py
@@ -1,0 +1,186 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
+import json
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODEL = ROOT / ".models" / "ggml-tiny.en.bin"
+MODEL_URL = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin"
+SAMPLE = ROOT / "samples" / "short.wav"
+MP4_SAMPLE = ROOT / "samples" / "short.mp4"
+DIAR_MODEL = ROOT / ".models" / "diar_streaming_sortformer_4spk-v2.1.onnx"
+DIAR_SAMPLE = ROOT / "samples" / "6_speakers.wav"
+
+
+def run(args: list[str], **kwargs):
+    return subprocess.run(args, cwd=ROOT, check=True, text=True, **kwargs)
+
+
+def ensure_model():
+    MODEL.parent.mkdir(exist_ok=True)
+    if MODEL.exists() and MODEL.stat().st_size > 1_000_000:
+        return
+    print(f"downloading {MODEL_URL}")
+    urllib.request.urlretrieve(MODEL_URL, MODEL)
+
+
+def main():
+    ensure_model()
+    run(["cargo", "build", "-p", "vibe-server"])
+
+    proc = subprocess.Popen(
+        [str(ROOT / "target" / "debug" / "vibe-server"), "serve", "--port", "0", "--exit-with-parent", "false"],
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        ready_line = proc.stdout.readline().strip()
+        ready = json.loads(ready_line)
+        port = ready["port"]
+        base = f"http://127.0.0.1:{port}"
+
+        req = urllib.request.Request(
+            f"{base}/v1/models/load",
+            data=json.dumps({"path": str(MODEL), "no_gpu": True}).encode(),
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        print(urllib.request.urlopen(req, timeout=120).read().decode())
+
+        boundary = "vibe-sidecar-boundary"
+        body = (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="response_format"\r\n\r\n'
+            "verbose_json\r\n"
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="file"; filename="short.wav"\r\n'
+            "Content-Type: audio/wav\r\n\r\n"
+        ).encode() + SAMPLE.read_bytes() + f"\r\n--{boundary}--\r\n".encode()
+        req = urllib.request.Request(
+            f"{base}/v1/audio/transcriptions",
+            data=body,
+            headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+            method="POST",
+        )
+        result = json.loads(urllib.request.urlopen(req, timeout=180).read().decode())
+        print(json.dumps(result, indent=2))
+        if not result.get("text"):
+            raise SystemExit("transcription returned empty text")
+
+        stream_events = transcribe_stream(base)
+        print("\n".join(stream_events))
+        if not any('"type":"result"' in event or '"type": "result"' in event for event in stream_events):
+            raise SystemExit("streaming transcription did not return a result event")
+
+        assert_stable_timestamp_validation(base)
+        if shutil.which("ffmpeg") and MP4_SAMPLE.exists():
+            mp4_result = transcribe_file(base, MP4_SAMPLE)
+            print(json.dumps(mp4_result, indent=2))
+            if not mp4_result.get("text"):
+                raise SystemExit("mp4 transcription returned empty text")
+        if DIAR_MODEL.exists() and DIAR_SAMPLE.exists():
+            diar_result = transcribe_file(base, DIAR_SAMPLE, diarize_model=DIAR_MODEL)
+            speaker_count = sum(1 for segment in diar_result.get("segments", []) if "speaker" in segment)
+            print(json.dumps({"diarized_segments": speaker_count}, indent=2))
+            if speaker_count == 0:
+                raise SystemExit("diarization returned no speaker labels")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def transcribe_file(base: str, path: Path, diarize_model: Path | None = None) -> dict:
+    boundary = "vibe-sidecar-file-boundary"
+    fields = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="response_format"\r\n\r\n'
+        "verbose_json\r\n"
+    )
+    if diarize_model is not None:
+        fields += (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="diarize_model"\r\n\r\n'
+            f"{diarize_model}\r\n"
+        )
+    body = (
+        fields +
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="file"; filename="{path.name}"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n"
+    ).encode() + path.read_bytes() + f"\r\n--{boundary}--\r\n".encode()
+    req = urllib.request.Request(
+        f"{base}/v1/audio/transcriptions",
+        data=body,
+        headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+        method="POST",
+    )
+    return json.loads(urllib.request.urlopen(req, timeout=180).read().decode())
+
+
+def assert_stable_timestamp_validation(base: str):
+    boundary = "vibe-sidecar-vad-boundary"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="stable_timestamps"\r\n\r\n'
+        "true\r\n"
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="short.wav"\r\n'
+        "Content-Type: audio/wav\r\n\r\n"
+    ).encode() + SAMPLE.read_bytes() + f"\r\n--{boundary}--\r\n".encode()
+    req = urllib.request.Request(
+        f"{base}/v1/audio/transcriptions",
+        data=body,
+        headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=180)
+    except urllib.error.HTTPError as err:
+        if err.code != 400:
+            raise
+        body = err.read().decode()
+        if "vad_model" not in body:
+            raise SystemExit(f"unexpected stable timestamp validation body: {body}")
+        return
+    raise SystemExit("stable timestamp validation unexpectedly succeeded")
+
+
+def transcribe_stream(base: str) -> list[str]:
+    boundary = "vibe-sidecar-stream-boundary"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="stream"\r\n\r\n'
+        "true\r\n"
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="short.wav"\r\n'
+        "Content-Type: audio/wav\r\n\r\n"
+    ).encode() + SAMPLE.read_bytes() + f"\r\n--{boundary}--\r\n".encode()
+    req = urllib.request.Request(
+        f"{base}/v1/audio/transcriptions",
+        data=body,
+        headers={"content-type": f"multipart/form-data; boundary={boundary}"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=180) as response:
+        if response.headers.get_content_type() != "application/x-ndjson":
+            raise SystemExit(f"unexpected stream content type: {response.headers.get_content_type()}")
+        return [line.decode().strip() for line in response if line.strip()]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Rust vibe-server sidecar with Sona-compatible transcription routes, OpenAPI docs, model loading, readiness, and device listing
- add local whisper-rs wrappers over whisper.cpp with backend device enumeration, stable timestamps, and native logging suppression
- add ffmpeg fallback, NDJSON streaming, Sortformer diarization support, parity docs, and validation script

## Validation
- cargo fmt --all
- cargo check -p vibe-server --bins
- uv run plans/rust-sidecar/rust-sidecar_001.py
- cargo run -p vibe-server -- devices