### PR TITLE
Bump version to 3.0.21

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./gen/schemas/desktop-schema.json",
 	"productName": "vibe",
-	"version": "3.0.20",
+	"version": "3.0.21",
 	"identifier": "github.com.thewh1teagle.vibe",
 	"app": {
 		"macOSPrivateApi": true,


### PR DESCRIPTION
## What changed

- Bump the Tauri application version from 3.0.20 to 3.0.21.

## Release contents

This release includes toggle-mode global dictation, the floating dictation indicator, Sona v0.2.3, dead-process recovery, robust NDJSON stream parsing, and the Sona module organization work.

## Validation

- Parsed `tauri.conf.json` and verified version 3.0.21.
- Previous feature PRs passed frontend and Rust validation.