### PR TITLE
Stop locked sidecars before Windows install

### DIFF
--- a/desktop/src-tauri/vc_redist.nsh
+++ b/desktop/src-tauri/vc_redist.nsh
@@ -1,3 +1,29 @@
+!macro StopSidecarBeforeInstall SIDECAR_NAME
+    ${If} ${FileExists} "$INSTDIR\${SIDECAR_NAME}"
+        ; taskkill is part of Windows and works when PowerShell script execution
+        ; is disabled. Restrict this to upgrades so a fresh install never stops
+        ; an unrelated process that happens to use the same executable name.
+        nsExec::ExecToStack '"$SYSDIR\taskkill.exe" /F /T /IM "${SIDECAR_NAME}"'
+        Pop $0
+        Pop $1
+        DetailPrint "taskkill ${SIDECAR_NAME} result: $0 $1"
+        Sleep 500
+
+        ; Removing the old file verifies that its lock is gone. Abort instead of
+        ; reporting success while silently retaining an incompatible sidecar.
+        Delete "$INSTDIR\${SIDECAR_NAME}"
+        ${If} ${FileExists} "$INSTDIR\${SIDECAR_NAME}"
+            MessageBox MB_OK|MB_ICONSTOP "Vibe could not replace ${SIDECAR_NAME} because it is still in use. Close Vibe and its background processes, then run the installer again."
+            Abort "The existing ${SIDECAR_NAME} is still locked"
+        ${EndIf}
+    ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+    ; Keep one entry per bundled sidecar that can outlive the main application.
+    !insertmacro StopSidecarBeforeInstall "sona.exe"
+!macroend
+
 Section
     ; Check if the VC++ Redistributable is already installed
     ReadRegStr $0 HKLM "SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Installed"


### PR DESCRIPTION
## Summary

- add a reusable NSIS preinstall macro for bundled sidecars
- terminate an installed `sona.exe` with Windows `taskkill` before files are copied
- delete and verify the old executable, aborting visibly if it remains locked

## Why

An orphaned Sona process can keep the installed executable locked during an upgrade. NSIS may then finish successfully while retaining the old sidecar, leaving the new Vibe version paired with an incompatible Sona binary.

The hook runs only when the sidecar already exists in the install directory, so fresh installations do not terminate processes. The macro can be extended with another `!insertmacro` invocation if more persistent sidecars are added later.

## User impact

Windows upgrades will replace the bundled Sona executable reliably or show an actionable installer failure instead of silently completing with a stale binary.

## Validation

- `git diff --check`
- verified the hook uses Tauri's `NSIS_HOOK_PREINSTALL` extension point
- verified only the intended installer hook file is included in the commit

## Related

- Windows installer silently fails to replace running `sona.exe`: https://github.com/thewh1teagle/vibe/issues/1235
- Tauri NSIS installer does not replace a running `externalBin` sidecar: https://github.com/tauri-apps/tauri/issues/15134
