### PR TITLE
Restore saved display language after Paraglide migration

### DIFF
--- a/desktop/src/lib/migrations/index.ts
+++ b/desktop/src/lib/migrations/index.ts
@@ -1,0 +1,32 @@
+import { migrateLegacyLocale } from './migrate-legacy-locale'
+
+/**
+ * Local storage migration versioning
+ *
+ * Give each migration the next sequential version and append it to the list.
+ * Never reuse, reorder, or remove released migrations: users may upgrade from
+ * any older Vibe release and must execute every missing migration in order.
+ *
+ * If a released migration needs a follow-up fix, append another migration.
+ * The stored version advances only after a migration succeeds, so keep each
+ * migration idempotent to make retries safe.
+ */
+const migrations = [{ version: 1, run: migrateLegacyLocale }]
+const MIGRATION_VERSION_KEY = 'vibe:migration-version'
+
+function readMigrationVersion() {
+	const version = Number(localStorage.getItem(MIGRATION_VERSION_KEY) ?? 0)
+	return Number.isInteger(version) && version >= 0 ? version : 0
+}
+
+export function runMigrations() {
+	let version = readMigrationVersion()
+
+	for (const migration of migrations) {
+		if (migration.version <= version) continue
+
+		migration.run()
+		version = migration.version
+		localStorage.setItem(MIGRATION_VERSION_KEY, String(version))
+	}
+}

--- a/desktop/src/lib/migrations/migrate-legacy-locale.ts
+++ b/desktop/src/lib/migrations/migrate-legacy-locale.ts
@@ -1,0 +1,20 @@
+import { baseLocale, isLocale, localStorageKey, setLocale } from '~/paraglide/runtime.js'
+
+const LEGACY_LOCALE_KEY = 'prefs_display_language'
+
+export function migrateLegacyLocale() {
+	const legacyLocale = localStorage.getItem(LEGACY_LOCALE_KEY)
+	if (legacyLocale === null) return
+
+	try {
+		const locale: unknown = JSON.parse(legacyLocale)
+		const paraglideLocale = localStorage.getItem(localStorageKey)
+		const shouldMigrate =
+			paraglideLocale === null || paraglideLocale === baseLocale || !isLocale(paraglideLocale)
+		if (isLocale(locale) && paraglideLocale !== locale && shouldMigrate) {
+			setLocale(locale, { reload: false })
+		}
+	} catch {
+		// Ignore malformed legacy preferences and keep Paraglide's base locale.
+	}
+}

--- a/desktop/src/lib/migrations/migrations.test.ts
+++ b/desktop/src/lib/migrations/migrations.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { localStorageKey } from '~/paraglide/runtime.js'
+import { runMigrations } from '.'
+
+describe('local storage migrations', () => {
+	beforeEach(() => {
+		localStorage.clear()
+	})
+
+	it('replaces Paraglide fallback English with the legacy locale once', () => {
+		localStorage.setItem('prefs_display_language', JSON.stringify('fr-FR'))
+		localStorage.setItem(localStorageKey, 'en-US')
+
+		runMigrations()
+
+		expect(localStorage.getItem(localStorageKey)).toBe('fr-FR')
+		expect(localStorage.getItem('vibe:migration-version')).toBe('1')
+
+		localStorage.setItem('prefs_display_language', JSON.stringify('he-IL'))
+		runMigrations()
+
+		expect(localStorage.getItem(localStorageKey)).toBe('fr-FR')
+	})
+
+	it('preserves an existing non-default Paraglide locale', () => {
+		localStorage.setItem('prefs_display_language', JSON.stringify('fr-FR'))
+		localStorage.setItem(localStorageKey, 'he-IL')
+
+		runMigrations()
+
+		expect(localStorage.getItem(localStorageKey)).toBe('he-IL')
+		expect(localStorage.getItem('vibe:migration-version')).toBe('1')
+	})
+})

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,22 +1,8 @@
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import App from './app'
-import DictationIndicator from './components/dictation-indicator'
 import './globals.css'
-import { m } from './paraglide/messages.js'
+import { runMigrations } from './lib/migrations'
+import Root from './root'
 
-const isDictationIndicator = new URLSearchParams(window.location.search).get('window') === 'dictation-indicator'
-if (isDictationIndicator) {
-	document.title = m.appTitle()
-	document.documentElement.classList.add('dictation-indicator-window')
-}
+runMigrations()
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-	isDictationIndicator ? (
-		<DictationIndicator />
-	) : (
-		<BrowserRouter>
-			<App />
-		</BrowserRouter>
-	),
-)
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<Root />)

--- a/desktop/src/root.tsx
+++ b/desktop/src/root.tsx
@@ -1,0 +1,15 @@
+import { BrowserRouter } from 'react-router-dom'
+import App from './app'
+import DictationIndicatorWindow from './windows/dictation-indicator-window'
+
+export default function Root() {
+	const isDictationIndicator = new URLSearchParams(window.location.search).get('window') === 'dictation-indicator'
+
+	return isDictationIndicator ? (
+		<DictationIndicatorWindow />
+	) : (
+		<BrowserRouter>
+			<App />
+		</BrowserRouter>
+	)
+}

--- a/desktop/src/windows/dictation-indicator-window.tsx
+++ b/desktop/src/windows/dictation-indicator-window.tsx
@@ -1,13 +1,20 @@
 import { listen } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
 import { AlertTriangle, Check, LoaderCircle } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useState } from 'react'
 import { m } from '~/paraglide/messages.js'
 import logoUrl from '../../../design/logo.svg?url'
 import { getDictationIndicatorState, type DictationIndicatorState } from '~/lib/dictation-indicator'
 
-export default function DictationIndicator() {
+export default function DictationIndicatorWindow() {
 	const [state, setState] = useState<DictationIndicatorState>({ sessionId: 0, status: 'recording' })
+
+	useLayoutEffect(() => {
+		document.title = m.appTitle()
+		document.documentElement.classList.add('dictation-indicator-window')
+
+		return () => document.documentElement.classList.remove('dictation-indicator-window')
+	}, [])
 
 	useEffect(() => {
 		invoke('dictation_indicator_ready').catch(console.error)


### PR DESCRIPTION
## Summary

- add an ordered, versioned local-storage migration runner
- migrate the legacy JSON-encoded `prefs_display_language` preference into Paraglide
- replace Paraglide's automatic base-locale fallback while preserving a valid non-default Paraglide locale
- separate native-window root selection from the React entry point and move the dictation indicator into `src/windows`
- add regression coverage for migrated and already-valid locale states

## Root cause

v3.0.22 intentionally compiles translations into the frontend bundle, so the removed external `locales/` directory is not itself the failure. Existing installations retain their selected language in `prefs_display_language`, while Paraglide reads `PARAGLIDE_LOCALE`. On an upgraded installation Paraglide can initialize that missing key to `en-US`, leaving the settings UI preference and rendered locale out of sync.

The migration treats the validated legacy preference as authoritative only when the Paraglide value is missing, invalid, or still equal to the base locale.

Fixes #1253.

## Validation

- `pnpm --dir desktop test` — 4 tests passed
- `pnpm --dir desktop build` — production build passed
- `git diff --check` — passed
