### PR TITLE
Generate Paraglide before type checking

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,7 +6,8 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"build": "tsc && vite build",
+		"i18n:generate": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations --strategy localStorage globalVariable baseLocale",
+		"build": "pnpm i18n:generate && tsc && vite build",
 		"preview": "vite preview",
 		"tauri": "tauri",
 		"lint": "eslint ."

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,8 @@
 	"packageManager": "pnpm@10.4.1",
 	"scripts": {
 		"dev": "vite",
-		"build": "tsc && vite build && cp dist/index.html dist/404.html",
+		"i18n:generate": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations --strategy localStorage preferredLanguage baseLocale",
+		"build": "pnpm i18n:generate && tsc && vite build && cp dist/index.html dist/404.html",
 		"preview": "vite preview"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes clean CI builds by generating ignored Paraglide files before TypeScript runs.

Verified from a clean generated-output state:
- `pnpm build` in `website`
- `pnpm build` in `desktop`