### PR TITLE
Organize settings and home modules

### DIFF
--- a/desktop/src/pages/home/hooks/use-audio-download.ts
+++ b/desktop/src/pages/home/hooks/use-audio-download.ts
@@ -1,0 +1,107 @@
+import { event } from '@tauri-apps/api'
+import { listen } from '@tauri-apps/api/event'
+import * as dialog from '@tauri-apps/plugin-dialog'
+import { useContext, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import * as ytDlp from '~/lib/ytdlp'
+import { ErrorModalContext } from '~/providers/error-modal'
+import { useFilesContext } from '~/providers/files-provider'
+import { usePreferenceProvider } from '~/providers/preference'
+import { useToastProvider } from '~/providers/toast'
+
+export function useAudioDownload(transcribe: (path: string) => Promise<void>) {
+	const { t } = useTranslation()
+	const preference = usePreferenceProvider()
+	const { setFiles } = useFilesContext()
+	const toast = useToastProvider()
+	const { setState: setErrorModal } = useContext(ErrorModalContext)
+	const [audioUrl, setAudioUrl] = useState('')
+	const [downloadingAudio, setDownloadingAudio] = useState(false)
+	const [ytdlpProgress, setYtDlpProgress] = useState<number | null>(null)
+	const cancelYtDlpRef = useRef(false)
+	const switchingToLinkRef = useRef(false)
+	const cachedYtDlpVersion = useRef<string | null | undefined>(undefined)
+	const skippedUpdatePromptRef = useRef(false)
+
+	useEffect(() => {
+		const unlisten = listen<number>('ytdlp-progress', ({ payload }) => {
+			const progress = Math.ceil(payload)
+			setYtDlpProgress((current) => (!current || progress > current ? progress : current))
+		})
+		return () => { unlisten.then((fn) => fn()) }
+	}, [])
+
+	async function cancelYtDlpDownload() {
+		cancelYtDlpRef.current = true
+		event.emit('ytdlp-cancel')
+	}
+
+	async function switchToLinkTab() {
+		if (switchingToLinkRef.current) return
+		switchingToLinkRef.current = true
+		try {
+			const binaryExists = await ytDlp.exists()
+			let latestVersion = cachedYtDlpVersion.current
+			if (latestVersion === undefined) {
+				try {
+					latestVersion = await ytDlp.getLatestVersion()
+					cachedYtDlpVersion.current = latestVersion
+				} catch (error) {
+					console.error('Failed to fetch latest yt-dlp version', error)
+					cachedYtDlpVersion.current = null
+					if (binaryExists) { preference.setHomeTab('link'); return }
+				}
+			}
+
+			const needsInstall = !binaryExists
+			const needsUpdate = !needsInstall && preference.shouldCheckYtDlpVersion && latestVersion !== null && latestVersion !== preference.ytDlpVersion
+			if (needsUpdate && skippedUpdatePromptRef.current) { preference.setHomeTab('link'); return }
+			if (!needsInstall && !needsUpdate) { preference.setHomeTab('link'); return }
+
+			const confirmed = needsUpdate
+				? await dialog.ask(t('common.ask-for-update-ytdlp-message'), { title: t('common.ask-for-update-ytdlp-title'), kind: 'info', cancelLabel: t('common.later'), okLabel: t('common.update-now') })
+				: await dialog.ask(t('common.ask-for-install-ytdlp-message'), { title: t('common.ask-for-install-ytdlp-title'), kind: 'info', cancelLabel: t('common.cancel'), okLabel: t('common.install-now') })
+
+			if (confirmed) {
+				try {
+					const version = latestVersion ?? preference.ytDlpVersion ?? '2026.02.04'
+					toast.setMessage(t('common.downloading-ytdlp')); toast.setProgress(0); toast.setOpen(true)
+					await ytDlp.downloadYtDlp(version)
+					preference.setYtDlpVersion(version)
+					skippedUpdatePromptRef.current = false
+					toast.setOpen(false)
+					preference.setHomeTab('link')
+				} catch (error) {
+					console.error(error)
+					setErrorModal?.({ log: String(error), open: true })
+				}
+			} else if (binaryExists) {
+				if (needsUpdate) skippedUpdatePromptRef.current = true
+				preference.setHomeTab('link')
+			}
+		} finally {
+			switchingToLinkRef.current = false
+		}
+	}
+
+	async function downloadAudio() {
+		if (!audioUrl) return
+		setYtDlpProgress(0)
+		setDownloadingAudio(true)
+		try {
+			const outPath = await ytDlp.downloadAudio(audioUrl, preference.storeRecordInDocuments, preference.customRecordingPath)
+			if (cancelYtDlpRef.current) { cancelYtDlpRef.current = false; return }
+			preference.setHomeTab('file')
+			setFiles([{ name: 'audio.m4a', path: outPath }])
+			await transcribe(outPath)
+		} catch (error) {
+			console.error(error)
+			setErrorModal?.({ log: String(error), open: true })
+		} finally {
+			setDownloadingAudio(false)
+			setYtDlpProgress(null)
+		}
+	}
+
+	return { cancelYtDlpRef, cancelYtDlpDownload, ytdlpProgress, setYtDlpProgress, switchToLinkTab, audioUrl, setAudioUrl, downloadAudio, downloadingAudio, setDownloadingAudio }
+}

--- a/desktop/src/pages/home/hooks/use-media-selection.ts
+++ b/desktop/src/pages/home/hooks/use-media-selection.ts
@@ -1,0 +1,73 @@
+import { convertFileSrc, invoke } from '@tauri-apps/api/core'
+import { basename } from '@tauri-apps/api/path'
+import * as dialog from '@tauri-apps/plugin-dialog'
+import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import * as config from '~/lib/config'
+import type { NamedPath } from '~/lib/types'
+import { useFilesContext } from '~/providers/files-provider'
+import { usePreferenceProvider } from '~/providers/preference'
+
+export function useMediaSelection() {
+	const location = useLocation()
+	const navigate = useNavigate()
+	const preference = usePreferenceProvider()
+	const { files, setFiles } = useFilesContext()
+	const [audio, setAudio] = useState<HTMLAudioElement | null>(null)
+	const [selectedFolder, setSelectedFolder] = useState<string | null>(null)
+	const [isCollectingFolder, setIsCollectingFolder] = useState(false)
+
+	useEffect(() => {
+		setFiles([])
+		setSelectedFolder(null)
+		if (files.length !== 1) setAudio(null)
+	}, [location])
+
+	useEffect(() => {
+		if (selectedFolder) setAudio(null)
+		else if (files.length === 1) setAudio(new Audio(convertFileSrc(files[0].path)))
+	}, [files, selectedFolder])
+
+	async function selectFiles() {
+		const selected = await dialog.open({ multiple: true, filters: [{ name: 'Audio or Video files', extensions: [...config.audioExtensions, ...config.videoExtensions] }] })
+		if (!selected) return
+		setSelectedFolder(null)
+		const newFiles: NamedPath[] = []
+		for (const filePath of selected) newFiles.push({ path: filePath, name: await basename(filePath) })
+		setFiles(newFiles)
+		if (newFiles.length > 1) navigate('/batch', { state: { files: newFiles.map((file) => file.path) } })
+	}
+
+	async function loadFolderFiles(folder: string, recursive: boolean) {
+		setIsCollectingFolder(true)
+		try {
+			const paths = await invoke<string[]>('glob_files', { folder, patterns: [...config.audioExtensions, ...config.videoExtensions], recursive })
+			const newFiles: NamedPath[] = []
+			for (const filePath of paths) newFiles.push({ path: filePath, name: await basename(filePath) })
+			setFiles(newFiles)
+		} finally {
+			setIsCollectingFolder(false)
+		}
+	}
+
+	async function selectFolder() {
+		const folder = await dialog.open({ multiple: false, directory: true })
+		if (!folder || Array.isArray(folder)) return
+		setSelectedFolder(folder)
+		await loadFolderFiles(folder, preference.advancedTranscribeOptions.includeSubFolders)
+	}
+
+	function startFolderBatch() {
+		if (selectedFolder && files.length) navigate('/batch', { state: { files: files.map((file) => file.path), outputFolder: selectedFolder } })
+	}
+
+	function clearFolderSelection() {
+		setSelectedFolder(null); setFiles([]); setAudio(null)
+	}
+
+	useEffect(() => {
+		if (selectedFolder) loadFolderFiles(selectedFolder, preference.advancedTranscribeOptions.includeSubFolders)
+	}, [selectedFolder, preference.advancedTranscribeOptions.includeSubFolders])
+
+	return { files, setFiles, audio, setAudio, selectedFolder, setSelectedFolder, isCollectingFolder, selectFiles, selectFolder, startFolderBatch, clearFolderSelection }
+}

--- a/desktop/src/pages/home/hooks/use-recording.ts
+++ b/desktop/src/pages/home/hooks/use-recording.ts
@@ -1,0 +1,83 @@
+import { emit } from '@tauri-apps/api/event'
+import { invoke } from '@tauri-apps/api/core'
+import { type SetStateAction, useContext, useEffect, useState } from 'react'
+import { useLocalStorage } from 'usehooks-ts'
+import type { AudioDevice } from '~/lib/audio'
+import { startKeepAwake, stopKeepAwake } from '~/lib/keep-awake'
+import { ensureSystemAudioPermission } from '~/lib/permissions'
+import { ErrorModalContext } from '~/providers/error-modal'
+import { usePreferenceProvider } from '~/providers/preference'
+
+export function useRecording(onBeforeStart: () => void) {
+	const preference = usePreferenceProvider()
+	const { setState: setErrorModal } = useContext(ErrorModalContext)
+	const [devices, setDevices] = useState<AudioDevice[]>([])
+	const [savedInputDeviceId, setSavedInputDeviceId] = useLocalStorage<string | null>('prefs_input_device_id', null)
+	const [savedOutputDeviceId, setSavedOutputDeviceId] = useLocalStorage<string | null>('prefs_output_device_id', null)
+	const [inputDevice, setInputDevice] = useState<AudioDevice | null>(null)
+	const [outputDevice, setOutputDevice] = useState<AudioDevice | null>(null)
+	const [isRecording, setIsRecording] = useState(false)
+	const [recordingName, setRecordingName] = useState('')
+
+	function setInputDeviceAndSave(value: SetStateAction<AudioDevice | null>) {
+		const device = typeof value === 'function' ? value(inputDevice) : value
+		setSavedInputDeviceId(device?.id ?? '')
+		setInputDevice(device)
+	}
+
+	function setOutputDeviceAndSave(value: SetStateAction<AudioDevice | null>) {
+		const device = typeof value === 'function' ? value(outputDevice) : value
+		setSavedOutputDeviceId(device?.id ?? '')
+		setOutputDevice(device)
+	}
+
+	async function loadAudioDevices() {
+		const newDevices = await invoke<AudioDevice[]>('get_audio_devices')
+		const inputs = newDevices.filter((device) => device.isInput)
+		const outputs = newDevices.filter((device) => !device.isInput)
+		setInputDevice(savedInputDeviceId === null ? inputs.find((device) => device.isDefault) ?? null : inputs.find((device) => device.id === savedInputDeviceId) ?? null)
+		setOutputDevice(savedOutputDeviceId === null ? outputs.find((device) => device.isDefault) ?? null : outputs.find((device) => device.id === savedOutputDeviceId) ?? null)
+		setDevices(newDevices)
+	}
+
+	useEffect(() => {
+		if (preference.homeTab === 'record') loadAudioDevices()
+	}, [preference.homeTab])
+
+	async function startRecord() {
+		if (outputDevice && !(await ensureSystemAudioPermission())) return
+		startKeepAwake()
+		onBeforeStart()
+		setIsRecording(true)
+		const selectedDevices = [inputDevice, outputDevice].filter((device): device is AudioDevice => device !== null)
+		try {
+			await invoke('start_record', {
+				devices: selectedDevices,
+				storeInDocuments: preference.storeRecordInDocuments,
+				customPath: preference.customRecordingPath,
+				recordingName: recordingName.trim() || null,
+			})
+		} catch (error) {
+			stopKeepAwake()
+			setIsRecording(false)
+			console.error('startRecord error: ', error)
+			setErrorModal?.({ log: String(error), open: true })
+		}
+	}
+
+	async function stopRecord() {
+		try {
+			await emit('stop_record')
+		} catch (error) {
+			stopKeepAwake()
+			setIsRecording(false)
+			console.error('stopRecord error: ', error)
+			setErrorModal?.({ log: String(error), open: true })
+		}
+	}
+
+	return {
+		devices, setDevices, inputDevice, outputDevice, isRecording, setIsRecording, recordingName, setRecordingName,
+		setInputDevice: setInputDeviceAndSave, setOutputDevice: setOutputDeviceAndSave, startRecord, stopRecord,
+	}
+}

--- a/desktop/src/pages/home/hooks/use-summarization.ts
+++ b/desktop/src/pages/home/hooks/use-summarization.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { useLocalStorage } from 'usehooks-ts'
+import { Claude, type Llm, Ollama, OpenAICompatible } from '~/lib/llm'
+import * as transcript from '~/lib/transcript'
+import { usePreferenceProvider } from '~/providers/preference'
+
+export function useSummarization() {
+	const { t } = useTranslation()
+	const preference = usePreferenceProvider()
+	const [llm, setLlm] = useState<Llm | null>(null)
+	const [segments, setSegments] = useState<transcript.Segment[] | null>(null)
+	const [summarizing, setSummarizing] = useState(false)
+	const [transcriptTab, setTranscriptTab] = useLocalStorage<'transcript' | 'summary'>('prefs_transcript_tab', 'transcript')
+
+	useEffect(() => {
+		const config = preference.llmConfig
+		setLlm(config.platform === 'ollama' ? new Ollama(config) : config.platform === 'openai' ? new OpenAICompatible(config) : new Claude(config))
+	}, [preference.llmConfig])
+
+	async function summarize(source: transcript.Segment[], prompt: string, showSummary = false) {
+		if (!llm) return
+		setSummarizing(true)
+		try {
+			const question = prompt.replace('%s', transcript.asText(source, t('common.speaker-prefix')))
+			const answerPromise = llm.ask(question)
+			toast.promise(answerPromise, {
+				loading: t('common.summarize-loading'),
+				error: (error) => String(error),
+				success: t('common.summarize-success'),
+			})
+			const answer = await answerPromise
+			if (answer) {
+				setSegments([{ start: 0, stop: source[source.length - 1]?.stop ?? 0, text: answer }])
+				if (showSummary) setTranscriptTab('summary')
+			}
+		} catch (error) {
+			console.error(error)
+		} finally {
+			setSummarizing(false)
+		}
+	}
+
+	return {
+		segments,
+		setSegments,
+		summarizing,
+		transcriptTab,
+		setTranscriptTab,
+		summarize,
+	}
+}

--- a/desktop/src/pages/home/hooks/use-transcription.ts
+++ b/desktop/src/pages/home/hooks/use-transcription.ts
@@ -1,0 +1,115 @@
+import { event } from '@tauri-apps/api'
+import { invoke } from '@tauri-apps/api/core'
+import * as webview from '@tauri-apps/api/webviewWindow'
+import * as dialog from '@tauri-apps/plugin-dialog'
+import { useContext, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import successSound from '~/assets/success.mp3'
+import { analyticsEvents, trackAnalyticsEvent } from '~/lib/analytics'
+import * as config from '~/lib/config'
+import { startKeepAwake, stopKeepAwake } from '~/lib/keep-awake'
+import { isUserError } from '~/lib/sona-errors'
+import * as transcript from '~/lib/transcript'
+import { ErrorModalContext } from '~/providers/error-modal'
+import { usePreferenceProvider } from '~/providers/preference'
+
+interface UseTranscriptionOptions {
+	onResetSummary: () => void
+	onSummarize: (segments: transcript.Segment[], prompt: string) => Promise<void>
+}
+
+export function useTranscription({ onResetSummary, onSummarize }: UseTranscriptionOptions) {
+	const { t } = useTranslation()
+	const preference = usePreferenceProvider()
+	const preferenceRef = useRef(preference)
+	const { setState: setErrorModal } = useContext(ErrorModalContext)
+	const abortRef = useRef(false)
+	const [loading, setLoading] = useState(false)
+	const [isAborting, setIsAborting] = useState(false)
+	const [segments, setSegments] = useState<transcript.Segment[] | null>(null)
+	const [progress, setProgress] = useState<number | null>(0)
+
+	useEffect(() => { preferenceRef.current = preference }, [preference])
+
+	async function onAbort() {
+		setIsAborting(true)
+		abortRef.current = true
+		event.emit('abort_transcribe')
+	}
+
+	async function transcribe(path: string) {
+		const avx2 = await invoke<boolean>('is_avx2_enabled')
+		if (!avx2) {
+			trackAnalyticsEvent(analyticsEvents.AVX2_NOT_SUPPORTED)
+			await dialog.message(t('common.avx2-not-supported'), { kind: 'error' })
+			return
+		}
+
+		startKeepAwake()
+		setSegments(null)
+		onResetSummary()
+		setLoading(true)
+		abortRef.current = false
+		let completedSegments: transcript.Segment[] = []
+		trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_STARTED, { source: 'home' })
+
+		try {
+			const current = preferenceRef.current
+			if (!current.modelPath) throw new Error('No model selected. Please download or select a model first.')
+			const loadResult = await invoke<string>('load_model', { modelPath: current.modelPath, gpuDevice: current.gpuDevice })
+			if (loadResult === 'gpu_fallback') toast.warning(t('common.gpu-fallback-to-cpu'), { position: 'bottom-center', duration: 8000 })
+
+			const modelsFolder = current.diarizeEnabled || current.stableTimestampsEnabled ? await invoke<string>('get_models_folder') : null
+			const diarizeModel = current.diarizeEnabled ? `${modelsFolder}/${config.diarizeModelFilename}` : undefined
+			const vadModel = current.stableTimestampsEnabled ? `${modelsFolder}/${config.vadModelFilename}` : undefined
+			const options = {
+				path,
+				...current.modelOptions,
+				...(diarizeModel ? { diarize_model: diarizeModel } : {}),
+				...(vadModel ? { vad_model: vadModel } : {}),
+				...(current.stableTimestampsEnabled ? { stable_timestamps: true } : {}),
+			}
+			const startedAt = performance.now()
+			const result = await invoke<transcript.Transcript>('transcribe', { options })
+			const total = Math.round((performance.now() - startedAt) / 1000)
+			console.info(`Transcribe took ${total} seconds.`)
+			completedSegments = result.segments
+			setSegments(result.segments)
+			toast.success(t('common.transcribe-took', { total: String(total) }), { position: 'bottom-center' })
+			trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_SUCCEEDED, { source: 'home', duration_seconds: total, segments_count: result.segments.length })
+		} catch (error) {
+			if (!abortRef.current) {
+				stopKeepAwake()
+				console.error('error: ', error)
+				const errorObject = typeof error === 'object' && error !== null ? (error as { code?: string; message?: string }) : null
+				const errorMessage = errorObject?.message || String(error)
+				if (errorObject?.code && isUserError(errorObject.code)) {
+					toast.error(`${t('common.error')}: ${errorMessage}`, { position: 'bottom-center' })
+				} else {
+					trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_FAILED, { source: 'home', error_message: errorMessage, file_ext: path.split('.').pop() ?? 'unknown' })
+					setErrorModal?.({ log: errorMessage, open: true })
+				}
+				setLoading(false)
+			}
+		} finally {
+			stopKeepAwake()
+			setLoading(false)
+			setIsAborting(false)
+			setProgress(null)
+			if (!abortRef.current) {
+				if (preferenceRef.current.soundOnFinish) new Audio(successSound).play()
+				if (preferenceRef.current.focusOnFinish) {
+					webview.getCurrentWebviewWindow().unminimize()
+					webview.getCurrentWebviewWindow().setFocus()
+				}
+			}
+		}
+
+		if (completedSegments.length > 0 && preferenceRef.current.llmConfig.enabled) {
+			await onSummarize(completedSegments, preferenceRef.current.llmConfig.prompt)
+		}
+	}
+
+	return { loading, isAborting, segments, setSegments, progress, setProgress, transcribe, onAbort }
+}

--- a/desktop/src/pages/home/view-model.ts
+++ b/desktop/src/pages/home/view-model.ts
@@ -1,37 +1,26 @@
-import '@fontsource/roboto'
-import { event, path } from '@tauri-apps/api'
-import { convertFileSrc, invoke } from '@tauri-apps/api/core'
-import { emit, listen } from '@tauri-apps/api/event'
-import { basename } from '@tauri-apps/api/path'
-import * as webview from '@tauri-apps/api/webviewWindow'
+import '@fontsource/roboto/400.css'
+import { path } from '@tauri-apps/api'
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
 import * as dialog from '@tauri-apps/plugin-dialog'
 import * as fs from '@tauri-apps/plugin-fs'
-import { SetStateAction, useContext, useEffect, useRef, useState } from 'react'
-import { toast as hotToast } from 'sonner'
+import { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { useLocalStorage } from 'usehooks-ts'
-import successSound from '~/assets/success.mp3'
 import { TextFormat } from '~/components/format-select'
-import { AudioDevice } from '~/lib/audio'
-import { ensureSystemAudioPermission } from '~/lib/permissions'
-import { analyticsEvents, trackAnalyticsEvent } from '~/lib/analytics'
-import * as config from '~/lib/config'
-import { Claude, Llm, Ollama, OpenAICompatible } from '~/lib/llm'
 import * as transcript from '~/lib/transcript'
-import { isUserError } from '~/lib/sona-errors'
 import { useConfirmExit } from '~/lib/use-confirm-exit'
 import { NamedPath } from '~/lib/types'
 import { ls, pathToNamedPath } from '~/lib/fs'
 import { openPath } from '~/lib/app'
-import { startKeepAwake, stopKeepAwake } from '~/lib/keep-awake'
-import * as ytDlp from '~/lib/ytdlp'
-import { ErrorModalContext } from '~/providers/error-modal'
-import { useFilesContext } from '~/providers/files-provider'
 import { ModelOptions, usePreferenceProvider } from '~/providers/preference'
-import { useToastProvider } from '~/providers/toast'
 import { UpdaterContext } from '~/providers/updater'
 import { hotkeyRecordingActive } from '~/providers/hotkey'
+import { useSummarization } from './hooks/use-summarization'
+import { useRecording } from './hooks/use-recording'
+import { useAudioDownload } from './hooks/use-audio-download'
+import { useMediaSelection } from './hooks/use-media-selection'
+import { useTranscription } from './hooks/use-transcription'
 
 export interface BatchOptions {
 	files: NamedPath[]
@@ -43,51 +32,54 @@ export function viewModel() {
 	const location = useLocation()
 	const [settingsVisible, setSettingsVisible] = useState(location.hash === '#settings')
 	const navigate = useNavigate()
-	const [loading, setLoading] = useState(false)
-	const [isRecording, setIsRecording] = useState(false)
-	const [recordingName, setRecordingName] = useState('')
-	const abortRef = useRef<boolean>(false)
-	const [isAborting, setIsAborting] = useState(false)
-	const [segments, setSegments] = useState<transcript.Segment[] | null>(null)
-	const [summarizeSegments, setSummarizeSegments] = useState<transcript.Segment[] | null>(null)
-	const [audio, setAudio] = useState<HTMLAudioElement | null>(null)
-	const [progress, setProgress] = useState<number | null>(0)
 	const { t } = useTranslation()
-	const toast = useToastProvider()
-	const [llm, setLlm] = useState<Llm | null>(null)
-	const [transcriptTab, setTranscriptTab] = useLocalStorage<'transcript' | 'summary'>('prefs_transcript_tab', 'transcript')
+	const {
+		segments: summarizeSegments,
+		setSegments: setSummarizeSegments,
+		summarizing,
+		transcriptTab,
+		setTranscriptTab,
+		summarize,
+	} = useSummarization()
+	const { loading, isAborting, segments, setSegments, progress, setProgress, transcribe, onAbort } = useTranscription({
+		onResetSummary: () => {
+			setSummarizeSegments(null)
+			setTranscriptTab('transcript')
+		},
+		onSummarize: summarize,
+	})
+	const {
+		devices,
+		setDevices,
+		inputDevice,
+		setInputDevice,
+		outputDevice,
+		setOutputDevice,
+		isRecording,
+		setIsRecording,
+		recordingName,
+		setRecordingName,
+		startRecord,
+		stopRecord,
+	} = useRecording(() => {
+		setSegments(null)
+		setSummarizeSegments(null)
+		setTranscriptTab('transcript')
+	})
 	useConfirmExit((segments?.length ?? 0) > 0 || loading)
 
-	const { files, setFiles } = useFilesContext()
+	const {
+		files, setFiles, audio, setAudio, selectedFolder, setSelectedFolder, isCollectingFolder,
+		selectFiles, selectFolder, startFolderBatch, clearFolderSelection,
+	} = useMediaSelection()
 	const preference = usePreferenceProvider()
-	const preferenceRef = useRef(preference)
-	const [devices, setDevices] = useState<AudioDevice[]>([])
-	const [savedInputDeviceId, setSavedInputDeviceId] = useLocalStorage<string | null>('prefs_input_device_id', null)
-	const [savedOutputDeviceId, setSavedOutputDeviceId] = useLocalStorage<string | null>('prefs_output_device_id', null)
-	const [inputDevice, setInputDevice] = useState<AudioDevice | null>(null)
-	const [outputDevice, setOutputDevice] = useState<AudioDevice | null>(null)
-	const [audioUrl, setAudioUrl] = useState<string>('')
-	const [downloadingAudio, setDownloadingAudio] = useState(false)
-	const [ytdlpProgress, setYtDlpProgress] = useState<number | null>(null)
-	const [selectedFolder, setSelectedFolder] = useState<string | null>(null)
-	const [isCollectingFolder, setIsCollectingFolder] = useState(false)
-	const cancelYtDlpRef = useRef<boolean>(false)
-	const switchingToLinkRef = useRef(false)
-	const cachedYtDlpVersion = useRef<string | null | undefined>(undefined)
-	const skippedYtDlpUpdatePromptRef = useRef(false)
+	const {
+		cancelYtDlpRef, cancelYtDlpDownload, ytdlpProgress, setYtDlpProgress, switchToLinkTab,
+		audioUrl, setAudioUrl, downloadAudio, downloadingAudio, setDownloadingAudio,
+	} = useAudioDownload(transcribe)
 
 	const { updateApp, availableUpdate } = useContext(UpdaterContext)
-	const { setState: setErrorModal } = useContext(ErrorModalContext)
 
-	async function onFilesChanged() {
-		if (selectedFolder) {
-			setAudio(null)
-			return
-		}
-		if (files.length === 1) {
-			setAudio(new Audio(convertFileSrc(files[0].path)))
-		}
-	}
 
 	async function checkIfCrashedRecently() {
 		const isCrashed = await invoke<boolean>('is_crashed_recently')
@@ -97,134 +89,12 @@ export function viewModel() {
 		}
 	}
 
-	useEffect(() => {
-		setFiles([])
-		setSelectedFolder(null)
-		if (!(files.length === 1)) {
-			setAudio(null)
-		}
-	}, [location])
 
 	useEffect(() => {
 		checkIfCrashedRecently()
 	}, [])
 
-	useEffect(() => {
-		onFilesChanged()
-	}, [files, selectedFolder])
 
-	useEffect(() => {
-		if (preference.llmConfig?.platform === 'ollama') {
-			const llmInstance = new Ollama(preference.llmConfig)
-			setLlm(llmInstance)
-		} else if (preference.llmConfig?.platform === 'openai') {
-			const llmInstance = new OpenAICompatible(preference.llmConfig)
-			setLlm(llmInstance)
-		} else {
-			const llmInstance = new Claude(preference.llmConfig)
-			setLlm(llmInstance)
-		}
-	}, [preference.llmConfig])
-
-	useEffect(() => {
-		const unlisten = listen<number>('ytdlp-progress', ({ payload }) => {
-			const newProgress = Math.ceil(payload)
-			if (!ytdlpProgress || newProgress > ytdlpProgress) {
-				setYtDlpProgress(newProgress)
-			}
-		})
-		return () => {
-			unlisten.then((fn) => fn())
-		}
-	}, [])
-
-	useEffect(() => {
-		preferenceRef.current = preference
-	}, [preference])
-
-	async function cancelYtDlpDownload() {
-		cancelYtDlpRef.current = true
-		event.emit('ytdlp-cancel')
-	}
-
-	async function switchToLinkTab() {
-		if (switchingToLinkRef.current) return
-		switchingToLinkRef.current = true
-
-		try {
-			const binaryExists = await ytDlp.exists()
-			let latestVersion: string | null = null
-
-			if (cachedYtDlpVersion.current !== undefined) {
-				latestVersion = cachedYtDlpVersion.current
-			} else {
-				try {
-					latestVersion = await ytDlp.getLatestVersion()
-					cachedYtDlpVersion.current = latestVersion
-				} catch (e) {
-					console.error('Failed to fetch latest yt-dlp version', e)
-					cachedYtDlpVersion.current = null
-					if (binaryExists) {
-						preference.setHomeTab("link")
-						return
-					}
-				}
-			}
-
-			const needsInstall = !binaryExists
-			const needsUpdate = !needsInstall && preference.shouldCheckYtDlpVersion && latestVersion !== null && latestVersion !== preference.ytDlpVersion
-
-			if (needsUpdate && skippedYtDlpUpdatePromptRef.current) {
-				preference.setHomeTab("link")
-				return
-			}
-
-			if (needsInstall || needsUpdate) {
-				let shouldInstallOrUpdate = false
-				if (needsUpdate) {
-					shouldInstallOrUpdate = await dialog.ask(t('common.ask-for-update-ytdlp-message'), {
-						title: t('common.ask-for-update-ytdlp-title'),
-						kind: 'info',
-						cancelLabel: t('common.later'),
-						okLabel: t('common.update-now'),
-					})
-				} else {
-					shouldInstallOrUpdate = await dialog.ask(t('common.ask-for-install-ytdlp-message'), {
-						title: t('common.ask-for-install-ytdlp-title'),
-						kind: 'info',
-						cancelLabel: t('common.cancel'),
-						okLabel: t('common.install-now'),
-					})
-				}
-
-				if (shouldInstallOrUpdate) {
-					try {
-						const versionToDownload = latestVersion ?? preference.ytDlpVersion ?? '2026.02.04'
-						toast.setMessage(t('common.downloading-ytdlp'))
-						toast.setProgress(0)
-						toast.setOpen(true)
-						await ytDlp.downloadYtDlp(versionToDownload)
-						preference.setYtDlpVersion(versionToDownload)
-						skippedYtDlpUpdatePromptRef.current = false
-						toast.setOpen(false)
-						preference.setHomeTab("link")
-					} catch (e) {
-						console.error(e)
-						setErrorModal?.({ log: String(e), open: true })
-					}
-				} else if (binaryExists) {
-					if (needsUpdate) {
-						skippedYtDlpUpdatePromptRef.current = true
-					}
-					preference.setHomeTab("link")
-				}
-			} else {
-				preference.setHomeTab("link")
-			}
-		} finally {
-			switchingToLinkRef.current = false
-		}
-	}
 
 	function setupEventListeners(): (() => void) {
 		const unlisteners: Promise<() => void>[] = []
@@ -274,111 +144,7 @@ export function viewModel() {
 		}
 	}
 
-	function setInputDeviceAndSave(value: SetStateAction<AudioDevice | null>) {
-		const device = typeof value === 'function' ? value(inputDevice) : value
-		setSavedInputDeviceId(device?.id ?? '')
-		setInputDevice(device)
-	}
 
-	function setOutputDeviceAndSave(value: SetStateAction<AudioDevice | null>) {
-		const device = typeof value === 'function' ? value(outputDevice) : value
-		setSavedOutputDeviceId(device?.id ?? '')
-		setOutputDevice(device)
-	}
-
-	async function loadAudioDevices() {
-		let newDevices = await invoke<AudioDevice[]>('get_audio_devices')
-		const inputs = newDevices.filter((d) => d.isInput)
-		const outputs = newDevices.filter((d) => !d.isInput)
-		// null = no saved preference → use system default; '' = user explicitly chose none
-		const restoredInput = savedInputDeviceId === null
-			? inputs.find((d) => d.isDefault) ?? null
-			: inputs.find((d) => d.id === savedInputDeviceId) ?? null
-		const restoredOutput = savedOutputDeviceId === null
-			? outputs.find((d) => d.isDefault) ?? null
-			: outputs.find((d) => d.id === savedOutputDeviceId) ?? null
-		setInputDevice(restoredInput)
-		setOutputDevice(restoredOutput)
-		setDevices(newDevices)
-	}
-
-	async function onAbort() {
-		setIsAborting(true)
-		abortRef.current = true
-		event.emit('abort_transcribe')
-	}
-
-	async function selectFiles() {
-		const selected = await dialog.open({
-			multiple: true,
-			filters: [
-				{
-					name: 'Audio or Video files',
-					extensions: [...config.audioExtensions, ...config.videoExtensions],
-				},
-			],
-		})
-		if (selected) {
-			setSelectedFolder(null)
-			const newFiles: NamedPath[] = []
-			for (const path of selected) {
-				const name = await basename(path)
-				newFiles.push({ path, name })
-			}
-			setFiles(newFiles)
-
-			if (newFiles.length > 1) {
-				navigate('/batch', { state: { files: newFiles.map((f) => f.path) } })
-			}
-		}
-	}
-
-	async function loadFolderFiles(folder: string, recursive: boolean) {
-		setIsCollectingFolder(true)
-		try {
-			const paths = await invoke<string[]>('glob_files', {
-				folder,
-				patterns: [...config.audioExtensions, ...config.videoExtensions],
-				recursive,
-			})
-			const newFiles: NamedPath[] = []
-			for (const filePath of paths) {
-				const name = await basename(filePath)
-				newFiles.push({ path: filePath, name })
-			}
-			setFiles(newFiles)
-		} finally {
-			setIsCollectingFolder(false)
-		}
-	}
-
-	async function selectFolder() {
-		const folder = await dialog.open({ multiple: false, directory: true })
-		if (!folder || Array.isArray(folder)) return
-		setSelectedFolder(folder)
-		await loadFolderFiles(folder, preference.advancedTranscribeOptions.includeSubFolders)
-	}
-
-	function startFolderBatch() {
-		if (!selectedFolder || !files.length) return
-		navigate('/batch', {
-			state: {
-				files: files.map((file) => file.path),
-				outputFolder: selectedFolder,
-			},
-		})
-	}
-
-	function clearFolderSelection() {
-		setSelectedFolder(null)
-		setFiles([])
-		setAudio(null)
-	}
-
-	useEffect(() => {
-		if (!selectedFolder) return
-		loadFolderFiles(selectedFolder, preference.advancedTranscribeOptions.includeSubFolders)
-	}, [selectedFolder, preference.advancedTranscribeOptions.includeSubFolders])
 
 	async function checkModelExists() {
 		try {
@@ -418,232 +184,12 @@ export function viewModel() {
 		}
 	}, [])
 
-	useEffect(() => {
-		if (preference.homeTab === "record") {
-			loadAudioDevices()
-		}
-	}, [preference.homeTab])
 
-	async function startRecord() {
-		if (outputDevice) {
-			const permitted = await ensureSystemAudioPermission()
-			if (!permitted) {
-				return
-			}
-		}
-
-		startKeepAwake()
-		setSegments(null)
-		setSummarizeSegments(null)
-		setTranscriptTab('transcript')
-
-		setIsRecording(true)
-		let devices: AudioDevice[] = []
-		if (inputDevice) {
-			devices.push(inputDevice)
-		}
-		if (outputDevice) {
-			devices.push(outputDevice)
-		}
-		try {
-			await invoke('start_record', {
-				devices,
-				storeInDocuments: preference.storeRecordInDocuments,
-				customPath: preference.customRecordingPath,
-				recordingName: recordingName.trim() || null,
-			})
-		} catch (error) {
-			stopKeepAwake()
-			setIsRecording(false)
-			console.error('startRecord error: ', error)
-			setErrorModal?.({ log: String(error), open: true })
-		}
-	}
-
-	async function stopRecord() {
-		try {
-			await emit('stop_record')
-		} catch (error) {
-			stopKeepAwake()
-			setIsRecording(false)
-			console.error('stopRecord error: ', error)
-			setErrorModal?.({ log: String(error), open: true })
-		}
-	}
-
-	async function transcribe(path: string) {
-		const avx2 = await invoke<boolean>('is_avx2_enabled')
-		if (!avx2) {
-			trackAnalyticsEvent(analyticsEvents.AVX2_NOT_SUPPORTED)
-			await dialog.message(t('common.avx2-not-supported'), { kind: 'error' })
-			return
-		}
-
-		startKeepAwake()
-
-		setSegments(null)
-		setSummarizeSegments(null)
-		setTranscriptTab('transcript')
-
-		setLoading(true)
-		abortRef.current = false
-
-		var newSegments: transcript.Segment[] = []
-		trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_STARTED, {
-			source: 'home',
-		})
-		try {
-			const modelPath = preferenceRef.current.modelPath
-			if (!modelPath) {
-				throw new Error('No model selected. Please download or select a model first.')
-			}
-			const loadResult = await invoke<string>('load_model', { modelPath, gpuDevice: preferenceRef.current.gpuDevice })
-			if (loadResult === 'gpu_fallback') {
-				hotToast.warning(t('common.gpu-fallback-to-cpu'), { position: 'bottom-center', duration: 8000 })
-			}
-			let diarize_model: string | undefined
-			if (preferenceRef.current.diarizeEnabled) {
-				const modelsFolder = await invoke<string>('get_models_folder')
-				diarize_model = modelsFolder + '/' + config.diarizeModelFilename
-			}
-			let vad_model: string | undefined
-			if (preferenceRef.current.stableTimestampsEnabled) {
-				const modelsFolder = await invoke<string>('get_models_folder')
-				vad_model = modelsFolder + '/' + config.vadModelFilename
-			}
-			const options = {
-				path,
-				...preferenceRef.current.modelOptions,
-				...(diarize_model ? { diarize_model } : {}),
-				...(vad_model ? { vad_model } : {}),
-				...(preferenceRef.current.stableTimestampsEnabled ? { stable_timestamps: true } : {}),
-			}
-			const startTime = performance.now()
-			const res: transcript.Transcript = await invoke('transcribe', {
-				options,
-			})
-
-			// Calcualte time
-			const total = Math.round((performance.now() - startTime) / 1000)
-			console.info(`Transcribe took ${total} seconds.`)
-
-			newSegments = res.segments
-			setSegments(res.segments)
-			hotToast.success(t('common.transcribe-took', { total: String(total) }), { position: 'bottom-center' })
-			trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_SUCCEEDED, {
-				source: 'home',
-				duration_seconds: total,
-				segments_count: res.segments.length,
-			})
-		} catch (error) {
-			if (!abortRef.current) {
-				stopKeepAwake()
-				console.error('error: ', error)
-
-				// Check if this is a structured error with code
-				const errorObj = typeof error === 'object' && error !== null ? (error as any) : null
-				const errorCode = errorObj?.code
-				const errorMessage = errorObj?.message || String(error)
-
-				if (errorCode && isUserError(errorCode)) {
-					// User error: show toast, skip analytics and error modal
-					hotToast.error(`${t('common.error')}: ${errorMessage}`, { position: 'bottom-center' })
-				} else {
-					// Internal error: show modal and track analytics
-					trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_FAILED, {
-						source: 'home',
-						error_message: errorMessage,
-						file_ext: path.split('.').pop() ?? 'unknown',
-					})
-					setErrorModal?.({ log: errorMessage, open: true })
-				}
-				setLoading(false)
-			}
-		} finally {
-			stopKeepAwake()
-			setLoading(false)
-			setIsAborting(false)
-			setProgress(null)
-			if (!abortRef.current) {
-				// Focus back the window and play sound
-				if (preferenceRef.current.soundOnFinish) {
-					new Audio(successSound).play()
-				}
-				if (preferenceRef.current.focusOnFinish) {
-					webview.getCurrentWebviewWindow().unminimize()
-					webview.getCurrentWebviewWindow().setFocus()
-				}
-			}
-		}
-
-		if (newSegments && llm && preferenceRef.current.llmConfig?.enabled) {
-			try {
-				const question = `${preferenceRef.current.llmConfig.prompt.replace('%s', transcript.asText(newSegments, t('common.speaker-prefix')))}`
-				const answerPromise = llm.ask(question)
-				hotToast.promise(answerPromise, {
-					loading: t('common.summarize-loading'),
-					error: (error) => {
-						return String(error)
-					},
-					success: t('common.summarize-success'),
-				})
-				const answer = await answerPromise
-				if (answer) {
-					setSummarizeSegments([{ start: 0, stop: newSegments?.[newSegments?.length - 1].stop ?? 0, text: answer }])
-				}
-			} catch (e) {
-				console.error(e)
-			}
-		}
-	}
-
-	const [summarizing, setSummarizing] = useState(false)
 
 	async function resummarize(prompt: string) {
-		if (!segments || !llm) return
-		setSummarizing(true)
-		try {
-			const question = prompt.replace('%s', transcript.asText(segments, t('common.speaker-prefix')))
-			const answerPromise = llm.ask(question)
-			hotToast.promise(answerPromise, {
-				loading: t('common.summarize-loading'),
-				error: (error) => String(error),
-				success: t('common.summarize-success'),
-			})
-			const answer = await answerPromise
-			if (answer) {
-				setSummarizeSegments([{ start: 0, stop: segments[segments.length - 1]?.stop ?? 0, text: answer }])
-				setTranscriptTab('summary')
-			}
-		} catch (e) {
-			console.error(e)
-		} finally {
-			setSummarizing(false)
-		}
+		if (segments) await summarize(segments, prompt, true)
 	}
 
-	async function downloadAudio() {
-		if (audioUrl) {
-			setYtDlpProgress(0)
-			setDownloadingAudio(true)
-			try {
-				const outPath = await ytDlp.downloadAudio(audioUrl, preference.storeRecordInDocuments, preference.customRecordingPath)
-				if (cancelYtDlpRef.current) {
-					cancelYtDlpRef.current = false
-					return
-				}
-				preference.setHomeTab("file")
-				setFiles([{ name: 'audio.m4a', path: outPath }])
-				transcribe(outPath)
-			} catch (e) {
-				console.error(e)
-				setErrorModal?.({ log: String(e), open: true })
-			} finally {
-				setDownloadingAudio(false)
-			}
-			setYtDlpProgress(null)
-		}
-	}
 
 	return {
 		cancelYtDlpRef,
@@ -657,9 +203,9 @@ export function viewModel() {
 		devices,
 		setDevices,
 		inputDevice,
-		setInputDevice: setInputDeviceAndSave,
+		setInputDevice,
 		outputDevice,
-		setOutputDevice: setOutputDeviceAndSave,
+		setOutputDevice,
 		isRecording,
 		setIsRecording,
 		recordingName,

--- a/desktop/src/pages/settings/page.tsx
+++ b/desktop/src/pages/settings/page.tsx
@@ -1,11 +1,7 @@
-import { message } from '@tauri-apps/plugin-dialog'
-import { openUrl } from '@tauri-apps/plugin-opener'
-import { ReactNode, useMemo, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
 	Bot,
-	Check,
-	Copy,
 	Cpu,
 	Globe,
 	Mic,
@@ -16,28 +12,18 @@ import {
 	Wrench,
 	X,
 } from 'lucide-react'
-import { useHotkeyProvider, type HotkeyOutputMode } from '~/providers/hotkey'
-import { InfoTooltip } from '~/components/info-tooltip'
-import LanguageInput from '~/components/language-input'
-import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
-import { ReactComponent as GithubIcon } from '~/icons/github.svg'
-import { ReactComponent as HeartIcon } from '~/icons/heart.svg'
-import { ReactComponent as LinkIcon } from '~/icons/link.svg'
-import { ReactComponent as ResetIcon } from '~/icons/reset.svg'
-import { ReactComponent as DiscordIcon } from '~/icons/discord.svg'
-import { ReactComponent as WrenchIcon } from '~/icons/wrench.svg'
-import { ReactComponent as CopyIcon } from '~/icons/copy.svg'
-import * as config from '~/lib/config'
-import { supportedLanguages } from '~/lib/i18n'
 import { ModifyState } from '~/lib/types'
-import { defaultClaudeConfig, defaultOllamaConfig, defaultOpenAIConfig } from '~/lib/llm'
 import { viewModel } from './view-model'
 import { Button } from '~/components/ui/button'
-import { Input } from '~/components/ui/input'
-import { Label } from '~/components/ui/label'
-import { Switch } from '~/components/ui/switch'
-import { Textarea } from '~/components/ui/textarea'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { AdvancedSection } from './sections/advanced'
+import { ApiSection } from './sections/api'
+import { DictationSection } from './sections/dictation'
+import { GeneralSection } from './sections/general'
+import { ModelsSection } from './sections/models'
+import { PrivacySection } from './sections/privacy'
+import { SummarizeSection } from './sections/summarize'
+import { TranscriptionSection } from './sections/transcription'
+import { TuningSection } from './sections/tuning'
 
 interface SettingsPageProps {
 	setVisible: ModifyState<boolean>
@@ -46,49 +32,53 @@ interface SettingsPageProps {
 
 type SectionId = 'general' | 'transcription' | 'models' | 'summarize' | 'tuning' | 'dictation' | 'api' | 'privacy' | 'advanced'
 
-function SectionCard({ children }: { children: ReactNode }) {
-	return <div className="rounded-2xl border border-border/60 bg-card/92 p-5 text-card-foreground shadow-xs">{children}</div>
+interface SettingsSection {
+	id: SectionId
+	label: string
+	icon: ReactNode
 }
 
-function Field({ label, children }: { label: ReactNode; children: ReactNode }) {
-	return (
-		<div className="w-full space-y-2">
-			<Label className="flex items-center gap-1">{label}</Label>
-			{children}
-		</div>
-	)
+interface SettingsGroup {
+	label: string
+	sections: SettingsSection[]
 }
 
 export default function SettingsPage({ setVisible, scrollTo }: SettingsPageProps) {
-	const { t, i18n } = useTranslation()
+	const { t } = useTranslation()
 	const vm = viewModel()
-	const apiDocsUrl = vm.apiBaseUrl ? `${vm.apiBaseUrl}/docs` : null
-	const serverActionBusy = vm.isStartingApiServer || vm.isStoppingApiServer
-	const hotkey = useHotkeyProvider()
-	const isMac = navigator.platform.toUpperCase().includes('MAC')
-	const shortcutKeys = useMemo(() => {
-		const keyMap: Record<string, string> = {
-			CmdOrCtrl: isMac ? '⌘' : 'Ctrl',
-			Cmd: '⌘',
-			Ctrl: isMac ? '⌃' : 'Ctrl',
-			Shift: isMac ? '⇧' : 'Shift',
-			Alt: isMac ? '⌥' : 'Alt',
-			Option: '⌥',
-		}
-		return hotkey.hotkeyShortcut.split('+').map((k) => keyMap[k] ?? k)
-	}, [hotkey.hotkeyShortcut, isMac])
 
-	const sections: { id: SectionId; label: string; icon: ReactNode }[] = [
-		{ id: 'general', label: t('common.general'), icon: <Globe className="h-4 w-4" /> },
-		{ id: 'transcription', label: t('common.transcription'), icon: <SlidersHorizontal className="h-4 w-4" /> },
-		{ id: 'models', label: t('common.customize'), icon: <Bot className="h-4 w-4" /> },
-		{ id: 'summarize', label: t('common.process-with-llm'), icon: <Sparkles className="h-4 w-4" /> },
-		{ id: 'dictation', label: t('common.global-dictation'), icon: <Mic className="h-4 w-4" /> },
-		{ id: 'tuning', label: t('common.fine-tuning'), icon: <Cpu className="h-4 w-4" /> },
-		{ id: 'privacy', label: t('common.privacy'), icon: <ShieldCheck className="h-4 w-4" /> },
-		{ id: 'api', label: t('common.api-and-agents'), icon: <Terminal className="h-4 w-4" /> },
-		{ id: 'advanced', label: t('common.advanced'), icon: <Wrench className="h-4 w-4" /> },
+	const groups: SettingsGroup[] = [
+		{
+			label: t('common.general'),
+			sections: [
+				{ id: 'general', label: t('common.general'), icon: <Globe className="h-4 w-4" /> },
+				{ id: 'privacy', label: t('common.privacy'), icon: <ShieldCheck className="h-4 w-4" /> },
+			],
+		},
+		{
+			label: t('common.transcription'),
+			sections: [
+				{ id: 'transcription', label: t('common.transcription'), icon: <SlidersHorizontal className="h-4 w-4" /> },
+				{ id: 'models', label: t('common.select-model'), icon: <Bot className="h-4 w-4" /> },
+				{ id: 'tuning', label: t('common.fine-tuning'), icon: <Cpu className="h-4 w-4" /> },
+			],
+		},
+		{
+			label: t('common.customize'),
+			sections: [
+				{ id: 'dictation', label: t('common.global-dictation'), icon: <Mic className="h-4 w-4" /> },
+				{ id: 'summarize', label: t('common.process-with-llm'), icon: <Sparkles className="h-4 w-4" /> },
+			],
+		},
+		{
+			label: t('common.advanced'),
+			sections: [
+				{ id: 'api', label: t('common.api-and-agents'), icon: <Terminal className="h-4 w-4" /> },
+				{ id: 'advanced', label: t('common.advanced'), icon: <Wrench className="h-4 w-4" /> },
+			],
+		},
 	]
+	const sections = groups.flatMap((group) => group.sections)
 
 	const [activeSection, setActiveSection] = useState<SectionId>(
 		sections.some((s) => s.id === scrollTo) ? (scrollTo as SectionId) : 'general',
@@ -106,20 +96,28 @@ export default function SettingsPage({ setVisible, scrollTo }: SettingsPageProps
 							<X className="h-4 w-4" />
 						</Button>
 					</div>
-					<nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto">
-						{sections.map((section) => (
-							<button
-								key={section.id}
-								type="button"
-								onClick={() => setActiveSection(section.id)}
-								className={`flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm font-medium transition-colors ${
-									activeSection === section.id
-										? 'bg-primary/10 text-primary'
-										: 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-								}`}>
-								<span className={activeSection === section.id ? 'text-primary' : 'text-muted-foreground'}>{section.icon}</span>
-								<span className="truncate">{section.label}</span>
-							</button>
+					<nav aria-label={t('common.settings')} className="flex flex-1 flex-col gap-3 overflow-y-auto">
+						{groups.map((group) => (
+							<div key={group.label} className="space-y-0.5">
+								<p className="px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
+									{group.label}
+								</p>
+								{group.sections.map((section) => (
+									<button
+										key={section.id}
+										type="button"
+										aria-current={activeSection === section.id ? 'page' : undefined}
+										onClick={() => setActiveSection(section.id)}
+										className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm font-medium transition-colors ${
+											activeSection === section.id
+												? 'bg-primary/10 text-primary'
+												: 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+										}`}>
+										<span className={activeSection === section.id ? 'text-primary' : 'text-muted-foreground'}>{section.icon}</span>
+										<span className="truncate">{section.label}</span>
+									</button>
+								))}
+							</div>
 						))}
 					</nav>
 					<p className="mt-2 border-t border-border/55 px-2.5 pt-3 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/60">
@@ -131,863 +129,24 @@ export default function SettingsPage({ setVisible, scrollTo }: SettingsPageProps
 					<div className="mb-5 border-b border-border/55 pb-3">
 						<h2 className="text-xl font-semibold">{sections.find((s) => s.id === activeSection)?.label}</h2>
 					</div>
-					{activeSection === 'general' && (
-						<div className="space-y-5">
-							<SectionCard>
-								<div className="grid grid-cols-1 divide-y divide-border/45 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
-									<div className="space-y-2 sm:pe-5">
-										<Label>{t('common.language')}</Label>
-										<Select
-											value={supportedLanguages[vm.preference.displayLanguage] ? vm.preference.displayLanguage : 'en-US'}
-											onValueChange={(value) => vm.preference.setDisplayLanguage(value)}>
-											<SelectTrigger className="capitalize">
-												<SelectValue placeholder={t('common.select-language')} />
-											</SelectTrigger>
-											<SelectContent>
-												{Object.entries(supportedLanguages).map(([code, name], index) => (
-													<SelectItem key={index} value={code} className="capitalize">
-														{code === i18n.language ? t(`language.${name}`) : name}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									</div>
-									<div className="space-y-2 pt-4 sm:ps-5 sm:pt-0">
-										<Label>{t('common.theme')}</Label>
-										<Select value={vm.preference.theme} onValueChange={(value) => vm.preference.setTheme(value as 'light' | 'dark')}>
-											<SelectTrigger className="capitalize">
-												<SelectValue placeholder={t('common.select-theme')} />
-											</SelectTrigger>
-											<SelectContent>
-												{config.themes.map((theme) => (
-													<SelectItem key={theme} value={theme} className="capitalize">
-														{t(`common.${theme}`)}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									</div>
-								</div>
-							</SectionCard>
+					{activeSection === 'general' && <GeneralSection vm={vm} />}
 
-							<div className="divide-y divide-border/45 rounded-2xl border border-border/60 bg-card/92 shadow-xs">
-								<Button
-									variant="ghost"
-									onMouseDown={() => openUrl(config.aboutURL)}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.project-link')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={vm.reportIssue}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.report-issue')} <GithubIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={() => openUrl(config.supportVibeURL)}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.support-the-project')} <HeartIcon className="h-4 w-4 fill-red-500 text-red-500 dark:fill-red-400 dark:text-red-400" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={() => openUrl(config.discordURL)}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.discord-community')} <DiscordIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-							</div>
-						</div>
-					)}
+					{activeSection === 'transcription' && <TranscriptionSection vm={vm} />}
 
-					{activeSection === 'transcription' && (
-						<div className="space-y-5">
-							<SectionCard>
-								<LanguageInput />
-							</SectionCard>
-							<SectionCard>
-								<div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/45 py-2">
-									<span className="text-sm font-medium">{t('common.play-sound-on-finish')}</span>
-									<Switch checked={vm.preference.soundOnFinish} onCheckedChange={vm.preference.setSoundOnFinish} />
-								</div>
-								<div className="flex flex-wrap items-center justify-between gap-2 pb-1 pt-4">
-									<span className="text-sm font-medium">{t('common.focus-window-on-finish')}</span>
-									<Switch checked={vm.preference.focusOnFinish} onCheckedChange={vm.preference.setFocusOnFinish} />
-								</div>
-							</SectionCard>
+					{activeSection === 'models' && <ModelsSection vm={vm} />}
 
-							<div className="space-y-2">
-								<div className="flex items-center gap-1 px-1">
-									<InfoTooltip text={t('common.recording-save-path-info')} />
-									<span className="text-sm font-semibold text-foreground/95">{t('common.recording-save-path')}</span>
-								</div>
-								<SectionCard>
-									<div className="flex items-center justify-between gap-2">
-										<p className="min-w-0 truncate text-sm text-muted-foreground" title={vm.preference.customRecordingPath ?? vm.defaultRecordingPath}>
-											{vm.preference.customRecordingPath ?? vm.defaultRecordingPath}
-										</p>
-										<div className="flex shrink-0 items-center gap-2">
-											{vm.preference.customRecordingPath && (
-												<Button variant="ghost" size="sm" onMouseDown={vm.resetRecordingPath}>
-													{t('common.reset-to-default')}
-												</Button>
-											)}
-											<Button variant="outline" size="sm" onMouseDown={vm.changeRecordingPath}>
-												{t('common.change-recording-path')}
-											</Button>
-										</div>
-									</div>
-								</SectionCard>
-							</div>
-						</div>
-					)}
+					{activeSection === 'summarize' && <SummarizeSection vm={vm} />}
 
-					{activeSection === 'models' && (
-						<div className="space-y-5">
-							<SectionCard>
-								<div className="space-y-5">
-									<div className="space-y-2">
-										<Label>{t('common.download-model')}</Label>
-										<div className="flex items-center gap-2">
-											<Input
-												type="text"
-												value={vm.downloadURL}
-												onChange={(event) => vm.setDownloadURL(event.target.value)}
-												placeholder={t('common.paste-model-link')}
-												onKeyDown={(event) => (event.key === 'Enter' ? vm.downloadModel() : null)}
-											/>
-											<Button variant="default" size="icon" onClick={vm.downloadModel} className="shrink-0">
-												<svg
-													aria-hidden="true"
-													focusable="false"
-													role="img"
-													className="octicon octicon-download"
-													viewBox="0 0 16 16"
-													width="16"
-													height="16"
-													fill="currentColor">
-													<path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"></path>
-													<path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"></path>
-												</svg>
-											</Button>
-										</div>
-									</div>
+					{activeSection === 'tuning' && <TuningSection vm={vm} />}
 
-									<div className="space-y-2">
-										<Label>{t('common.select-model')}</Label>
-										<Select
-											value={vm.preference.modelPath ?? undefined}
-											onValueChange={(value) => vm.preference.setModelPath(value)}
-											onOpenChange={(open) => {
-												if (open) vm.loadModels()
-											}}>
-											<SelectTrigger>
-												<SelectValue placeholder={t('common.select-model')} />
-											</SelectTrigger>
-											<SelectContent>
-												{vm.models.map((model, index) => (
-													<SelectItem key={index} value={model.path}>
-														{model.name}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									</div>
+					{activeSection === 'dictation' && <DictationSection />}
 
-									{!vm.isMacOS && (
-										<div className="space-y-2">
-											<Label>{t('common.gpu-device')}</Label>
-											{vm.gpuDevices.length > 0 ? (
-												<Select
-													value={vm.preference.gpuDevice != null ? String(vm.preference.gpuDevice) : 'auto'}
-													onValueChange={(value) => {
-														vm.preference.setGpuDevice(value === 'auto' ? null : parseInt(value, 10))
-													}}>
-													<SelectTrigger>
-														<SelectValue placeholder={t('common.gpu-device')} />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="auto">Auto</SelectItem>
-														{vm.gpuDevices.map((device) => (
-															<SelectItem key={device.index} value={String(device.index)}>
-																{device.description}
-															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
-											) : (
-												<Input
-													type="number"
-													value={vm.preference.gpuDevice ?? ''}
-													onChange={(e) => {
-														const val = e.target.value
-														vm.preference.setGpuDevice(val === '' ? null : parseInt(val, 10))
-													}}
-													placeholder={t('common.gpu-device-placeholder')}
-												/>
-											)}
-										</div>
-									)}
+					{activeSection === 'api' && <ApiSection vm={vm} />}
 
-									<div className="space-y-1 pt-1">
-										<Button
-											variant="ghost"
-											onMouseDown={vm.openModelsUrl}
-											className="h-11 w-full justify-between rounded-lg px-3 font-medium hover:bg-accent/60">
-											{t('common.download-models-link')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
-										</Button>
-										<Button
-											variant="ghost"
-											onMouseDown={vm.openModelPath}
-											className="h-11 w-full justify-between rounded-lg px-3 font-medium hover:bg-accent/60">
-											{t('common.models-folder')} <FolderIcon className="h-4 w-4 text-muted-foreground" />
-										</Button>
-										<Button
-											variant="ghost"
-											onMouseDown={vm.changeModelsFolder}
-											className="h-11 w-full justify-between rounded-lg px-3 font-medium hover:bg-accent/60">
-											{t('common.change-models-folder')} <WrenchIcon className="h-4 w-4 text-muted-foreground" />
-										</Button>
-									</div>
-								</div>
-							</SectionCard>
+					{activeSection === 'privacy' && <PrivacySection vm={vm} />}
 
-							<div className="space-y-2">
-								<div className="flex items-center gap-1 px-1">
-									<InfoTooltip text={t('common.ytdlp-options-info')} />
-									<span className="text-sm font-semibold text-foreground/95">{t('common.ytdlp-options')}</span>
-								</div>
-								<SectionCard>
-									<div className="flex flex-wrap items-center justify-between gap-2">
-										<span className="text-sm font-medium">{t('common.check-ytdlp-updates')}</span>
-										<Switch checked={vm.preference.shouldCheckYtDlpVersion} onCheckedChange={vm.preference.setShouldCheckYtDlpVersion} />
-									</div>
-								</SectionCard>
-							</div>
-						</div>
-					)}
+					{activeSection === 'advanced' && <AdvancedSection vm={vm} />}
 
-					{activeSection === 'summarize' && (
-						<div className="space-y-5">
-							<div className="space-y-4">
-								<div className="flex items-center justify-between">
-									<div className="flex items-center gap-2">
-										<h3 className="text-sm font-semibold">{t('common.process-with-llm')} ✨</h3>
-										<InfoTooltip text={t('common.info-llm-summarize')} />
-									</div>
-									<Switch checked={vm.preference.llmConfig?.enabled} onCheckedChange={vm.onEnableLlm} />
-									</div>
-
-									<Field label={t('common.llm-platform')}>
-										<Select
-											value={vm.preference.llmConfig?.platform}
-											onValueChange={(value) => {
-												const lang = new Intl.DisplayNames([i18n.language], { type: 'language' }).of(i18n.language) ?? 'English'
-												const defaults =
-													value === 'ollama' ? defaultOllamaConfig(lang) : value === 'openai' ? defaultOpenAIConfig(lang) : defaultClaudeConfig(lang)
-												vm.preference.setLlmConfig({
-													...defaults,
-													ollamaBaseUrl: vm.preference.llmConfig.ollamaBaseUrl,
-													claudeApiKey: vm.preference.llmConfig.claudeApiKey,
-													openaiBaseUrl: vm.preference.llmConfig.openaiBaseUrl,
-													openaiApiKey: vm.preference.llmConfig.openaiApiKey,
-													enabled: vm.preference.llmConfig?.enabled ?? false,
-												})
-											}}>
-											<SelectTrigger className="capitalize">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{['claude', 'ollama', 'openai'].map((name) => (
-													<SelectItem key={name} value={name} className="capitalize">
-														{name === 'openai' ? 'OpenAI Compatible' : name}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									</Field>
-
-									{vm.preference.llmConfig?.platform === 'claude' && (
-										<>
-											<Field
-												label={
-													<>
-														<InfoTooltip text={t('common.info-llm-api-key')} />
-														{t('common.llm-api-key')}
-														<button
-															type="button"
-															className="ml-1 text-primary underline hover:text-primary/80"
-															onClick={() => openUrl(config.llmApiKeyUrl)}>
-															{t('common.find-here')}
-														</button>
-													</>
-												}>
-												<Input
-													value={vm.preference.llmConfig?.claudeApiKey}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, claudeApiKey: e.target.value })}
-													placeholder="Paste here your API key"
-													type="text"
-												/>
-											</Field>
-											<Field
-												label={
-													<>
-														{t('common.llm-model')}
-														<button
-															type="button"
-															className="ml-1 text-primary underline hover:text-primary/80"
-															onClick={() => openUrl('https://docs.anthropic.com/en/docs/about-claude/models')}>
-															{t('common.find-here')}
-														</button>
-													</>
-												}>
-												<Input
-													value={vm.preference.llmConfig?.model}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, model: e.target.value })}
-													placeholder="claude-sonnet-4-5"
-												/>
-											</Field>
-										</>
-									)}
-
-									{vm.preference.llmConfig?.platform === 'ollama' && (
-										<>
-											<Field label={t('common.ollama-base-url')}>
-												<Input
-													value={vm.preference.llmConfig?.ollamaBaseUrl}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, ollamaBaseUrl: e.target.value })}
-												/>
-											</Field>
-											<Field
-												label={
-													<>
-														{t('common.llm-model')}
-														<button
-															type="button"
-															className="ml-1 text-primary underline hover:text-primary/80"
-															onClick={() => openUrl(`https://ollama.com/library/${vm.preference.llmConfig.model}`)}>
-															{t('common.find-here')}
-														</button>
-													</>
-												}>
-												<Input
-													value={vm.preference.llmConfig?.model}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, model: e.target.value })}
-												/>
-											</Field>
-										</>
-									)}
-
-									{vm.preference.llmConfig?.platform === 'openai' && (
-										<>
-											<Field label="Base URL">
-												<Input
-													value={vm.preference.llmConfig?.openaiBaseUrl}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, openaiBaseUrl: e.target.value })}
-													placeholder="https://api.openai.com/v1"
-												/>
-											</Field>
-											<Field label="API Key">
-												<Input
-													value={vm.preference.llmConfig?.openaiApiKey}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, openaiApiKey: e.target.value })}
-													placeholder="sk-... (optional for local servers)"
-													type="text"
-												/>
-											</Field>
-											<Field label={t('common.llm-model')}>
-												<Input
-													value={vm.preference.llmConfig?.model}
-													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, model: e.target.value })}
-													placeholder="gpt-4o-mini"
-												/>
-											</Field>
-										</>
-									)}
-
-									<Field
-										label={
-											<>
-												<InfoTooltip text={t('common.info-llm-prompt')} />
-												{t('common.llm-prompt')}
-											</>
-										}>
-										<Textarea
-											value={vm.preference.llmConfig?.prompt}
-											onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, prompt: e.target.value })}
-											onBlur={vm.validateLlmPrompt}
-											className="min-h-[100px]"
-										/>
-									</Field>
-
-									<Field
-										label={
-											<>
-												<InfoTooltip text={t('common.info-max-tokens')} />
-												{t('common.max-tokens')}
-											</>
-										}>
-										<Input
-											type="number"
-											onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, maxTokens: vm.parseIntOr(e.target.value, 1) })}
-											value={vm.preference.llmConfig?.maxTokens}
-										/>
-									</Field>
-
-									<Button onClick={vm.checkLlm} size="sm" className="w-full">
-										{t('common.run-llm-check')}
-									</Button>
-
-									{vm.llmError && (
-										<div className="relative rounded-lg border border-destructive/30 bg-destructive/5 p-3 pe-10">
-											<button type="button" className="absolute end-2 top-2 p-1 text-muted-foreground hover:text-foreground" onClick={vm.copyLlmError}>
-												{vm.llmErrorCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-											</button>
-											<pre className="whitespace-pre-wrap break-all text-xs text-destructive">{vm.llmError}</pre>
-										</div>
-									)}
-
-									{vm.preference.llmConfig?.platform === 'claude' && (
-										<div className="flex flex-col gap-2 text-sm">
-											<button type="button" className="text-left text-primary underline hover:text-primary/80" onClick={() => openUrl(config.llmLimitsUrl)}>
-												{t('common.set-monthly-spend-limit')}
-											</button>
-											<button type="button" className="text-left text-primary underline hover:text-primary/80" onClick={() => openUrl(config.llmCostUrl)}>
-												{t('common.llm-current-cost')}
-											</button>
-										</div>
-									)}
-								</div>
-							</div>
-						)}
-
-					{activeSection === 'tuning' && (
-						<div className="space-y-5">
-							<div className="space-y-2">
-								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.speaker-timing')}</span>
-								<SectionCard>
-									<div className="space-y-4">
-										<div className="flex items-center justify-between">
-											<span className="flex items-center gap-1 text-sm font-medium">
-												<InfoTooltip text={t('common.info-diarization')} />
-												{t('common.enable-diarization')}
-											</span>
-											<Switch checked={vm.preference.diarizeEnabled} onCheckedChange={vm.toggleDiarization} />
-										</div>
-										{vm.preference.diarizeEnabled && (
-											<p className="text-sm italic text-muted-foreground">{t('common.diarize-max-speakers-note')}</p>
-										)}
-										<div className="h-px bg-border/45" />
-										<div className="flex items-center justify-between">
-											<span className="flex items-center gap-1 text-sm font-medium">
-												<InfoTooltip text="Uses VAD per-segment decode for tighter subtitle timing. Around 4x slower; best for movie/long-form transcript work." />
-												Enable stable timestamps
-											</span>
-											<Switch checked={vm.preference.stableTimestampsEnabled} onCheckedChange={vm.handleStableTimestampsToggle} />
-										</div>
-									</div>
-								</SectionCard>
-							</div>
-
-							<div className="space-y-2">
-								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.model-options')}</span>
-								<SectionCard>
-									<div className="space-y-4">
-										<div className="flex items-center justify-between">
-											<span className="flex items-center gap-1 text-sm font-medium">
-												<InfoTooltip text={t('common.info-translate-to-english')} />
-												{t('common.translate-to-english')}
-											</span>
-											<Switch
-												checked={Boolean(vm.preference.modelOptions.translate)}
-												onCheckedChange={(checked) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, translate: checked })}
-											/>
-										</div>
-
-										<Field
-											label={
-												<>
-													<InfoTooltip text={t('common.info-prompt')} />
-													{t('common.prompt')} ({t('common.leftover')} {1024 - (vm.preference.modelOptions?.init_prompt?.length ?? 0)}{' '}
-													{t('common.characters')})
-												</>
-											}>
-											<Textarea
-												value={vm.preference.modelOptions?.init_prompt}
-												onChange={(e) =>
-													vm.preference.setModelOptions({ ...vm.preference.modelOptions, init_prompt: e.target.value.slice(0, 1024) })
-												}
-												className="min-h-[80px]"
-											/>
-										</Field>
-
-										<div className="flex items-center justify-between">
-											<span className="flex items-center gap-1 text-sm font-medium">
-												<InfoTooltip text={t('common.info-use-word-timestamps')} />
-												{t('common.use-word-timestamps')}
-											</span>
-											<Switch
-												checked={Boolean(vm.preference.modelOptions.word_timestamps)}
-												onCheckedChange={(checked) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, word_timestamps: checked })}
-											/>
-										</div>
-
-										<div className="grid grid-cols-2 gap-4">
-											<Field
-												label={
-													<>
-														<InfoTooltip text={t('common.info-max-sentence-len')} />
-														{t('common.max-sentence-len')}
-													</>
-												}>
-												<Input
-													type="number"
-													value={vm.preference.modelOptions.max_sentence_len}
-													onChange={(e) => {
-														if (!vm.preference.modelOptions.word_timestamps) message(t('common.please-enable-word-timestamps'))
-														vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_sentence_len: vm.parseIntOr(e.target.value, 1) })
-													}}
-												/>
-											</Field>
-
-											<Field
-												label={
-													<>
-														<InfoTooltip text={t('common.info-threads')} />
-														{t('common.threads')}
-													</>
-												}>
-												<Input
-													type="number"
-													value={vm.preference.modelOptions.n_threads}
-													onChange={(e) =>
-														vm.preference.setModelOptions({ ...vm.preference.modelOptions, n_threads: vm.parseIntOr(e.target.value, 1) })
-													}
-												/>
-											</Field>
-
-											<Field
-												label={
-													<>
-														<InfoTooltip text={t('common.info-temperature')} />
-														{t('common.temperature')}
-													</>
-												}>
-												<Input
-													type="number"
-													step={0.1}
-													value={vm.preference.modelOptions.temperature}
-													onChange={(e) =>
-														vm.preference.setModelOptions({ ...vm.preference.modelOptions, temperature: parseFloat(e.target.value) || 0 })
-													}
-												/>
-											</Field>
-
-											<Field
-												label={
-													<>
-														<InfoTooltip text={t('common.info-max-text-ctx')} />
-														{t('common.max-text-ctx')}
-													</>
-												}>
-												<Input
-													type="number"
-													step={1}
-													value={vm.preference.modelOptions.max_text_ctx ?? 0}
-													onChange={(e) =>
-														vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_text_ctx: vm.parseIntOr(e.target.value, 0) })
-													}
-												/>
-											</Field>
-										</div>
-
-										<div className="grid grid-cols-2 gap-4">
-											<Field
-												label={
-													<>
-														<InfoTooltip text="Greedy vs Beam Search: Default is Beam Search (Size 5, Patience -1), which evaluates 5 possible sequences at each step for more accurate results, but is slower. Greedy, on the other hand, selects the best token from the top 5 at each step, making it faster but potentially less accurate." />
-														{t('common.sampling-strategy')}
-													</>
-												}>
-												<Select
-													value={vm.preference.modelOptions.sampling_strategy}
-													onValueChange={(value) =>
-														vm.preference.setModelOptions({ ...vm.preference.modelOptions, sampling_strategy: value as 'greedy' | 'beam search' })
-													}>
-													<SelectTrigger className="capitalize">
-														<SelectValue />
-													</SelectTrigger>
-													<SelectContent>
-														{['beam search', 'greedy'].map((name) => (
-															<SelectItem key={name} value={name} className="capitalize">
-																{name}
-															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
-											</Field>
-
-											<Field
-												label={
-													<>
-														<InfoTooltip
-															text={
-																vm.preference.modelOptions.sampling_strategy === 'greedy'
-																	? 'Top candidates in Greedy mode (default: 5) — higher = better accuracy, slower.'
-																	: 'Paths explored in Beam Search (default: 5) — higher = better accuracy, slower.'
-															}
-														/>
-														{vm.preference.modelOptions.sampling_strategy === 'greedy' ? 'Best of' : 'Beam size'}
-													</>
-												}>
-												<Input
-													type="number"
-													step={1}
-													value={
-														vm.preference.modelOptions.sampling_strategy === 'greedy'
-															? (vm.preference.modelOptions.best_of ?? 5)
-															: (vm.preference.modelOptions.beam_size ?? 5)
-													}
-													onChange={(e) => {
-														const val = vm.parseIntOr(e.target.value, 5)
-														if (vm.preference.modelOptions.sampling_strategy === 'greedy') {
-															vm.preference.setModelOptions({ ...vm.preference.modelOptions, best_of: val })
-														} else {
-															vm.preference.setModelOptions({ ...vm.preference.modelOptions, beam_size: val })
-														}
-													}}
-												/>
-											</Field>
-										</div>
-									</div>
-								</SectionCard>
-							</div>
-
-							<div className="space-y-2">
-								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.ffmpeg-options')}</span>
-								<SectionCard>
-									<div className="space-y-4">
-										<div className="flex items-center justify-between">
-											<span className="flex items-center gap-1 text-sm font-medium">
-												<InfoTooltip text={t('common.info-normalize-loudness')} />
-												{t('common.normalize-loudness')}
-											</span>
-											<Switch
-												checked={vm.preference.ffmpegOptions.normalize_loudness}
-												onCheckedChange={(checked) =>
-													vm.preference.setFfmpegOptions({ ...vm.preference.ffmpegOptions, normalize_loudness: checked })
-												}
-											/>
-										</div>
-
-										<Field
-											label={
-												<>
-													<InfoTooltip text={'ffmpeg -i {input} -ar 16000 -ac 1 -c:a pcm_s16le {custom_command} -hide_banner -y -loglevel error'} />
-													{t('common.custom-ffmpeg-command')}
-												</>
-											}>
-											<Input
-												value={vm.preference.ffmpegOptions.custom_command ?? ''}
-												onChange={(e) =>
-													vm.preference.setFfmpegOptions({ ...vm.preference.ffmpegOptions, custom_command: e.target.value || null })
-												}
-												placeholder={vm.preference.ffmpegOptions.normalize_loudness ? '-af loudnorm=I=-16:TP=-1.5:LRA=11' : ''}
-												type="text"
-											/>
-										</Field>
-									</div>
-								</SectionCard>
-							</div>
-
-							<div className="space-y-2">
-								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.presets')}</span>
-								<SectionCard>
-									<div className="flex gap-4">
-										<Button variant="secondary" onClick={vm.preference.enableSubtitlesPreset} className="flex-1">
-											{t('common.preset-for-subtitles')}
-										</Button>
-										<Button variant="secondary" onClick={vm.preference.resetOptions} className="flex-1">
-											{t('common.reset-options')}
-										</Button>
-									</div>
-								</SectionCard>
-							</div>
-						</div>
-					)}
-
-					{activeSection === 'dictation' && (
-						<div className="space-y-5">
-							<p className="px-1 text-sm text-muted-foreground">{t('common.global-dictation-promo')}</p>
-							<SectionCard>
-								<div className="space-y-4">
-									<div className="flex items-center justify-between">
-										<span className="text-sm font-medium">{t('common.global-hotkey-enabled')}</span>
-										<Switch checked={hotkey.hotkeyEnabled} onCheckedChange={hotkey.setHotkeyEnabled} />
-									</div>
-
-									{hotkey.hotkeyEnabled && (
-										<>
-											<Field
-												label={
-													<span className="flex items-center gap-2">
-														{t('common.global-hotkey-shortcut')}
-														<span className="flex items-center gap-1">
-															{shortcutKeys.map((key, i) => (
-																<kbd
-																	key={i}
-																	className="inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-border/80 bg-background/70 px-1.5 font-mono text-[11px] font-medium text-foreground/80 shadow-[0_1px_0_1px_rgba(0,0,0,0.04)]">
-																	{key}
-																</kbd>
-															))}
-														</span>
-													</span>
-												}>
-												<Input
-													type="text"
-													value={hotkey.hotkeyShortcut}
-													onChange={(e) => hotkey.setHotkeyShortcut(e.target.value)}
-												/>
-											</Field>
-											<div className="flex gap-2">
-												{(['clipboard', 'type'] as HotkeyOutputMode[]).map((mode) => (
-													<button
-														key={mode}
-														type="button"
-														onClick={() => hotkey.setHotkeyOutputMode(mode)}
-														className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
-															hotkey.hotkeyOutputMode === mode
-																? 'border-primary bg-primary/10 text-primary'
-																: 'border-border/65 bg-background/50 text-muted-foreground hover:bg-accent/40'
-														}`}>
-														{t(`common.hotkey-output-${mode}`)}
-													</button>
-												))}
-											</div>
-											<p className="text-xs italic text-muted-foreground">{t('common.global-hotkey-description')}</p>
-
-											<div className="h-px bg-border/45" />
-
-											<div className="flex items-center justify-between gap-3">
-												<span className="flex items-center gap-1 text-sm font-medium">
-													<InfoTooltip text={t('common.normalize-hotkey-output-info')} />
-													{t('common.normalize-hotkey-output')}
-												</span>
-												<Switch checked={hotkey.hotkeyNormalizeOutput} onCheckedChange={hotkey.setHotkeyNormalizeOutput} />
-											</div>
-										</>
-									)}
-								</div>
-							</SectionCard>
-						</div>
-					)}
-
-					{activeSection === 'api' && (
-						<div className="space-y-5">
-							<p className="px-1 text-sm text-muted-foreground">{t('common.api-agents-description')}</p>
-							<SectionCard>
-								<div className="flex items-center justify-between gap-3">
-									<div className="flex items-center gap-2.5">
-										<span
-											className={`h-2 w-2 rounded-full ${vm.apiBaseUrl ? 'bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]' : 'bg-muted-foreground/40 shadow-[0_0_0_4px_rgba(148,163,184,0.12)]'}`}
-										/>
-										<div>
-											<p className="text-sm font-semibold">{vm.apiBaseUrl ? t('common.api-server-running') : t('common.api-server-off')}</p>
-											{vm.apiBaseUrl && <p className="text-xs text-muted-foreground">{vm.apiBaseUrl}</p>}
-										</div>
-									</div>
-									<Button
-										variant={vm.apiBaseUrl ? 'outline' : 'default'}
-										size="sm"
-										className="rounded-lg"
-										onMouseDown={vm.apiBaseUrl ? vm.stopApiServer : vm.startApiServer}
-										disabled={serverActionBusy}>
-										{vm.isStartingApiServer
-											? t('common.api-starting')
-											: vm.isStoppingApiServer
-												? t('common.api-stopping')
-												: vm.apiBaseUrl
-													? t('common.stop')
-													: t('common.start')}
-									</Button>
-								</div>
-							</SectionCard>
-
-							<div className={`divide-y divide-border/45 rounded-2xl border border-border/60 bg-card/92 shadow-xs ${!vm.apiBaseUrl ? 'pointer-events-none opacity-50' : ''}`}>
-								<Button
-									variant="ghost"
-									onMouseDown={() => (apiDocsUrl ? openUrl(apiDocsUrl) : null)}
-									disabled={!apiDocsUrl}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.swagger-docs')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={vm.copyCurlExample}
-									disabled={!vm.apiBaseUrl}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.copy-curl-example')} <CopyIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={vm.copyAgentSkill}
-									disabled={!vm.apiBaseUrl}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.copy-agent-skill')} <Bot className="h-4 w-4 text-muted-foreground" />
-								</Button>
-							</div>
-						</div>
-					)}
-
-					{activeSection === 'privacy' && (
-						<div className="space-y-5">
-							<SectionCard>
-								<div className="flex flex-wrap items-center justify-between gap-2">
-									<span className="text-sm font-medium">{t('common.analytics-enabled')}</span>
-									<Switch checked={vm.preference.analyticsEnabled} onCheckedChange={vm.preference.setAnalyticsEnabled} />
-								</div>
-								{!vm.preference.analyticsEnabled && (
-									<p className="mt-2 text-xs italic text-muted-foreground">{t('common.analytics-disabled-warning')}</p>
-								)}
-							</SectionCard>
-							<Button
-								variant="ghost"
-								onMouseDown={() => openUrl(config.privacyPolicyURL)}
-								className="h-11 w-full justify-between rounded-xl border border-border/55 bg-card/92 px-4 font-medium hover:bg-accent/55">
-								{t('common.privacy-policy')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
-							</Button>
-						</div>
-					)}
-
-					{activeSection === 'advanced' && (
-						<div className="space-y-5">
-							<div className="divide-y divide-border/45 rounded-2xl border border-border/60 bg-card/92 shadow-xs">
-								<Button
-									variant="ghost"
-									onMouseDown={vm.copyLogs}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.copy-logs')} <CopyIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={vm.revealLogs}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.logs-folder')} <FolderIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onMouseDown={vm.revealTemp}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
-									{t('common.temp-folder')} <FolderIcon className="h-4 w-4 text-muted-foreground" />
-								</Button>
-								<Button
-									variant="ghost"
-									onClick={vm.askAndReset}
-									className="h-12 w-full justify-between rounded-none px-4 font-medium text-destructive first:rounded-t-2xl last:rounded-b-2xl hover:bg-destructive/12 hover:text-destructive">
-									{t('common.reset-app')} <ResetIcon className="h-5 w-5" />
-								</Button>
-							</div>
-						</div>
-					)}
 				</div>
 			</div>
 		</div>

--- a/desktop/src/pages/settings/sections/advanced.tsx
+++ b/desktop/src/pages/settings/sections/advanced.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next'
+import { InfoTooltip } from '~/components/info-tooltip'
+import { Button } from '~/components/ui/button'
+import { Switch } from '~/components/ui/switch'
+import { ReactComponent as CopyIcon } from '~/icons/copy.svg'
+import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
+import { ReactComponent as ResetIcon } from '~/icons/reset.svg'
+import { SectionCard, type SettingsViewModel } from './shared'
+
+export function AdvancedSection({ vm }: { vm: SettingsViewModel }) {
+	const { t } = useTranslation()
+	return (
+		<div className="space-y-5">
+			<div className="space-y-2">
+				<div className="flex items-center gap-1 px-1">
+					<InfoTooltip text={t('common.ytdlp-options-info')} />
+					<span className="text-sm font-semibold text-foreground/95">{t('common.ytdlp-options')}</span>
+				</div>
+				<SectionCard>
+					<div className="flex flex-wrap items-center justify-between gap-2">
+						<span className="text-sm font-medium">{t('common.check-ytdlp-updates')}</span>
+						<Switch checked={vm.preference.shouldCheckYtDlpVersion} onCheckedChange={vm.preference.setShouldCheckYtDlpVersion} />
+					</div>
+				</SectionCard>
+			</div>
+			<div className="divide-y divide-border/45 rounded-2xl border border-border/60 bg-card/92 shadow-xs">
+				<Button variant="ghost" onMouseDown={vm.copyLogs} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">{t('common.copy-logs')} <CopyIcon className="h-4 w-4 text-muted-foreground" /></Button>
+				<Button variant="ghost" onMouseDown={vm.revealLogs} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">{t('common.logs-folder')} <FolderIcon className="h-4 w-4 text-muted-foreground" /></Button>
+				<Button variant="ghost" onMouseDown={vm.revealTemp} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">{t('common.temp-folder')} <FolderIcon className="h-4 w-4 text-muted-foreground" /></Button>
+				<Button variant="ghost" onClick={vm.askAndReset} className="h-12 w-full justify-between rounded-none px-4 font-medium text-destructive first:rounded-t-2xl last:rounded-b-2xl hover:bg-destructive/12 hover:text-destructive">{t('common.reset-app')} <ResetIcon className="h-5 w-5" /></Button>
+			</div>
+		</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/api.tsx
+++ b/desktop/src/pages/settings/sections/api.tsx
@@ -1,0 +1,69 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { Bot } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { ReactComponent as CopyIcon } from '~/icons/copy.svg'
+import { ReactComponent as LinkIcon } from '~/icons/link.svg'
+import { Button } from '~/components/ui/button'
+import { SectionCard, type SettingsViewModel } from './shared'
+
+export function ApiSection({ vm }: { vm: SettingsViewModel }) {
+	const { t } = useTranslation()
+	const apiDocsUrl = vm.apiBaseUrl ? `${vm.apiBaseUrl}/docs` : null
+	const serverActionBusy = vm.isStartingApiServer || vm.isStoppingApiServer
+	return (
+<div className="space-y-5">
+							<p className="px-1 text-sm text-muted-foreground">{t('common.api-agents-description')}</p>
+							<SectionCard>
+								<div className="flex items-center justify-between gap-3">
+									<div className="flex items-center gap-2.5">
+										<span
+											className={`h-2 w-2 rounded-full ${vm.apiBaseUrl ? 'bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]' : 'bg-muted-foreground/40 shadow-[0_0_0_4px_rgba(148,163,184,0.12)]'}`}
+										/>
+										<div>
+											<p className="text-sm font-semibold">{vm.apiBaseUrl ? t('common.api-server-running') : t('common.api-server-off')}</p>
+											{vm.apiBaseUrl && <p className="text-xs text-muted-foreground">{vm.apiBaseUrl}</p>}
+										</div>
+									</div>
+									<Button
+										variant={vm.apiBaseUrl ? 'outline' : 'default'}
+										size="sm"
+										className="rounded-lg"
+										onMouseDown={vm.apiBaseUrl ? vm.stopApiServer : vm.startApiServer}
+										disabled={serverActionBusy}>
+										{vm.isStartingApiServer
+											? t('common.api-starting')
+											: vm.isStoppingApiServer
+												? t('common.api-stopping')
+												: vm.apiBaseUrl
+													? t('common.stop')
+													: t('common.start')}
+									</Button>
+								</div>
+							</SectionCard>
+
+							<div className={`divide-y divide-border/45 rounded-2xl border border-border/60 bg-card/92 shadow-xs ${!vm.apiBaseUrl ? 'pointer-events-none opacity-50' : ''}`}>
+								<Button
+									variant="ghost"
+									onMouseDown={() => (apiDocsUrl ? openUrl(apiDocsUrl) : null)}
+									disabled={!apiDocsUrl}
+									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+									{t('common.swagger-docs')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
+								</Button>
+								<Button
+									variant="ghost"
+									onMouseDown={vm.copyCurlExample}
+									disabled={!vm.apiBaseUrl}
+									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+									{t('common.copy-curl-example')} <CopyIcon className="h-4 w-4 text-muted-foreground" />
+								</Button>
+								<Button
+									variant="ghost"
+									onMouseDown={vm.copyAgentSkill}
+									disabled={!vm.apiBaseUrl}
+									className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+									{t('common.copy-agent-skill')} <Bot className="h-4 w-4 text-muted-foreground" />
+								</Button>
+							</div>
+						</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/dictation.tsx
+++ b/desktop/src/pages/settings/sections/dictation.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { InfoTooltip } from '~/components/info-tooltip'
+import { Input } from '~/components/ui/input'
+import { Switch } from '~/components/ui/switch'
+import { useHotkeyProvider, type HotkeyOutputMode } from '~/providers/hotkey'
+import { Field, SectionCard } from './shared'
+
+export function DictationSection() {
+	const { t } = useTranslation()
+	const hotkey = useHotkeyProvider()
+	const isMac = navigator.platform.toUpperCase().includes('MAC')
+	const shortcutKeys = useMemo(() => {
+		const keyMap: Record<string, string> = { CmdOrCtrl: isMac ? '⌘' : 'Ctrl', Cmd: '⌘', Ctrl: isMac ? '⌃' : 'Ctrl', Shift: isMac ? '⇧' : 'Shift', Alt: isMac ? '⌥' : 'Alt', Option: '⌥' }
+		return hotkey.hotkeyShortcut.split('+').map((key) => keyMap[key] ?? key)
+	}, [hotkey.hotkeyShortcut, isMac])
+	return (
+<div className="space-y-5">
+							<p className="px-1 text-sm text-muted-foreground">{t('common.global-dictation-promo')}</p>
+							<SectionCard>
+								<div className="space-y-4">
+									<div className="flex items-center justify-between">
+										<span className="text-sm font-medium">{t('common.global-hotkey-enabled')}</span>
+										<Switch checked={hotkey.hotkeyEnabled} onCheckedChange={hotkey.setHotkeyEnabled} />
+									</div>
+
+									{hotkey.hotkeyEnabled && (
+										<>
+											<Field
+												label={
+													<span className="flex items-center gap-2">
+														{t('common.global-hotkey-shortcut')}
+														<span className="flex items-center gap-1">
+															{shortcutKeys.map((key, i) => (
+																<kbd
+																	key={i}
+																	className="inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-border/80 bg-background/70 px-1.5 font-mono text-[11px] font-medium text-foreground/80 shadow-[0_1px_0_1px_rgba(0,0,0,0.04)]">
+																	{key}
+																</kbd>
+															))}
+														</span>
+													</span>
+												}>
+												<Input
+													type="text"
+													value={hotkey.hotkeyShortcut}
+													onChange={(e) => hotkey.setHotkeyShortcut(e.target.value)}
+												/>
+											</Field>
+											<div className="flex gap-2">
+												{(['clipboard', 'type'] as HotkeyOutputMode[]).map((mode) => (
+													<button
+														key={mode}
+														type="button"
+														onClick={() => hotkey.setHotkeyOutputMode(mode)}
+														className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+															hotkey.hotkeyOutputMode === mode
+																? 'border-primary bg-primary/10 text-primary'
+																: 'border-border/65 bg-background/50 text-muted-foreground hover:bg-accent/40'
+														}`}>
+														{t(`common.hotkey-output-${mode}`)}
+													</button>
+												))}
+											</div>
+											<p className="text-xs italic text-muted-foreground">{t('common.global-hotkey-description')}</p>
+
+											<div className="h-px bg-border/45" />
+
+											<div className="flex items-center justify-between gap-3">
+												<span className="flex items-center gap-1 text-sm font-medium">
+													<InfoTooltip text={t('common.normalize-hotkey-output-info')} />
+													{t('common.normalize-hotkey-output')}
+												</span>
+												<Switch checked={hotkey.hotkeyNormalizeOutput} onCheckedChange={hotkey.setHotkeyNormalizeOutput} />
+											</div>
+										</>
+									)}
+								</div>
+							</SectionCard>
+						</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/general.tsx
+++ b/desktop/src/pages/settings/sections/general.tsx
@@ -1,0 +1,64 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { useTranslation } from 'react-i18next'
+import { ReactComponent as DiscordIcon } from '~/icons/discord.svg'
+import { ReactComponent as GithubIcon } from '~/icons/github.svg'
+import { ReactComponent as HeartIcon } from '~/icons/heart.svg'
+import { ReactComponent as LinkIcon } from '~/icons/link.svg'
+import * as config from '~/lib/config'
+import { supportedLanguages } from '~/lib/i18n'
+import { Button } from '~/components/ui/button'
+import { Label } from '~/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { SectionCard, type SettingsViewModel } from './shared'
+
+export function GeneralSection({ vm }: { vm: SettingsViewModel }) {
+	const { t, i18n } = useTranslation()
+
+	return (
+		<div className="space-y-5">
+			<SectionCard>
+				<div className="grid grid-cols-1 divide-y divide-border/45 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
+					<div className="space-y-2 sm:pe-5">
+						<Label>{t('common.language')}</Label>
+						<Select
+							value={supportedLanguages[vm.preference.displayLanguage] ? vm.preference.displayLanguage : 'en-US'}
+							onValueChange={vm.preference.setDisplayLanguage}>
+							<SelectTrigger className="capitalize"><SelectValue placeholder={t('common.select-language')} /></SelectTrigger>
+							<SelectContent>
+								{Object.entries(supportedLanguages).map(([code, name]) => (
+									<SelectItem key={code} value={code} className="capitalize">
+										{code === i18n.language ? t(`language.${name}`) : name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="space-y-2 pt-4 sm:ps-5 sm:pt-0">
+						<Label>{t('common.theme')}</Label>
+						<Select value={vm.preference.theme} onValueChange={(value) => vm.preference.setTheme(value as 'light' | 'dark')}>
+							<SelectTrigger className="capitalize"><SelectValue placeholder={t('common.select-theme')} /></SelectTrigger>
+							<SelectContent>
+								{config.themes.map((theme) => <SelectItem key={theme} value={theme} className="capitalize">{t(`common.${theme}`)}</SelectItem>)}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+			</SectionCard>
+
+			<div className="divide-y divide-border/45 rounded-2xl border border-border/60 bg-card/92 shadow-xs">
+				<Button variant="ghost" onMouseDown={() => openUrl(config.aboutURL)} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+					{t('common.project-link')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
+				</Button>
+				<Button variant="ghost" onMouseDown={vm.reportIssue} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+					{t('common.report-issue')} <GithubIcon className="h-4 w-4 text-muted-foreground" />
+				</Button>
+				<Button variant="ghost" onMouseDown={() => openUrl(config.supportVibeURL)} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+					{t('common.support-the-project')} <HeartIcon className="h-4 w-4 fill-red-500 text-red-500 dark:fill-red-400 dark:text-red-400" />
+				</Button>
+				<Button variant="ghost" onMouseDown={() => openUrl(config.discordURL)} className="h-12 w-full justify-between rounded-none px-4 font-medium first:rounded-t-2xl last:rounded-b-2xl hover:bg-accent/55">
+					{t('common.discord-community')} <DiscordIcon className="h-4 w-4 text-muted-foreground" />
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/models.tsx
+++ b/desktop/src/pages/settings/sections/models.tsx
@@ -1,0 +1,125 @@
+import { useTranslation } from 'react-i18next'
+import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
+import { ReactComponent as LinkIcon } from '~/icons/link.svg'
+import { ReactComponent as WrenchIcon } from '~/icons/wrench.svg'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Label } from '~/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { SectionCard, type SettingsViewModel } from './shared'
+
+export function ModelsSection({ vm }: { vm: SettingsViewModel }) {
+	const { t } = useTranslation()
+	return (
+<div className="space-y-5">
+							<SectionCard>
+								<div className="space-y-5">
+									<div className="space-y-2">
+										<Label>{t('common.download-model')}</Label>
+										<div className="flex items-center gap-2">
+											<Input
+												type="text"
+												value={vm.downloadURL}
+												onChange={(event) => vm.setDownloadURL(event.target.value)}
+												placeholder={t('common.paste-model-link')}
+												onKeyDown={(event) => (event.key === 'Enter' ? vm.downloadModel() : null)}
+											/>
+											<Button variant="default" size="icon" onClick={vm.downloadModel} className="shrink-0">
+												<svg
+													aria-hidden="true"
+													focusable="false"
+													role="img"
+													className="octicon octicon-download"
+													viewBox="0 0 16 16"
+													width="16"
+													height="16"
+													fill="currentColor">
+													<path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"></path>
+													<path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"></path>
+												</svg>
+											</Button>
+										</div>
+									</div>
+
+									<div className="space-y-2">
+										<Label>{t('common.select-model')}</Label>
+										<Select
+											value={vm.preference.modelPath ?? undefined}
+											onValueChange={(value) => vm.preference.setModelPath(value)}
+											onOpenChange={(open) => {
+												if (open) vm.loadModels()
+											}}>
+											<SelectTrigger>
+												<SelectValue placeholder={t('common.select-model')} />
+											</SelectTrigger>
+											<SelectContent>
+												{vm.models.map((model, index) => (
+													<SelectItem key={index} value={model.path}>
+														{model.name}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</div>
+
+									{!vm.isMacOS && (
+										<div className="space-y-2">
+											<Label>{t('common.gpu-device')}</Label>
+											{vm.gpuDevices.length > 0 ? (
+												<Select
+													value={vm.preference.gpuDevice != null ? String(vm.preference.gpuDevice) : 'auto'}
+													onValueChange={(value) => {
+														vm.preference.setGpuDevice(value === 'auto' ? null : parseInt(value, 10))
+													}}>
+													<SelectTrigger>
+														<SelectValue placeholder={t('common.gpu-device')} />
+													</SelectTrigger>
+													<SelectContent>
+														<SelectItem value="auto">Auto</SelectItem>
+														{vm.gpuDevices.map((device) => (
+															<SelectItem key={device.index} value={String(device.index)}>
+																{device.description}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											) : (
+												<Input
+													type="number"
+													value={vm.preference.gpuDevice ?? ''}
+													onChange={(e) => {
+														const val = e.target.value
+														vm.preference.setGpuDevice(val === '' ? null : parseInt(val, 10))
+													}}
+													placeholder={t('common.gpu-device-placeholder')}
+												/>
+											)}
+										</div>
+									)}
+
+									<div className="space-y-1 pt-1">
+										<Button
+											variant="ghost"
+											onMouseDown={vm.openModelsUrl}
+											className="h-11 w-full justify-between rounded-lg px-3 font-medium hover:bg-accent/60">
+											{t('common.download-models-link')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
+										</Button>
+										<Button
+											variant="ghost"
+											onMouseDown={vm.openModelPath}
+											className="h-11 w-full justify-between rounded-lg px-3 font-medium hover:bg-accent/60">
+											{t('common.models-folder')} <FolderIcon className="h-4 w-4 text-muted-foreground" />
+										</Button>
+										<Button
+											variant="ghost"
+											onMouseDown={vm.changeModelsFolder}
+											className="h-11 w-full justify-between rounded-lg px-3 font-medium hover:bg-accent/60">
+											{t('common.change-models-folder')} <WrenchIcon className="h-4 w-4 text-muted-foreground" />
+										</Button>
+									</div>
+								</div>
+							</SectionCard>
+
+						</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/privacy.tsx
+++ b/desktop/src/pages/settings/sections/privacy.tsx
@@ -1,0 +1,25 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { useTranslation } from 'react-i18next'
+import { ReactComponent as LinkIcon } from '~/icons/link.svg'
+import * as config from '~/lib/config'
+import { Button } from '~/components/ui/button'
+import { Switch } from '~/components/ui/switch'
+import { SectionCard, type SettingsViewModel } from './shared'
+
+export function PrivacySection({ vm }: { vm: SettingsViewModel }) {
+	const { t } = useTranslation()
+	return (
+		<div className="space-y-5">
+			<SectionCard>
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<span className="text-sm font-medium">{t('common.analytics-enabled')}</span>
+					<Switch checked={vm.preference.analyticsEnabled} onCheckedChange={vm.preference.setAnalyticsEnabled} />
+				</div>
+				{!vm.preference.analyticsEnabled && <p className="mt-2 text-xs italic text-muted-foreground">{t('common.analytics-disabled-warning')}</p>}
+			</SectionCard>
+			<Button variant="ghost" onMouseDown={() => openUrl(config.privacyPolicyURL)} className="h-11 w-full justify-between rounded-xl border border-border/55 bg-card/92 px-4 font-medium hover:bg-accent/55">
+				{t('common.privacy-policy')} <LinkIcon className="h-4 w-4 text-muted-foreground" />
+			</Button>
+		</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/shared.tsx
+++ b/desktop/src/pages/settings/sections/shared.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+import { Label } from '~/components/ui/label'
+import type { viewModel } from '../view-model'
+
+export type SettingsViewModel = ReturnType<typeof viewModel>
+
+export function SectionCard({ children }: { children: ReactNode }) {
+	return <div className="rounded-2xl border border-border/60 bg-card/92 p-5 text-card-foreground shadow-xs">{children}</div>
+}
+
+export function Field({ label, children }: { label: ReactNode; children: ReactNode }) {
+	return (
+		<div className="w-full space-y-2">
+			<Label className="flex items-center gap-1">{label}</Label>
+			{children}
+		</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/summarize.tsx
+++ b/desktop/src/pages/settings/sections/summarize.tsx
@@ -1,0 +1,209 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { Check, Copy } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import * as config from '~/lib/config'
+import { defaultClaudeConfig, defaultOllamaConfig, defaultOpenAIConfig } from '~/lib/llm'
+import { InfoTooltip } from '~/components/info-tooltip'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Switch } from '~/components/ui/switch'
+import { Textarea } from '~/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { Field, type SettingsViewModel } from './shared'
+
+export function SummarizeSection({ vm }: { vm: SettingsViewModel }) {
+	const { t, i18n } = useTranslation()
+	return (
+<div className="space-y-5">
+							<div className="space-y-4">
+								<div className="flex items-center justify-between">
+									<div className="flex items-center gap-2">
+										<h3 className="text-sm font-semibold">{t('common.process-with-llm')} ✨</h3>
+										<InfoTooltip text={t('common.info-llm-summarize')} />
+									</div>
+									<Switch checked={vm.preference.llmConfig?.enabled} onCheckedChange={vm.onEnableLlm} />
+									</div>
+
+									<Field label={t('common.llm-platform')}>
+										<Select
+											value={vm.preference.llmConfig?.platform}
+											onValueChange={(value) => {
+												const lang = new Intl.DisplayNames([i18n.language], { type: 'language' }).of(i18n.language) ?? 'English'
+												const defaults =
+													value === 'ollama' ? defaultOllamaConfig(lang) : value === 'openai' ? defaultOpenAIConfig(lang) : defaultClaudeConfig(lang)
+												vm.preference.setLlmConfig({
+													...defaults,
+													ollamaBaseUrl: vm.preference.llmConfig.ollamaBaseUrl,
+													claudeApiKey: vm.preference.llmConfig.claudeApiKey,
+													openaiBaseUrl: vm.preference.llmConfig.openaiBaseUrl,
+													openaiApiKey: vm.preference.llmConfig.openaiApiKey,
+													enabled: vm.preference.llmConfig?.enabled ?? false,
+												})
+											}}>
+											<SelectTrigger className="capitalize">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{['claude', 'ollama', 'openai'].map((name) => (
+													<SelectItem key={name} value={name} className="capitalize">
+														{name === 'openai' ? 'OpenAI Compatible' : name}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</Field>
+
+									{vm.preference.llmConfig?.platform === 'claude' && (
+										<>
+											<Field
+												label={
+													<>
+														<InfoTooltip text={t('common.info-llm-api-key')} />
+														{t('common.llm-api-key')}
+														<button
+															type="button"
+															className="ml-1 text-primary underline hover:text-primary/80"
+															onClick={() => openUrl(config.llmApiKeyUrl)}>
+															{t('common.find-here')}
+														</button>
+													</>
+												}>
+												<Input
+													value={vm.preference.llmConfig?.claudeApiKey}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, claudeApiKey: e.target.value })}
+													placeholder="Paste here your API key"
+													type="text"
+												/>
+											</Field>
+											<Field
+												label={
+													<>
+														{t('common.llm-model')}
+														<button
+															type="button"
+															className="ml-1 text-primary underline hover:text-primary/80"
+															onClick={() => openUrl('https://docs.anthropic.com/en/docs/about-claude/models')}>
+															{t('common.find-here')}
+														</button>
+													</>
+												}>
+												<Input
+													value={vm.preference.llmConfig?.model}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, model: e.target.value })}
+													placeholder="claude-sonnet-4-5"
+												/>
+											</Field>
+										</>
+									)}
+
+									{vm.preference.llmConfig?.platform === 'ollama' && (
+										<>
+											<Field label={t('common.ollama-base-url')}>
+												<Input
+													value={vm.preference.llmConfig?.ollamaBaseUrl}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, ollamaBaseUrl: e.target.value })}
+												/>
+											</Field>
+											<Field
+												label={
+													<>
+														{t('common.llm-model')}
+														<button
+															type="button"
+															className="ml-1 text-primary underline hover:text-primary/80"
+															onClick={() => openUrl(`https://ollama.com/library/${vm.preference.llmConfig.model}`)}>
+															{t('common.find-here')}
+														</button>
+													</>
+												}>
+												<Input
+													value={vm.preference.llmConfig?.model}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, model: e.target.value })}
+												/>
+											</Field>
+										</>
+									)}
+
+									{vm.preference.llmConfig?.platform === 'openai' && (
+										<>
+											<Field label="Base URL">
+												<Input
+													value={vm.preference.llmConfig?.openaiBaseUrl}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, openaiBaseUrl: e.target.value })}
+													placeholder="https://api.openai.com/v1"
+												/>
+											</Field>
+											<Field label="API Key">
+												<Input
+													value={vm.preference.llmConfig?.openaiApiKey}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, openaiApiKey: e.target.value })}
+													placeholder="sk-... (optional for local servers)"
+													type="text"
+												/>
+											</Field>
+											<Field label={t('common.llm-model')}>
+												<Input
+													value={vm.preference.llmConfig?.model}
+													onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, model: e.target.value })}
+													placeholder="gpt-4o-mini"
+												/>
+											</Field>
+										</>
+									)}
+
+									<Field
+										label={
+											<>
+												<InfoTooltip text={t('common.info-llm-prompt')} />
+												{t('common.llm-prompt')}
+											</>
+										}>
+										<Textarea
+											value={vm.preference.llmConfig?.prompt}
+											onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, prompt: e.target.value })}
+											onBlur={vm.validateLlmPrompt}
+											className="min-h-[100px]"
+										/>
+									</Field>
+
+									<Field
+										label={
+											<>
+												<InfoTooltip text={t('common.info-max-tokens')} />
+												{t('common.max-tokens')}
+											</>
+										}>
+										<Input
+											type="number"
+											onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, maxTokens: vm.parseIntOr(e.target.value, 1) })}
+											value={vm.preference.llmConfig?.maxTokens}
+										/>
+									</Field>
+
+									<Button onClick={vm.checkLlm} size="sm" className="w-full">
+										{t('common.run-llm-check')}
+									</Button>
+
+									{vm.llmError && (
+										<div className="relative rounded-lg border border-destructive/30 bg-destructive/5 p-3 pe-10">
+											<button type="button" className="absolute end-2 top-2 p-1 text-muted-foreground hover:text-foreground" onClick={vm.copyLlmError}>
+												{vm.llmErrorCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+											</button>
+											<pre className="whitespace-pre-wrap break-all text-xs text-destructive">{vm.llmError}</pre>
+										</div>
+									)}
+
+									{vm.preference.llmConfig?.platform === 'claude' && (
+										<div className="flex flex-col gap-2 text-sm">
+											<button type="button" className="text-left text-primary underline hover:text-primary/80" onClick={() => openUrl(config.llmLimitsUrl)}>
+												{t('common.set-monthly-spend-limit')}
+											</button>
+											<button type="button" className="text-left text-primary underline hover:text-primary/80" onClick={() => openUrl(config.llmCostUrl)}>
+												{t('common.llm-current-cost')}
+											</button>
+										</div>
+									)}
+								</div>
+							</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/transcription.tsx
+++ b/desktop/src/pages/settings/sections/transcription.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next'
+import LanguageInput from '~/components/language-input'
+import { InfoTooltip } from '~/components/info-tooltip'
+import { Button } from '~/components/ui/button'
+import { Switch } from '~/components/ui/switch'
+import { SectionCard, type SettingsViewModel } from './shared'
+
+export function TranscriptionSection({ vm }: { vm: SettingsViewModel }) {
+	const { t } = useTranslation()
+
+	return (
+		<div className="space-y-5">
+			<SectionCard><LanguageInput /></SectionCard>
+			<SectionCard>
+				<div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/45 py-2">
+					<span className="text-sm font-medium">{t('common.play-sound-on-finish')}</span>
+					<Switch checked={vm.preference.soundOnFinish} onCheckedChange={vm.preference.setSoundOnFinish} />
+				</div>
+				<div className="flex flex-wrap items-center justify-between gap-2 pb-1 pt-4">
+					<span className="text-sm font-medium">{t('common.focus-window-on-finish')}</span>
+					<Switch checked={vm.preference.focusOnFinish} onCheckedChange={vm.preference.setFocusOnFinish} />
+				</div>
+			</SectionCard>
+			<div className="space-y-2">
+				<div className="flex items-center gap-1 px-1">
+					<InfoTooltip text={t('common.recording-save-path-info')} />
+					<span className="text-sm font-semibold text-foreground/95">{t('common.recording-save-path')}</span>
+				</div>
+				<SectionCard>
+					<div className="flex items-center justify-between gap-2">
+						<p className="min-w-0 truncate text-sm text-muted-foreground" title={vm.preference.customRecordingPath ?? vm.defaultRecordingPath}>
+							{vm.preference.customRecordingPath ?? vm.defaultRecordingPath}
+						</p>
+						<div className="flex shrink-0 items-center gap-2">
+							{vm.preference.customRecordingPath && <Button variant="ghost" size="sm" onMouseDown={vm.resetRecordingPath}>{t('common.reset-to-default')}</Button>}
+							<Button variant="outline" size="sm" onMouseDown={vm.changeRecordingPath}>{t('common.change-recording-path')}</Button>
+						</div>
+					</div>
+				</SectionCard>
+			</div>
+		</div>
+	)
+}

--- a/desktop/src/pages/settings/sections/tuning.tsx
+++ b/desktop/src/pages/settings/sections/tuning.tsx
@@ -1,0 +1,267 @@
+import { message } from '@tauri-apps/plugin-dialog'
+import { useTranslation } from 'react-i18next'
+import { InfoTooltip } from '~/components/info-tooltip'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Switch } from '~/components/ui/switch'
+import { Textarea } from '~/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { Field, SectionCard, type SettingsViewModel } from './shared'
+
+export function TuningSection({ vm }: { vm: SettingsViewModel }) {
+	const { t } = useTranslation()
+	return (
+<div className="space-y-5">
+							<div className="space-y-2">
+								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.speaker-timing')}</span>
+								<SectionCard>
+									<div className="space-y-4">
+										<div className="flex items-center justify-between">
+											<span className="flex items-center gap-1 text-sm font-medium">
+												<InfoTooltip text={t('common.info-diarization')} />
+												{t('common.enable-diarization')}
+											</span>
+											<Switch checked={vm.preference.diarizeEnabled} onCheckedChange={vm.toggleDiarization} />
+										</div>
+										{vm.preference.diarizeEnabled && (
+											<p className="text-sm italic text-muted-foreground">{t('common.diarize-max-speakers-note')}</p>
+										)}
+										<div className="h-px bg-border/45" />
+										<div className="flex items-center justify-between">
+											<span className="flex items-center gap-1 text-sm font-medium">
+												<InfoTooltip text="Uses VAD per-segment decode for tighter subtitle timing. Around 4x slower; best for movie/long-form transcript work." />
+												Enable stable timestamps
+											</span>
+											<Switch checked={vm.preference.stableTimestampsEnabled} onCheckedChange={vm.handleStableTimestampsToggle} />
+										</div>
+									</div>
+								</SectionCard>
+							</div>
+
+							<div className="space-y-2">
+								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.model-options')}</span>
+								<SectionCard>
+									<div className="space-y-4">
+										<div className="flex items-center justify-between">
+											<span className="flex items-center gap-1 text-sm font-medium">
+												<InfoTooltip text={t('common.info-translate-to-english')} />
+												{t('common.translate-to-english')}
+											</span>
+											<Switch
+												checked={Boolean(vm.preference.modelOptions.translate)}
+												onCheckedChange={(checked) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, translate: checked })}
+											/>
+										</div>
+
+										<Field
+											label={
+												<>
+													<InfoTooltip text={t('common.info-prompt')} />
+													{t('common.prompt')} ({t('common.leftover')} {1024 - (vm.preference.modelOptions?.init_prompt?.length ?? 0)}{' '}
+													{t('common.characters')})
+												</>
+											}>
+											<Textarea
+												value={vm.preference.modelOptions?.init_prompt}
+												onChange={(e) =>
+													vm.preference.setModelOptions({ ...vm.preference.modelOptions, init_prompt: e.target.value.slice(0, 1024) })
+												}
+												className="min-h-[80px]"
+											/>
+										</Field>
+
+										<div className="flex items-center justify-between">
+											<span className="flex items-center gap-1 text-sm font-medium">
+												<InfoTooltip text={t('common.info-use-word-timestamps')} />
+												{t('common.use-word-timestamps')}
+											</span>
+											<Switch
+												checked={Boolean(vm.preference.modelOptions.word_timestamps)}
+												onCheckedChange={(checked) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, word_timestamps: checked })}
+											/>
+										</div>
+
+										<div className="grid grid-cols-2 gap-4">
+											<Field
+												label={
+													<>
+														<InfoTooltip text={t('common.info-max-sentence-len')} />
+														{t('common.max-sentence-len')}
+													</>
+												}>
+												<Input
+													type="number"
+													value={vm.preference.modelOptions.max_sentence_len}
+													onChange={(e) => {
+														if (!vm.preference.modelOptions.word_timestamps) message(t('common.please-enable-word-timestamps'))
+														vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_sentence_len: vm.parseIntOr(e.target.value, 1) })
+													}}
+												/>
+											</Field>
+
+											<Field
+												label={
+													<>
+														<InfoTooltip text={t('common.info-threads')} />
+														{t('common.threads')}
+													</>
+												}>
+												<Input
+													type="number"
+													value={vm.preference.modelOptions.n_threads}
+													onChange={(e) =>
+														vm.preference.setModelOptions({ ...vm.preference.modelOptions, n_threads: vm.parseIntOr(e.target.value, 1) })
+													}
+												/>
+											</Field>
+
+											<Field
+												label={
+													<>
+														<InfoTooltip text={t('common.info-temperature')} />
+														{t('common.temperature')}
+													</>
+												}>
+												<Input
+													type="number"
+													step={0.1}
+													value={vm.preference.modelOptions.temperature}
+													onChange={(e) =>
+														vm.preference.setModelOptions({ ...vm.preference.modelOptions, temperature: parseFloat(e.target.value) || 0 })
+													}
+												/>
+											</Field>
+
+											<Field
+												label={
+													<>
+														<InfoTooltip text={t('common.info-max-text-ctx')} />
+														{t('common.max-text-ctx')}
+													</>
+												}>
+												<Input
+													type="number"
+													step={1}
+													value={vm.preference.modelOptions.max_text_ctx ?? 0}
+													onChange={(e) =>
+														vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_text_ctx: vm.parseIntOr(e.target.value, 0) })
+													}
+												/>
+											</Field>
+										</div>
+
+										<div className="grid grid-cols-2 gap-4">
+											<Field
+												label={
+													<>
+														<InfoTooltip text="Greedy vs Beam Search: Default is Beam Search (Size 5, Patience -1), which evaluates 5 possible sequences at each step for more accurate results, but is slower. Greedy, on the other hand, selects the best token from the top 5 at each step, making it faster but potentially less accurate." />
+														{t('common.sampling-strategy')}
+													</>
+												}>
+												<Select
+													value={vm.preference.modelOptions.sampling_strategy}
+													onValueChange={(value) =>
+														vm.preference.setModelOptions({ ...vm.preference.modelOptions, sampling_strategy: value as 'greedy' | 'beam search' })
+													}>
+													<SelectTrigger className="capitalize">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{['beam search', 'greedy'].map((name) => (
+															<SelectItem key={name} value={name} className="capitalize">
+																{name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</Field>
+
+											<Field
+												label={
+													<>
+														<InfoTooltip
+															text={
+																vm.preference.modelOptions.sampling_strategy === 'greedy'
+																	? 'Top candidates in Greedy mode (default: 5) — higher = better accuracy, slower.'
+																	: 'Paths explored in Beam Search (default: 5) — higher = better accuracy, slower.'
+															}
+														/>
+														{vm.preference.modelOptions.sampling_strategy === 'greedy' ? 'Best of' : 'Beam size'}
+													</>
+												}>
+												<Input
+													type="number"
+													step={1}
+													value={
+														vm.preference.modelOptions.sampling_strategy === 'greedy'
+															? (vm.preference.modelOptions.best_of ?? 5)
+															: (vm.preference.modelOptions.beam_size ?? 5)
+													}
+													onChange={(e) => {
+														const val = vm.parseIntOr(e.target.value, 5)
+														if (vm.preference.modelOptions.sampling_strategy === 'greedy') {
+															vm.preference.setModelOptions({ ...vm.preference.modelOptions, best_of: val })
+														} else {
+															vm.preference.setModelOptions({ ...vm.preference.modelOptions, beam_size: val })
+														}
+													}}
+												/>
+											</Field>
+										</div>
+									</div>
+								</SectionCard>
+							</div>
+
+							<div className="space-y-2">
+								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.ffmpeg-options')}</span>
+								<SectionCard>
+									<div className="space-y-4">
+										<div className="flex items-center justify-between">
+											<span className="flex items-center gap-1 text-sm font-medium">
+												<InfoTooltip text={t('common.info-normalize-loudness')} />
+												{t('common.normalize-loudness')}
+											</span>
+											<Switch
+												checked={vm.preference.ffmpegOptions.normalize_loudness}
+												onCheckedChange={(checked) =>
+													vm.preference.setFfmpegOptions({ ...vm.preference.ffmpegOptions, normalize_loudness: checked })
+												}
+											/>
+										</div>
+
+										<Field
+											label={
+												<>
+													<InfoTooltip text={'ffmpeg -i {input} -ar 16000 -ac 1 -c:a pcm_s16le {custom_command} -hide_banner -y -loglevel error'} />
+													{t('common.custom-ffmpeg-command')}
+												</>
+											}>
+											<Input
+												value={vm.preference.ffmpegOptions.custom_command ?? ''}
+												onChange={(e) =>
+													vm.preference.setFfmpegOptions({ ...vm.preference.ffmpegOptions, custom_command: e.target.value || null })
+												}
+												placeholder={vm.preference.ffmpegOptions.normalize_loudness ? '-af loudnorm=I=-16:TP=-1.5:LRA=11' : ''}
+												type="text"
+											/>
+										</Field>
+									</div>
+								</SectionCard>
+							</div>
+
+							<div className="space-y-2">
+								<span className="px-1 text-sm font-semibold text-foreground/95">{t('common.presets')}</span>
+								<SectionCard>
+									<div className="flex gap-4">
+										<Button variant="secondary" onClick={vm.preference.enableSubtitlesPreset} className="flex-1">
+											{t('common.preset-for-subtitles')}
+										</Button>
+										<Button variant="secondary" onClick={vm.preference.resetOptions} className="flex-1">
+											{t('common.reset-options')}
+										</Button>
+									</div>
+								</SectionCard>
+							</div>
+						</div>
+	)
+}


### PR DESCRIPTION
## What changed

- Extract settings sections into focused components.
- Extract home recording, transcription, summarization, media selection, and download logic into page-local hooks.
- Use the explicit Roboto 400 CSS entry.

## Why

The settings page and home view model had accumulated unrelated responsibilities and were difficult to navigate safely. This keeps behavior intact while giving each concern a clear home.

## Validation

- `pnpm --dir desktop build`
- `git diff --cached --check`