### PR TITLE
fix Windows updates while Sona is running

### DIFF
--- a/desktop/src/providers/updater.tsx
+++ b/desktop/src/providers/updater.tsx
@@ -94,7 +94,12 @@ export function UpdaterProvider({ children }: { children: React.ReactNode }) {
 		setUpdating(true)
 		setProgress(0)
 		console.info(`Installing update ${update?.version}, ${update?.date}, ${update?.body}`)
-		await update?.downloadAndInstall(onDownloadEvent)
+		await update?.download(onDownloadEvent)
+		// Windows cannot replace the bundled sona.exe while it is running. Stop it
+		// only after the update has downloaded so transcription remains available
+		// while the (potentially long) download is in progress.
+		await invoke('stop_api_server')
+		await update?.install()
 		setUpdating(false)
 		setTotal(null)
 		setPartSize(null)
@@ -119,7 +124,7 @@ export function UpdaterProvider({ children }: { children: React.ReactNode }) {
 		})
 		if (shouldUpdate) {
 			try {
-				downloadAndInstall()
+				await downloadAndInstall()
 			} catch (e) {
 				console.error(e)
 				setUpdating(false)


### PR DESCRIPTION
## What changed

- Download updates before stopping the Sona sidecar.
- Stop Sona immediately before updater installation.
- Await the full update operation so installation errors reach the existing error UI.

## Why

On Windows, the updater could not replace the bundled `sona.exe` while that process was still running. The existing exit cleanup happens after installation begins, which is too late.

Closes #935.

## Validation

- `pnpm exec tsc --noEmit -p desktop/tsconfig.json`
- `git diff --check`
