### PR TITLE
Make model download recovery resilient

### DIFF
--- a/desktop/src-tauri/src/cmd/download.rs
+++ b/desktop/src-tauri/src/cmd/download.rs
@@ -1,102 +1,218 @@
 use crate::error::LogError;
-use eyre::{Context, Result};
+use eyre::{bail, Context, Result};
+use futures::future::{AbortHandle, Abortable};
 use futures_util::StreamExt;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use serde::Serialize;
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
 };
 use tauri::{Emitter, Listener, Manager};
 
 use super::ui::set_progress_bar;
 
-#[tauri::command]
-pub async fn download_model(app_handle: tauri::AppHandle, url: String, path: String) -> Result<String> {
-    tracing::debug!("Download model invoked! with path {}", path);
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DownloadModelResult {
+    Completed { path: String },
+    Cancelled,
+}
 
-    let abort_atomic = Arc::new(AtomicBool::new(false));
-    let abort_atomic_c = abort_atomic.clone();
+#[derive(Debug, PartialEq, Eq)]
+enum DownloadOutcome {
+    Completed,
+    Cancelled,
+}
 
-    let app_handle_c = app_handle.clone();
+fn partial_path(path: &Path) -> PathBuf {
+    let mut partial = path.as_os_str().to_os_string();
+    partial.push(".part");
+    PathBuf::from(partial)
+}
 
-    let app_handle_d = app_handle_c.clone();
-    app_handle.listen("abort_download", move |_| {
-        set_progress_bar(&app_handle_d, None).log_error();
-        abort_atomic_c.store(true, Ordering::Relaxed);
-    });
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).context(format!("Failed to remove file {}", path.display())),
+    }
+}
 
-    let client = reqwest::Client::new();
-    let res = client.get(&url).send().await?.error_for_status()?;
-    let total_size = res.content_length().unwrap_or(0);
-    let mut file = std::fs::File::create(&path).context(format!("Failed to create file {}", path))?;
-    let mut downloaded: u64 = 0;
-    let callback_limit: u64 = 1024 * 1024 * 2;
-    let mut callback_offset: u64 = 0;
-    let mut stream = res.bytes_stream();
+fn publish_download(partial: &Path, destination: &Path) -> Result<()> {
+    if !destination.exists() {
+        return std::fs::rename(partial, destination).context(format!("Failed to move download to {}", destination.display()));
+    }
 
-    while let Some(item) = stream.next().await {
-        if abort_atomic.load(Ordering::Relaxed) {
-            break;
+    let mut backup = destination.as_os_str().to_os_string();
+    backup.push(".backup");
+    let backup = PathBuf::from(backup);
+    remove_if_exists(&backup)?;
+    std::fs::rename(destination, &backup).context(format!(
+        "Failed to prepare existing file {} for replacement",
+        destination.display()
+    ))?;
+
+    match std::fs::rename(partial, destination) {
+        Ok(()) => {
+            remove_if_exists(&backup)?;
+            Ok(())
         }
-        let chunk = item.context("Error while downloading file")?;
-        use std::io::Write;
-        file.write_all(&chunk)
-            .context(format!("Error while writing to file {}", path))?;
-        downloaded += chunk.len() as u64;
-        if total_size > 0 && downloaded > callback_offset + callback_limit {
-            let percentage = (downloaded as f64 / total_size as f64) * 100.0;
-            tracing::trace!("percentage: {}", percentage);
-            set_progress_bar(&app_handle_c, Some(percentage)).log_error();
-            if let Some(window) = app_handle_c.get_webview_window("main") {
-                window.emit("download_progress", (downloaded, total_size)).log_error();
+        Err(error) => {
+            if let Err(restore_error) = std::fs::rename(&backup, destination) {
+                return Err(error).context(format!(
+                    "Failed to publish {} and failed to restore the previous file: {}",
+                    destination.display(),
+                    restore_error
+                ));
             }
-            callback_offset = downloaded;
+            Err(error).context(format!("Failed to replace file {}", destination.display()))
         }
     }
-    set_progress_bar(&app_handle, None)?;
-    Ok(path)
+}
+
+async fn download_to_partial(
+    app_handle: &tauri::AppHandle,
+    url: &str,
+    destination: &Path,
+    show_system_progress: bool,
+) -> Result<DownloadOutcome> {
+    let partial = partial_path(destination);
+    remove_if_exists(&partial)?;
+
+    let (abort_handle, abort_registration) = AbortHandle::new_pair();
+    let app_handle_listener = app_handle.clone();
+    let listener_id = app_handle.listen("abort_download", move |_| {
+        if show_system_progress {
+            set_progress_bar(&app_handle_listener, None).log_error();
+        }
+        abort_handle.abort();
+    });
+
+    let operation = async {
+        let client = reqwest::Client::new();
+        let response = client.get(url).send().await?.error_for_status()?;
+        let total_size = response.content_length().unwrap_or(0);
+        let mut file = std::fs::File::create(&partial).context(format!("Failed to create file {}", partial.display()))?;
+        let mut downloaded: u64 = 0;
+        let callback_limit: u64 = 1024 * 1024 * 2;
+        let mut callback_offset: u64 = 0;
+        let mut stream = response.bytes_stream();
+
+        while let Some(item) = stream.next().await {
+            let chunk = item.context("Error while downloading file")?;
+            file.write_all(&chunk)
+                .context(format!("Error while writing to file {}", partial.display()))?;
+            downloaded += chunk.len() as u64;
+
+            if total_size > 0 && downloaded > callback_offset + callback_limit {
+                let percentage = (downloaded as f64 / total_size as f64) * 100.0;
+                tracing::trace!("percentage: {}", percentage);
+                if show_system_progress {
+                    set_progress_bar(app_handle, Some(percentage)).log_error();
+                }
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    window.emit("download_progress", (downloaded, total_size)).log_error();
+                }
+                callback_offset = downloaded;
+            }
+        }
+
+        if total_size > 0 && downloaded != total_size {
+            bail!("Incomplete download: expected {} bytes, received {}", total_size, downloaded);
+        }
+
+        file.flush().context(format!("Failed to flush file {}", partial.display()))?;
+        drop(file);
+        publish_download(&partial, destination)?;
+        Ok(DownloadOutcome::Completed)
+    };
+
+    let result = match Abortable::new(operation, abort_registration).await {
+        Ok(result) => result,
+        Err(_) => Ok(DownloadOutcome::Cancelled),
+    };
+
+    app_handle.unlisten(listener_id);
+    if show_system_progress {
+        set_progress_bar(app_handle, None).log_error();
+    }
+
+    if !matches!(&result, Ok(DownloadOutcome::Completed)) {
+        remove_if_exists(&partial).log_error();
+    }
+
+    result
+}
+
+#[tauri::command]
+pub async fn download_model(app_handle: tauri::AppHandle, url: String, path: String) -> Result<DownloadModelResult> {
+    tracing::debug!("Download model invoked! with path {}", path);
+
+    match download_to_partial(&app_handle, &url, Path::new(&path), true).await? {
+        DownloadOutcome::Completed => Ok(DownloadModelResult::Completed { path }),
+        DownloadOutcome::Cancelled => Ok(DownloadModelResult::Cancelled),
+    }
 }
 
 #[tauri::command]
 pub async fn download_file(app_handle: tauri::AppHandle, url: String, path: String) -> Result<()> {
     tracing::debug!("Download file invoked! with path {}", path);
 
-    let abort_atomic = Arc::new(AtomicBool::new(false));
-    let abort_atomic_c = abort_atomic.clone();
-
-    let app_handle_c = app_handle.clone();
-
-    let app_handle_d = app_handle_c.clone();
-    app_handle.listen("abort_download", move |_| {
-        set_progress_bar(&app_handle_d, None).log_error();
-        abort_atomic_c.store(true, Ordering::Relaxed);
-    });
-
-    let client = reqwest::Client::new();
-    let res = client.get(&url).send().await?.error_for_status()?;
-    let total_size = res.content_length().unwrap_or(0);
-    let mut file = std::fs::File::create(&path).context(format!("Failed to create file {}", path))?;
-    let mut downloaded: u64 = 0;
-    let callback_limit: u64 = 1024 * 1024 * 2;
-    let mut callback_offset: u64 = 0;
-    let mut stream = res.bytes_stream();
-
-    while let Some(item) = stream.next().await {
-        if abort_atomic.load(Ordering::Relaxed) {
-            break;
-        }
-        let chunk = item.context("Error while downloading file")?;
-        use std::io::Write;
-        file.write_all(&chunk)
-            .context(format!("Error while writing to file {}", path))?;
-        downloaded += chunk.len() as u64;
-        if total_size > 0 && downloaded > callback_offset + callback_limit {
-            let percentage = (downloaded as f64 / total_size as f64) * 100.0;
-            tracing::trace!("percentage: {}", percentage);
-            if let Some(window) = app_handle_c.get_webview_window("main") {
-                window.emit("download_progress", (downloaded, total_size)).log_error();
-            }
-            callback_offset = downloaded;
-        }
+    match download_to_partial(&app_handle, &url, Path::new(&path), false).await? {
+        DownloadOutcome::Completed => Ok(()),
+        DownloadOutcome::Cancelled => bail!("Download cancelled"),
     }
-    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{partial_path, publish_download, remove_if_exists};
+    use std::{fs, path::PathBuf, time::SystemTime};
+
+    fn test_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos();
+        std::env::temp_dir().join(format!("vibe-download-{name}-{}-{unique}", std::process::id()))
+    }
+
+    #[test]
+    fn partial_path_keeps_the_model_extension_out_of_the_final_suffix() {
+        assert_eq!(
+            partial_path(PathBuf::from("model.bin").as_path()),
+            PathBuf::from("model.bin.part")
+        );
+    }
+
+    #[test]
+    fn publish_download_moves_a_complete_partial_file() {
+        let dir = test_dir("publish");
+        fs::create_dir_all(&dir).unwrap();
+        let destination = dir.join("model.bin");
+        let partial = partial_path(&destination);
+        fs::write(&partial, b"complete model").unwrap();
+
+        publish_download(&partial, &destination).unwrap();
+
+        assert_eq!(fs::read(&destination).unwrap(), b"complete model");
+        assert!(!partial.exists());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn publish_download_replaces_an_existing_file_without_leaving_a_backup() {
+        let dir = test_dir("replace");
+        fs::create_dir_all(&dir).unwrap();
+        let destination = dir.join("yt-dlp");
+        let partial = partial_path(&destination);
+        let backup = dir.join("yt-dlp.backup");
+        fs::write(&destination, b"old binary").unwrap();
+        fs::write(&partial, b"new binary").unwrap();
+
+        publish_download(&partial, &destination).unwrap();
+
+        assert_eq!(fs::read(&destination).unwrap(), b"new binary");
+        assert!(!partial.exists());
+        assert!(!backup.exists());
+        remove_if_exists(&destination).unwrap();
+        fs::remove_dir_all(dir).unwrap();
+    }
 }

--- a/desktop/src/components/layout.tsx
+++ b/desktop/src/components/layout.tsx
@@ -5,6 +5,7 @@ import AppMenu from './app-menu'
 import DropModal from './drop-modal'
 import SettingsModal from './settings-modal'
 import PageTransition from './page-transition'
+import ModelDownloadPrompt from './model-download-prompt'
 
 export default function Layout({ children }: { children: ReactNode }) {
 	const [settingsVisible, setSettingsVisible] = useState(false)
@@ -29,6 +30,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 		<div className="min-h-screen">
 			{settingsVisible && <SettingsModal visible={settingsVisible} setVisible={setSettingsVisible} scrollTo={settingsScrollTo} />}
 			<DropModal />
+			<ModelDownloadPrompt />
 			<div className="app-shell">
 				<div className="stagger-in mb-6 flex items-center justify-between gap-4 pb-1">
 					<h1 className="app-title">{m.appTitle()}</h1>

--- a/desktop/src/components/model-download-prompt.tsx
+++ b/desktop/src/components/model-download-prompt.tsx
@@ -1,0 +1,51 @@
+import { Download, X } from 'lucide-react'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useLocalStorage } from 'usehooks-ts'
+import { m } from '~/paraglide/messages.js'
+import { usePreferenceProvider } from '~/providers/preference'
+import { Button } from './ui/button'
+
+const DISMISSED_KEY = 'prefs_no_model_prompt_dismissed'
+
+export default function ModelDownloadPrompt() {
+	const navigate = useNavigate()
+	const preference = usePreferenceProvider()
+	const [dismissed, setDismissed] = useLocalStorage(DISMISSED_KEY, false)
+
+	useEffect(() => {
+		if (preference.modelPath && dismissed) {
+			setDismissed(false)
+		}
+	}, [preference.modelPath, dismissed, setDismissed])
+
+	if (preference.modelPath || dismissed) return null
+
+	function downloadDefaultModel() {
+		preference.setSkippedSetup(false)
+		navigate('/setup')
+	}
+
+	return (
+		<aside className="fixed bottom-4 left-4 right-4 z-40 rounded-xl border border-border/70 bg-card/95 p-4 shadow-xl backdrop-blur-md sm:left-auto sm:w-[340px]">
+			<Button
+				variant="ghost"
+				size="icon"
+				className="absolute right-2 top-2 h-7 w-7 text-muted-foreground"
+				onClick={() => setDismissed(true)}
+				aria-label={m.cancel()}>
+				<X className="h-4 w-4" />
+			</Button>
+
+			<div className="pr-7">
+				<p className="font-medium">{m.noModelsInstalled()}</p>
+				<p className="mt-1 text-sm text-muted-foreground">{m.downloadDefaultModelDescription()}</p>
+			</div>
+
+			<Button size="sm" className="mt-3 w-full" onClick={downloadDefaultModel}>
+				<Download className="mr-2 h-4 w-4" />
+				{m.downloadModel()}
+			</Button>
+		</aside>
+	)
+}

--- a/desktop/src/lib/model.ts
+++ b/desktop/src/lib/model.ts
@@ -7,6 +7,8 @@ export type ModelExtension = (typeof MODEL_EXTENSIONS)[number]
 
 const MODEL_EXTENSION_PATTERN = new RegExp(`\\.(${MODEL_EXTENSIONS.join('|')})$`, 'i')
 
+type DownloadModelResult = { status: 'completed'; path: string } | { status: 'cancelled' }
+
 export function getModelExtension(filename: string): ModelExtension | null {
 	const extension = filename.match(MODEL_EXTENSION_PATTERN)?.[1]?.toLowerCase()
 	return MODEL_EXTENSIONS.includes(extension as ModelExtension) ? (extension as ModelExtension) : null
@@ -48,8 +50,8 @@ export async function downloadModel(url: string) {
 		filename = randomString(8, 'ggml-model_', `.${getModelExtension(filename) ?? 'bin'}`)
 		modelPath = await pathExt.join(modelsFolder, filename)
 	}
-	await invoke('download_model', { url, path: modelPath })
-	return modelPath
+	const result = await invoke<DownloadModelResult>('download_model', { url, path: modelPath })
+	return result.status === 'completed' ? result.path : null
 }
 
 export function isModelFile(filename: string) {

--- a/desktop/src/pages/home/view-model.ts
+++ b/desktop/src/pages/home/view-model.ts
@@ -152,6 +152,7 @@ export function viewModel() {
 			const entries = await ls(configPath)
 			const filtered = entries.filter((e) => isModelFile(e.name))
 			if (filtered.length === 0) {
+				preference.setModelPath(null)
 				// Download new model if no models and it's not manual installation
 				if (!preference.skippedSetup) {
 					navigate('/setup')

--- a/desktop/src/pages/setup/view-model.ts
+++ b/desktop/src/pages/setup/view-model.ts
@@ -93,15 +93,17 @@ export function viewModel() {
 				try {
 					console.log(`[model] Attempting to download from: ${url}`)
 					const path = await utils.downloadModel(url)
-					if (path) {
-						console.log(`[model] Download succeeded: ${path}`)
-						if (!(await selectDownloadedModel(path))) {
-							navigate('/#settings', { replace: true })
-							return
-						}
-						navigate('/', { replace: true, state: { disableBack: true } })
+					if (!path) {
+						console.log('[model] Download cancelled')
 						return
 					}
+					console.log(`[model] Download succeeded: ${path}`)
+					if (!(await selectDownloadedModel(path))) {
+						navigate('/#settings', { replace: true })
+						return
+					}
+					navigate('/', { replace: true, state: { disableBack: true } })
+					return
 				} catch (err) {
 					console.error(`[model] Failed to download from ${url}:`, err)
 					lastError = err

--- a/i18n/translations/ca-AD/desktop.json
+++ b/i18n/translations/ca-AD/desktop.json
@@ -49,6 +49,8 @@
 	"downloadingDiarizeModel": "Descarregant el model de diarització...",
 	"downloadingAiModels": "Descarregant models d'IA...",
 	"downloadingModel": "Descarregant el model...",
+	"noModelsInstalled": "No hi ha cap model instal·lat",
+	"downloadDefaultModelDescription": "Descarrega el model predeterminat per començar a transcriure.",
 	"downloadingYtdlp": "Descarregant ytdlp",
 	"enableDiarization": "Activar diarització de veu",
 	"enableLogs": "Activar registres (logs)",

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -227,6 +227,8 @@
 	"avx2NotSupported": "Your CPU is not supported by this version of Vibe. Please use a more modern PC.",
 	"noModelLoadedBatchStopped": "Model not loaded. Stopping batch.",
 	"noModelSelected": "Select a model in Settings to get started",
+	"noModelsInstalled": "No models installed",
+	"downloadDefaultModelDescription": "Download the default model to start transcribing.",
 	"transcribeFolder": "Transcribe folder",
 	"transcribeTook": "Transcribed successfully in {total} seconds.",
 	"transcribed": "Transcribed",

--- a/i18n/translations/es-ES/desktop.json
+++ b/i18n/translations/es-ES/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Descargando... {progress}%",
 	"downloadingAiModels": "Descargando modelos de IA...",
 	"downloadingModel": "Descargando modelo...",
+	"noModelsInstalled": "No hay modelos instalados",
+	"downloadDefaultModelDescription": "Descarga el modelo predeterminado para empezar a transcribir.",
 	"downloadingYtdlp": "Descargando ytdlp",
 	"enableLogs": "Habilitar registros",
 	"error": "Error",

--- a/i18n/translations/es-MX/desktop.json
+++ b/i18n/translations/es-MX/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Descargando... {progress}%",
 	"downloadingAiModels": "Descargando modelos de IA...",
 	"downloadingModel": "Descargando modelo...",
+	"noModelsInstalled": "No hay modelos instalados",
+	"downloadDefaultModelDescription": "Descarga el modelo predeterminado para comenzar a transcribir.",
 	"downloadingYtdlp": "Descargando ytdlp",
 	"enableLogs": "Habilitar Registros",
 	"error": "Error",

--- a/i18n/translations/fr-FR/desktop.json
+++ b/i18n/translations/fr-FR/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Téléchargement... {progress} %",
 	"downloadingAiModels": "Téléchargement de modèles d'IA...",
 	"downloadingModel": "Téléchargement du modèle en cours…",
+	"noModelsInstalled": "Aucun modèle installé",
+	"downloadDefaultModelDescription": "Téléchargez le modèle par défaut pour commencer la transcription.",
 	"downloadingYtdlp": "Téléchargement de ytdlp",
 	"enableLogs": "Activer les journaux",
 	"error": "Erreur",

--- a/i18n/translations/he-IL/desktop.json
+++ b/i18n/translations/he-IL/desktop.json
@@ -50,6 +50,8 @@
 	"downloading": "מוריד... {progress}%",
 	"downloadingAiModels": "מוריד מודלים...",
 	"downloadingModel": "מוריד מודל בינה מלאכותית...",
+	"noModelsInstalled": "לא מותקנים מודלים",
+	"downloadDefaultModelDescription": "הורד את מודל ברירת המחדל כדי להתחיל לתמלל.",
 	"downloadingYtdlp": "מוריד ytdlp",
 	"enableLogs": "הפעל לוגים",
 	"enabled": "מופעל",

--- a/i18n/translations/hi-IN/desktop.json
+++ b/i18n/translations/hi-IN/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "डाउनलोड हो रहा है... {progress}%",
 	"downloadingAiModels": "AI मॉडल डाउनलोड हो रहा है...",
 	"downloadingModel": "मॉडल डाउनलोड हो रहा है...",
+	"noModelsInstalled": "कोई मॉडल इंस्टॉल नहीं है",
+	"downloadDefaultModelDescription": "ट्रांसक्राइब करना शुरू करने के लिए डिफ़ॉल्ट मॉडल डाउनलोड करें।",
 	"downloadingYtdlp": "Ytdlp डाउनलोड हो रहा है",
 	"enableLogs": "लॉग सक्षम करें",
 	"error": "गलती",

--- a/i18n/translations/it-IT/desktop.json
+++ b/i18n/translations/it-IT/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Download in corso... {progress}%",
 	"downloadingAiModels": "Scaricando i modelli AI...",
 	"downloadingModel": "Scaricando il modello...",
+	"noModelsInstalled": "Nessun modello installato",
+	"downloadDefaultModelDescription": "Scarica il modello predefinito per iniziare a trascrivere.",
 	"downloadingYtdlp": "Scaricando i modelli ytdlp",
 	"enableLogs": "Abilita registri",
 	"error": "Errore",

--- a/i18n/translations/ja-JP/desktop.json
+++ b/i18n/translations/ja-JP/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "ダウンロード中... {progress}%",
 	"downloadingAiModels": "AIモデルをダウンロード中...",
 	"downloadingModel": "モデルをダウンロード中...",
+	"noModelsInstalled": "モデルがインストールされていません",
+	"downloadDefaultModelDescription": "文字起こしを開始するには、デフォルトモデルをダウンロードしてください。",
 	"downloadingYtdlp": "ytdlpをダウンロード中",
 	"enableLogs": "ログを有効化",
 	"error": "エラー",

--- a/i18n/translations/ko-KR/desktop.json
+++ b/i18n/translations/ko-KR/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "다운로드 중... {progress}%",
 	"downloadingAiModels": "AI 모델 다운로드 중...",
 	"downloadingModel": "모델 다운로드 중...",
+	"noModelsInstalled": "설치된 모델이 없습니다",
+	"downloadDefaultModelDescription": "전사를 시작하려면 기본 모델을 다운로드하세요.",
 	"downloadingYtdlp": "ytdlp 다운로드 중",
 	"enableLogs": "로그 활성화",
 	"error": "오류",

--- a/i18n/translations/no-NO/desktop.json
+++ b/i18n/translations/no-NO/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Laster ned... {progress}%",
 	"downloadingAiModels": "Laster ned AI-modeller...",
 	"downloadingModel": "Laster ned modell...",
+	"noModelsInstalled": "Ingen modeller er installert",
+	"downloadDefaultModelDescription": "Last ned standardmodellen for å begynne å transkribere.",
 	"downloadingYtdlp": "Laster ned ytdlp",
 	"enableLogs": "Aktiver logger",
 	"error": "Feil",

--- a/i18n/translations/pl-PL/desktop.json
+++ b/i18n/translations/pl-PL/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Pobieranie... {progress}%",
 	"downloadingAiModels": "Pobieranie modeli AI...",
 	"downloadingModel": "Pobieranie modelu...",
+	"noModelsInstalled": "Brak zainstalowanych modeli",
+	"downloadDefaultModelDescription": "Pobierz domyślny model, aby rozpocząć transkrypcję.",
 	"downloadingYtdlp": "Pobieranie ytdlp",
 	"enableLogs": "Włącz logi",
 	"error": "Błąd",

--- a/i18n/translations/pt-BR/desktop.json
+++ b/i18n/translations/pt-BR/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Baixando... {progress}%",
 	"downloadingAiModels": "Baixando modelos de IA...",
 	"downloadingModel": "Baixando o modelo...",
+	"noModelsInstalled": "Nenhum modelo instalado",
+	"downloadDefaultModelDescription": "Baixe o modelo padrão para começar a transcrever.",
 	"downloadingYtdlp": "Baixando ytdlp",
 	"enableLogs": "Habilitar registros",
 	"error": "Erro",

--- a/i18n/translations/ru-RU/desktop.json
+++ b/i18n/translations/ru-RU/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Загрузка... {progress}%",
 	"downloadingAiModels": "Загрузка AI моделей...",
 	"downloadingModel": "Загрузка модели...",
+	"noModelsInstalled": "Нет установленных моделей",
+	"downloadDefaultModelDescription": "Загрузите модель по умолчанию, чтобы начать расшифровку.",
 	"downloadingYtdlp": "Загрузка ytdlp",
 	"enableLogs": "Включить логи",
 	"error": "Ошибка",

--- a/i18n/translations/sv-SE/desktop.json
+++ b/i18n/translations/sv-SE/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Laddar ned... {progress}%",
 	"downloadingAiModels": "Laddar ner AI-modeller...",
 	"downloadingModel": "Hämtar modell...",
+	"noModelsInstalled": "Inga modeller är installerade",
+	"downloadDefaultModelDescription": "Hämta standardmodellen för att börja transkribera.",
 	"downloadingYtdlp": "Laddar ner ytdlp",
 	"enableLogs": "Aktivera loggar",
 	"error": "Fel",

--- a/i18n/translations/tr-TR/desktop.json
+++ b/i18n/translations/tr-TR/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "İndiriliyor... {progress}%",
 	"downloadingAiModels": "AI modellerini indiriliyor...",
 	"downloadingModel": "Model indiriliyor...",
+	"noModelsInstalled": "Yüklü model yok",
+	"downloadDefaultModelDescription": "Deşifreye başlamak için varsayılan modeli indirin.",
 	"downloadingYtdlp": "Ytdlp indiriliyor",
 	"enableLogs": "Günlükleri Etkinleştir",
 	"error": "Hata",

--- a/i18n/translations/vi-VN/desktop.json
+++ b/i18n/translations/vi-VN/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "Đang tải xuống... {progress}%",
 	"downloadingAiModels": "Đang tải xuống mô hình AI...",
 	"downloadingModel": "Đang tải xuống mô hình...",
+	"noModelsInstalled": "Chưa cài đặt mô hình nào",
+	"downloadDefaultModelDescription": "Tải mô hình mặc định để bắt đầu phiên âm.",
 	"downloadingYtdlp": "Đang tải xuống ytdlp",
 	"enableLogs": "Bật nhật ký",
 	"error": "Lỗi",

--- a/i18n/translations/zh-CN/desktop.json
+++ b/i18n/translations/zh-CN/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "正在下载... {progress}%",
 	"downloadingAiModels": "正在下载 AI 模型...",
 	"downloadingModel": "正在下载模型...",
+	"noModelsInstalled": "尚未安装模型",
+	"downloadDefaultModelDescription": "下载默认模型以开始转录。",
 	"downloadingYtdlp": "下载 ytdlp",
 	"enableLogs": "启用日志",
 	"error": "错误",

--- a/i18n/translations/zh-HK/desktop.json
+++ b/i18n/translations/zh-HK/desktop.json
@@ -42,6 +42,8 @@
 	"downloading": "正在下載... {progress}%",
 	"downloadingAiModels": "正在下載 AI 模型...",
 	"downloadingModel": "正在下載模型...",
+	"noModelsInstalled": "尚未安裝模型",
+	"downloadDefaultModelDescription": "下載預設模型以開始轉錄。",
 	"downloadingYtdlp": "下載 ytdlp",
 	"enableLogs": "啟用日誌",
 	"error": "錯誤",


### PR DESCRIPTION
## Summary

- add a dismissible no-model recovery card that retries the default model setup flow
- localize the recovery card across all 19 supported desktop locales
- download models and other files transactionally through `.part` files
- abort active HTTP operations immediately and delete incomplete downloads on cancellation or failure
- stop model fallback attempts cleanly after cancellation and clear stale selected-model paths

## Why

Cancelled downloads previously left partial files with valid model extensions, returned them as successful, and could select them as the active model. Abort listeners also accumulated between attempts. Users who cancelled or exhausted setup had no direct recovery action outside Settings.

The new flow only publishes a final model filename after the complete response has been written and verified. The recovery prompt remains dismissed for the current no-model period and resets after model availability changes.

## Validation

- `cargo clippy -p vibe -- -D warnings`
- `cargo test -p vibe` — 6 tests passed
- `pnpm --dir desktop test` — 2 tests passed
- `pnpm --dir desktop build`
- `pnpm check:i18n`
- Rust formatting, targeted Prettier, and diff whitespace checks
