### PR TITLE
make Windows signing optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,6 @@ jobs:
                   releaseName: "v__VERSION__"
                   releaseBody: "What's new? 🎉📣"
                   prerelease: true
-                  args: ${{ matrix.args }}
+                  args: ${{ matrix.args }} ${{ matrix.platform == 'windows-latest' && inputs.sign-windows && '--config src-tauri/tauri.windows.signing.conf.json' || '' }}
                   projectPath: "./desktop"
                   tauriScript: pnpm exec tauri

--- a/desktop/src-tauri/tauri.windows.conf.json
+++ b/desktop/src-tauri/tauri.windows.conf.json
@@ -4,10 +4,6 @@
 		"windows": {
 			"nsis": {
 				"installerHooks": "vc_redist.nsh"
-			},
-			"signCommand": {
-				"cmd": "uv.exe",
-				"args": ["run", "../../scripts/sign_windows.py", "%1"]
 			}
 		}
 	}

--- a/desktop/src-tauri/tauri.windows.signing.conf.json
+++ b/desktop/src-tauri/tauri.windows.signing.conf.json
@@ -1,0 +1,10 @@
+{
+	"bundle": {
+		"windows": {
+			"signCommand": {
+				"cmd": "uv.exe",
+				"args": ["run", "../../scripts/sign_windows.py", "%1"]
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- move the Windows Tauri signing command into a signing-only config override
- load that override only when the release input requests Windows signing

## Impact
Unsigned beta releases no longer invoke custom signing or signature verification.

## Validation
- JSON configuration parses with jq
- release workflow parses with Ruby YAML
- git diff --check