### PR TITLE
fix: summarization not starting after direct recording

### DIFF
--- a/desktop/src/pages/home/hooks/use-summarization.ts
+++ b/desktop/src/pages/home/hooks/use-summarization.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { m } from '~/paraglide/messages.js'
 import { toast } from 'sonner'
 import { CONFIG_KEYS } from '~/lib/config-keys'
@@ -9,18 +9,18 @@ import { usePreferenceProvider } from '~/providers/preference'
 
 export function useSummarization() {
 	const preference = usePreferenceProvider()
-	const [llm, setLlm] = useState<Llm | null>(null)
 	const [segments, setSegments] = useState<transcript.Segment[] | null>(null)
 	const [summarizing, setSummarizing] = useState(false)
 	const [transcriptTab, setTranscriptTab] = usePersisted<'transcript' | 'summary'>(CONFIG_KEYS.transcriptTab, 'transcript')
 
-	useEffect(() => {
+	// Built during render rather than in an effect: a recording that finishes fast could call
+	// summarize() before the effect had set the client, and the run was dropped in silence (#983).
+	const llm = useMemo<Llm>(() => {
 		const config = preference.llmConfig
-		setLlm(config.platform === 'ollama' ? new Ollama(config) : config.platform === 'openai' ? new OpenAICompatible(config) : new Claude(config))
+		return config.platform === 'ollama' ? new Ollama(config) : config.platform === 'openai' ? new OpenAICompatible(config) : new Claude(config)
 	}, [preference.llmConfig])
 
 	async function summarize(source: transcript.Segment[], prompt: string, showSummary = false) {
-		if (!llm) return
 		setSummarizing(true)
 		try {
 			const question = prompt.replace('%s', transcript.asText(source, m.speakerPrefix()))


### PR DESCRIPTION
## Summary

Fixes #983.

`useSummarization`'s `llm` client was initialized asynchronously via
`useState(null)` + `useEffect`. When `summarize()` runs right after a direct
recording (transcription can complete very quickly), it can execute before
the effect has had a chance to set `llm`, hitting the `if (!llm) return`
guard and silently no-op'ing — no error, no toast, nothing in the logs.

This matches the reports in #983 exactly: manually pressing the
"Transcribe" button on an existing file works (by then `llm` has long since
been set), but the direct record → auto-transcribe → auto-summarize flow
does not.

## Fix

Build `llm` synchronously with `useMemo` instead of `useState` + `useEffect`,
so it's never `null` after mount and there's no initialization race window.

## Testing

- Verified with `tsc --noEmit` that the change type-checks cleanly.
- Reasoned through both call sites (`use-transcription.ts`'s direct-record
  path via `view-model.ts`, and the manual file-transcribe path) — both now
  go through the same synchronously-available `llm`.
- I wasn't able to build/run the full Tauri app in my environment to do a
  live end-to-end repro, so it'd be good if someone who can reproduce #983
  locally can confirm this resolves it for them too.