### PR TITLE
Improve model selection flow

### DIFF
--- a/desktop/src/components/app-menu.tsx
+++ b/desktop/src/components/app-menu.tsx
@@ -15,7 +15,8 @@ interface AppMenuProps {
 export default function AppMenu({ availableUpdate, updateApp, onClickSettings }: AppMenuProps) {
 	const navigate = useNavigate()
 	const location = useLocation()
-	const canGoBack = location.key !== 'default'
+	const disableBack = Boolean((location.state as { disableBack?: boolean } | null)?.disableBack)
+	const canGoBack = location.key !== 'default' && !disableBack
 	const [open, setOpen] = useState(false)
 
 	return (

--- a/desktop/src/lib/model.ts
+++ b/desktop/src/lib/model.ts
@@ -16,6 +16,12 @@ export async function getFilenameFromUrl(url: string) {
 	return fileName
 }
 
+export function getFriendlyModelName(filename: string) {
+	const name = filename.replace(/\.bin$/i, '').replace(/^ggml[-_]?/, '')
+	if (!name || name === 'model') return 'Custom model'
+	return name.replace(/[-_]+/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
 export async function downloadModel(url: string) {
 	let filename = await getFilenameFromUrl(url)
 	if (!filename.endsWith('.bin')) {

--- a/desktop/src/pages/batch/page.tsx
+++ b/desktop/src/pages/batch/page.tsx
@@ -1,7 +1,6 @@
 import { m } from '~/paraglide/messages.js'
 import LanguageInput from '~/components/language-input'
 import Layout from '~/components/layout'
-import AdvancedOptionsButton from '~/components/advanced-options-button'
 import BatchPanel from './batch-panel'
 import { viewModel } from './view-model'
 import { Button } from '~/components/ui/button'
@@ -20,7 +19,6 @@ export default function BatchPage() {
 					</div>
 					<LanguageInput />
 					<FormatMultiSelect setFormats={vm.setFormats} formats={vm.formats} />
-					<AdvancedOptionsButton />
 
 					<div className="pt-2">
 						<BatchPanel

--- a/desktop/src/pages/settings/sections/models.tsx
+++ b/desktop/src/pages/settings/sections/models.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import { FolderOpen, PencilLine } from 'lucide-react'
 import { m } from '~/paraglide/messages.js'
 import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
 import { ReactComponent as LinkIcon } from '~/icons/link.svg'
@@ -7,8 +9,13 @@ import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
 import { SectionCard, type SettingsViewModel } from './shared'
+import { getFriendlyModelName } from '~/lib/model'
 
 export function ModelsSection({ vm }: { vm: SettingsViewModel }) {
+	const [editingPath, setEditingPath] = useState<string | null>(null)
+	const [editingName, setEditingName] = useState('')
+	const currentModel = vm.models.find((model) => model.path === vm.preference.modelPath)
+
 	return (
 <div className="space-y-5">
 							<SectionCard>
@@ -52,13 +59,40 @@ export function ModelsSection({ vm }: { vm: SettingsViewModel }) {
 												<SelectValue placeholder={m.selectModel()} />
 											</SelectTrigger>
 											<SelectContent>
-												{vm.models.map((model, index) => (
-													<SelectItem key={index} value={model.path}>
-														{model.name}
-													</SelectItem>
+														{vm.models.map((model, index) => (
+															<SelectItem key={index} value={model.path}>
+																{vm.preference.modelDisplayNames[model.path] ?? getFriendlyModelName(model.name)}
+															</SelectItem>
 												))}
 											</SelectContent>
-										</Select>
+											</Select>
+							{currentModel && (editingPath === currentModel.path ? (
+								<div className="flex items-center gap-2">
+									<Input autoFocus value={editingName} onChange={(event) => setEditingName(event.target.value)} onKeyDown={(event) => {
+										if (event.key === 'Enter') {
+											const name = editingName.trim()
+											if (name) vm.preference.setModelDisplayNames({ ...vm.preference.modelDisplayNames, [currentModel.path]: name })
+											setEditingPath(null)
+										}
+										if (event.key === 'Escape') setEditingPath(null)
+									}} />
+									<Button size="sm" onClick={() => {
+										const name = editingName.trim()
+										if (name) vm.preference.setModelDisplayNames({ ...vm.preference.modelDisplayNames, [currentModel.path]: name })
+										setEditingPath(null)
+									}}>{m.save()}</Button>
+									<Button variant="ghost" size="sm" onClick={() => setEditingPath(null)}>{m.cancel()}</Button>
+								</div>
+							) : (
+								<div className="mt-2 flex items-center justify-end gap-1 px-1">
+									<Button variant="ghost" size="xs" className="px-2.5 text-muted-foreground hover:text-foreground" onClick={() => vm.openSelectedModel(currentModel.path)}>
+										<FolderOpen className="size-3.5" /> {m.showInFolder()}
+									</Button>
+									<Button variant="ghost" size="xs" className="px-2.5 text-muted-foreground hover:text-foreground" onClick={() => { setEditingPath(currentModel.path); setEditingName(vm.preference.modelDisplayNames[currentModel.path] ?? getFriendlyModelName(currentModel.name)) }}>
+										<PencilLine className="size-3.5" /> {m.rename()}
+									</Button>
+								</div>
+							))}
 									</div>
 
 									{!vm.isMacOS && (

--- a/desktop/src/pages/settings/view-model.ts
+++ b/desktop/src/pages/settings/view-model.ts
@@ -34,6 +34,10 @@ async function openModelPath() {
 	invoke('open_path', { path: dst })
 }
 
+async function openSelectedModel(path: string | null) {
+	if (path) await invoke('open_path', { path })
+}
+
 async function openModelsUrl() {
 	openUrl(config.modelsDocURL)
 }
@@ -252,6 +256,9 @@ export function viewModel() {
 		const entries = await ls(modelsFolder)
 		const found = entries.filter((e) => e.name?.endsWith('.bin'))
 		setModels(found)
+		if (preference.modelPath && !found.some((model) => model.path === preference.modelPath)) {
+			preference.setModelPath(null)
+		}
 	}
 
 	async function getDefaultModel() {
@@ -413,6 +420,7 @@ export function viewModel() {
 		preference: preference,
 		askAndReset,
 		openModelPath,
+		openSelectedModel,
 		openModelsUrl,
 		revealLogs,
 		revealTemp,

--- a/desktop/src/pages/setup/view-model.ts
+++ b/desktop/src/pages/setup/view-model.ts
@@ -68,7 +68,7 @@ export function viewModel() {
 					if (path) {
 						console.log(`[model] Download succeeded: ${path}`)
 						preference.setModelPath(path)
-						navigate('/')
+						navigate('/', { replace: true, state: { disableBack: true } })
 						return
 					}
 				} catch (err) {
@@ -99,7 +99,7 @@ export function viewModel() {
 		// Cancel and go to settings
 		preference.setSkippedSetup(true)
 		emit('abort_download')
-		navigate('/#settings')
+		navigate('/#settings', { replace: true, state: { disableBack: true } })
 	}
 
 	useEffect(() => {

--- a/desktop/src/providers/preference.tsx
+++ b/desktop/src/providers/preference.tsx
@@ -30,6 +30,8 @@ export interface Preference {
 	setFocusOnFinish: ModifyState<boolean>
 	modelPath: string | null
 	setModelPath: ModifyState<string | null>
+	modelDisplayNames: Record<string, string>
+	setModelDisplayNames: ModifyState<Record<string, string>>
 	skippedSetup: boolean
 	setSkippedSetup: ModifyState<boolean>
 	textAreaDirection: Direction
@@ -144,6 +146,7 @@ export function PreferenceProvider({ children }: { children: ReactNode }) {
 	const [isFirstRun, setIsFirstRun] = useLocalStorage('prefs_first_localstorage_read', true)
 
 	const [modelPath, setModelPath] = useLocalStorage<string | null>('prefs_model_path', null)
+	const [modelDisplayNames, setModelDisplayNames] = useLocalStorage<Record<string, string>>('prefs_model_display_names', {})
 	const [skippedSetup, setSkippedSetup] = useLocalStorage<boolean>('prefs_skipped_setup', false)
 	const [textAreaDirection, setTextAreaDirection] = useLocalStorage<Direction>('prefs_textarea_direction', 'ltr')
 	const [textFormatTranscript, setTextFormatTranscript] = useLocalStorage<TextFormat>('prefs_text_format_transcript', 'pdf')
@@ -277,6 +280,8 @@ export function PreferenceProvider({ children }: { children: ReactNode }) {
 		setFocusOnFinish,
 		modelPath,
 		setModelPath,
+		modelDisplayNames,
+		setModelDisplayNames,
 		theme,
 		setTheme,
 		homeTab,

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -366,5 +366,9 @@
 	"loading": "Loading...",
 	"agentInstructionsCopied": "Agent skill instructions copied to clipboard",
 	"localApiUnreachable": "Could not reach the local API",
-	"permissionAudioRecording": "Please enable system audio recording in System Settings, then try again."
+	"permissionAudioRecording": "Please enable system audio recording in System Settings, then try again.",
+	"rename": "Rename",
+	"modelName": "Model name",
+	"save": "Save",
+	"showInFolder": "Show in folder"
 }


### PR DESCRIPTION
Adds friendly persisted model names, inline rename controls, a selected-model reveal action, stale selection cleanup after file deletion, and removes Advanced Options from Batch. Also ensures setup exits do not leave a usable Back entry.