### PR TITLE
Add resilient model download fallbacks

### DIFF
--- a/desktop/src/lib/config.ts
+++ b/desktop/src/lib/config.ts
@@ -12,7 +12,8 @@ export const latestVersionWithoutVulkan = 'https://github.com/thewh1teagle/vibe/
 export const modelUrls = {
 	default: [
 		'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin',
-		'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin', // Fallback
+		'https://huggingface.co/vibe-app/whisper-large-v3-turbo-gguf/resolve/main/ggml-large-v3-turbo.bin', // Hugging Face fallback
+		'https://github.com/thewh1teagle/vibe/releases/download/model-files-v1.0/ggml-large-v3-turbo.bin', // GitHub fallback
 	],
 	hebrew: ['https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin'],
 }

--- a/desktop/src/pages/setup/page.tsx
+++ b/desktop/src/pages/setup/page.tsx
@@ -13,7 +13,7 @@ function App() {
 		<div className="app-shell flex min-h-screen items-center justify-center">
 			<div className="app-panel w-full max-w-xl text-center">
 				<p className="app-kicker mb-2">{m.setup({ defaultValue: 'Setup' })}</p>
-				<div className="text-balance text-2xl font-semibold md:text-3xl">{m.downloadingModel({ company: vm.modelCompany })}</div>
+				<div className="text-balance text-2xl font-semibold md:text-3xl">{m.downloadingModel()}</div>
 
 				<div className="mt-6 flex flex-col items-center gap-3">
 					{vm.downloadProgress > 0 && (

--- a/desktop/src/pages/setup/view-model.ts
+++ b/desktop/src/pages/setup/view-model.ts
@@ -19,7 +19,6 @@ export function viewModel() {
 	const { setState: setErrorModal } = useContext(ErrorModalContext)
 	const navigate = useNavigate()
 	const preference = usePreferenceProvider()
-	const [modelCompany, setModelCompany] = useState('OpenAI')
 
 	function handleProgressEvenets() {
 		listen('download_progress', (event) => {
@@ -78,9 +77,6 @@ export function viewModel() {
 			if (location?.state?.downloadURL) {
 				urls = [location.state.downloadURL]
 				console.log(`[model] Using provided model URL: ${urls[0]}`)
-				if (urls[0].includes('ivrit')) {
-					setModelCompany('ivrit.ai')
-				}
 			} else {
 				urls = [...config.modelUrls.default]
 				const locale = await osExt.locale()
@@ -89,7 +85,6 @@ export function viewModel() {
 				if (locale?.endsWith('-IL')) {
 					console.log(`[model] Prioritizing Hebrew models`)
 					urls.unshift(...config.modelUrls.hebrew)
-					setModelCompany('ivrit.ai')
 				}
 			}
 
@@ -143,7 +138,6 @@ export function viewModel() {
 	}, [])
 
 	return {
-		modelCompany,
 		navigate,
 		cancelSetup,
 		setErrorModal,

--- a/i18n/translations/ca-AD/desktop.json
+++ b/i18n/translations/ca-AD/desktop.json
@@ -48,7 +48,7 @@
 	"downloading": "Descarregant... {progress}%",
 	"downloadingDiarizeModel": "Descarregant el model de diarització...",
 	"downloadingAiModels": "Descarregant models d'IA...",
-	"downloadingModel": "Descarregant model de {company}...",
+	"downloadingModel": "Descarregant el model...",
 	"downloadingYtdlp": "Descarregant ytdlp",
 	"enableDiarization": "Activar diarització de veu",
 	"enableLogs": "Activar registres (logs)",

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -56,7 +56,7 @@
 	"downloading": "Downloading... {progress}%",
 	"downloadingDiarizeModel": "Downloading diarization model...",
 	"downloadingAiModels": "Downloading AI models...",
-	"downloadingModel": "Downloading {company} Model...",
+	"downloadingModel": "Downloading Model...",
 	"downloadingYtdlp": "Downloading ytdlp",
 	"enableDiarization": "Enable speaker diarization",
 	"enableLogs": "Enable Logs",

--- a/i18n/translations/es-ES/desktop.json
+++ b/i18n/translations/es-ES/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Descargar modelos",
 	"downloading": "Descargando... {progress}%",
 	"downloadingAiModels": "Descargando modelos de IA...",
-	"downloadingModel": "Descargando modelo de OpenAI...",
+	"downloadingModel": "Descargando modelo...",
 	"downloadingYtdlp": "Descargando ytdlp",
 	"enableLogs": "Habilitar registros",
 	"error": "Error",

--- a/i18n/translations/es-MX/desktop.json
+++ b/i18n/translations/es-MX/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Descargar Modelos",
 	"downloading": "Descargando... {progress}%",
 	"downloadingAiModels": "Descargando modelos de IA...",
-	"downloadingModel": "Descargando Modelo de OpenAI...",
+	"downloadingModel": "Descargando modelo...",
 	"downloadingYtdlp": "Descargando ytdlp",
 	"enableLogs": "Habilitar Registros",
 	"error": "Error",

--- a/i18n/translations/fr-FR/desktop.json
+++ b/i18n/translations/fr-FR/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Télécharger les modèles",
 	"downloading": "Téléchargement... {progress} %",
 	"downloadingAiModels": "Téléchargement de modèles d'IA...",
-	"downloadingModel": "Téléchargement du modèle OpenAI en cours…",
+	"downloadingModel": "Téléchargement du modèle en cours…",
 	"downloadingYtdlp": "Téléchargement de ytdlp",
 	"enableLogs": "Activer les journaux",
 	"error": "Erreur",

--- a/i18n/translations/he-IL/desktop.json
+++ b/i18n/translations/he-IL/desktop.json
@@ -49,7 +49,7 @@
 	"downloadModelsLink": "הורדת מודלים",
 	"downloading": "מוריד... {progress}%",
 	"downloadingAiModels": "מוריד מודלים...",
-	"downloadingModel": "מוריד מודל בינה מלאכותית מאת {company}",
+	"downloadingModel": "מוריד מודל בינה מלאכותית...",
 	"downloadingYtdlp": "מוריד ytdlp",
 	"enableLogs": "הפעל לוגים",
 	"enabled": "מופעל",

--- a/i18n/translations/hi-IN/desktop.json
+++ b/i18n/translations/hi-IN/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "मॉडल डाउनलोड करें",
 	"downloading": "डाउनलोड हो रहा है... {progress}%",
 	"downloadingAiModels": "AI मॉडल डाउनलोड हो रहा है...",
-	"downloadingModel": "OpenAI मॉडल डाउनलोड हो रहा है...",
+	"downloadingModel": "मॉडल डाउनलोड हो रहा है...",
 	"downloadingYtdlp": "Ytdlp डाउनलोड हो रहा है",
 	"enableLogs": "लॉग सक्षम करें",
 	"error": "गलती",

--- a/i18n/translations/it-IT/desktop.json
+++ b/i18n/translations/it-IT/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Scarica modelli",
 	"downloading": "Download in corso... {progress}%",
 	"downloadingAiModels": "Scaricando i modelli AI...",
-	"downloadingModel": "Scaricando i modelli di OpenAI...",
+	"downloadingModel": "Scaricando il modello...",
 	"downloadingYtdlp": "Scaricando i modelli ytdlp",
 	"enableLogs": "Abilita registri",
 	"error": "Errore",

--- a/i18n/translations/ja-JP/desktop.json
+++ b/i18n/translations/ja-JP/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "モデルをダウンロード",
 	"downloading": "ダウンロード中... {progress}%",
 	"downloadingAiModels": "AIモデルをダウンロード中...",
-	"downloadingModel": "{company}モデルをダウンロード中...",
+	"downloadingModel": "モデルをダウンロード中...",
 	"downloadingYtdlp": "ytdlpをダウンロード中",
 	"enableLogs": "ログを有効化",
 	"error": "エラー",

--- a/i18n/translations/ko-KR/desktop.json
+++ b/i18n/translations/ko-KR/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "모델 다운로드",
 	"downloading": "다운로드 중... {progress}%",
 	"downloadingAiModels": "AI 모델 다운로드 중...",
-	"downloadingModel": "{company} 모델 다운로드 중...",
+	"downloadingModel": "모델 다운로드 중...",
 	"downloadingYtdlp": "ytdlp 다운로드 중",
 	"enableLogs": "로그 활성화",
 	"error": "오류",

--- a/i18n/translations/no-NO/desktop.json
+++ b/i18n/translations/no-NO/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Last ned modeller",
 	"downloading": "Laster ned... {progress}%",
 	"downloadingAiModels": "Laster ned AI-modeller...",
-	"downloadingModel": "Laster ned modeller fra OpenAI...",
+	"downloadingModel": "Laster ned modell...",
 	"downloadingYtdlp": "Laster ned ytdlp",
 	"enableLogs": "Aktiver logger",
 	"error": "Feil",

--- a/i18n/translations/pl-PL/desktop.json
+++ b/i18n/translations/pl-PL/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Pobierz modele",
 	"downloading": "Pobieranie... {progress}%",
 	"downloadingAiModels": "Pobieranie modeli AI...",
-	"downloadingModel": "Pobieranie modelu {company}...",
+	"downloadingModel": "Pobieranie modelu...",
 	"downloadingYtdlp": "Pobieranie ytdlp",
 	"enableLogs": "Włącz logi",
 	"error": "Błąd",

--- a/i18n/translations/pt-BR/desktop.json
+++ b/i18n/translations/pt-BR/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Baixar modelos",
 	"downloading": "Baixando... {progress}%",
 	"downloadingAiModels": "Baixando modelos de IA...",
-	"downloadingModel": "Baixando o modelo OpenAI....",
+	"downloadingModel": "Baixando o modelo...",
 	"downloadingYtdlp": "Baixando ytdlp",
 	"enableLogs": "Habilitar registros",
 	"error": "Erro",

--- a/i18n/translations/ru-RU/desktop.json
+++ b/i18n/translations/ru-RU/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Скачать модели",
 	"downloading": "Загрузка... {progress}%",
 	"downloadingAiModels": "Загрузка AI моделей...",
-	"downloadingModel": "Загрузка модели OpenAI...",
+	"downloadingModel": "Загрузка модели...",
 	"downloadingYtdlp": "Загрузка ytdlp",
 	"enableLogs": "Включить логи",
 	"error": "Ошибка",

--- a/i18n/translations/sv-SE/desktop.json
+++ b/i18n/translations/sv-SE/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Hämta Modeller",
 	"downloading": "Laddar ned... {progress}%",
 	"downloadingAiModels": "Laddar ner AI-modeller...",
-	"downloadingModel": "Hämtar OpenAI Model...",
+	"downloadingModel": "Hämtar modell...",
 	"downloadingYtdlp": "Laddar ner ytdlp",
 	"enableLogs": "Aktivera loggar",
 	"error": "Fel",

--- a/i18n/translations/tr-TR/desktop.json
+++ b/i18n/translations/tr-TR/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Modelleri İndirin",
 	"downloading": "İndiriliyor... {progress}%",
 	"downloadingAiModels": "AI modellerini indiriliyor...",
-	"downloadingModel": "{company} Modeli indiriliyor...",
+	"downloadingModel": "Model indiriliyor...",
 	"downloadingYtdlp": "Ytdlp indiriliyor",
 	"enableLogs": "Günlükleri Etkinleştir",
 	"error": "Hata",

--- a/i18n/translations/vi-VN/desktop.json
+++ b/i18n/translations/vi-VN/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "Tải xuống các mô hình",
 	"downloading": "Đang tải xuống... {progress}%",
 	"downloadingAiModels": "Đang tải xuống mô hình AI...",
-	"downloadingModel": "Đang tải xuống mô hình OpenAI...",
+	"downloadingModel": "Đang tải xuống mô hình...",
 	"downloadingYtdlp": "Đang tải xuống ytdlp",
 	"enableLogs": "Bật nhật ký",
 	"error": "Lỗi",

--- a/i18n/translations/zh-CN/desktop.json
+++ b/i18n/translations/zh-CN/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "下载模型",
 	"downloading": "正在下载... {progress}%",
 	"downloadingAiModels": "正在下载 AI 模型...",
-	"downloadingModel": "正在下载 OpenAI 模型...",
+	"downloadingModel": "正在下载模型...",
 	"downloadingYtdlp": "下载 ytdlp",
 	"enableLogs": "启用日志",
 	"error": "错误",

--- a/i18n/translations/zh-HK/desktop.json
+++ b/i18n/translations/zh-HK/desktop.json
@@ -41,7 +41,7 @@
 	"downloadModelsLink": "下載模型",
 	"downloading": "正在下載... {progress}%",
 	"downloadingAiModels": "正在下載 AI 模型...",
-	"downloadingModel": "正在下載 OpenAI 模型...",
+	"downloadingModel": "正在下載模型...",
 	"downloadingYtdlp": "下載 ytdlp",
 	"enableLogs": "啟用日誌",
 	"error": "錯誤",


### PR DESCRIPTION
## Summary

- add Vibe-hosted Hugging Face and GitHub Release mirrors for the default Whisper Large v3 Turbo model
- remove the Medium model fallback so every automatic source resolves to the same verified Turbo model
- make the setup download message provider-neutral across all supported locales

## Why

Hugging Face's Xet/CloudFront bridge returned `403 Forbidden` for large model downloads in multiple regions. The mirrors provide an independent GitHub delivery path while preserving the exact model bytes and filename.

## Recent related issues

- issue #1243 — model setup failed with a Hugging Face Xet `403 Forbidden` response
- issue #1241 — model download failed with a Hugging Face Xet `403 Forbidden` response
- issue #1240 — model setup failed with a Hugging Face Xet `403 Forbidden` response
- issue #1238 — model setup failed after the Hugging Face connection was closed

## Validation

- `pnpm check:i18n`
- `pnpm --dir desktop build`
- verified the Hugging Face and GitHub mirror assets are both 1,624,555,275 bytes with SHA-256 `1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69`
