### PR TITLE
fix: match media extensions case-insensitively

### DIFF
--- a/desktop/src-tauri/src/cmd/files.rs
+++ b/desktop/src-tauri/src/cmd/files.rs
@@ -16,13 +16,9 @@ pub async fn glob_files(folder: String, patterns: Vec<String>, recursive: bool) 
     match glob::glob(&search_pattern) {
         Ok(paths) => {
             for entry in paths.filter_map(Result::ok) {
-                if entry.is_file() {
-                    if let Some(file_name) = entry.file_name().and_then(|n| n.to_str()) {
-                        if patterns.iter().any(|p| file_name.ends_with(p)) {
-                            if let Ok(path_str) = entry.into_os_string().into_string() {
-                                files.push(path_str);
-                            }
-                        }
+                if entry.is_file() && has_matching_extension(&entry, &patterns) {
+                    if let Ok(path_str) = entry.into_os_string().into_string() {
+                        files.push(path_str);
                     }
                 }
             }
@@ -33,6 +29,18 @@ pub async fn glob_files(folder: String, patterns: Vec<String>, recursive: bool) 
     }
 
     files
+}
+
+/// Recorders and phones write `.MP3` and `.MOV`, so the extension is matched without regard to
+/// case — otherwise those files vanish from every folder scan. Patterns may carry a leading dot.
+fn has_matching_extension(path: &Path, patterns: &[String]) -> bool {
+    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+        return false;
+    };
+
+    patterns
+        .iter()
+        .any(|pattern| pattern.trim_start_matches('.').eq_ignore_ascii_case(extension))
 }
 
 #[tauri::command]
@@ -180,4 +188,25 @@ fn macos_open_panel(extensions: &[String]) -> Option<Vec<String>> {
         }
     }
     Some(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_matching_extension;
+    use std::path::Path;
+
+    #[test]
+    fn matches_the_extension_whatever_its_case() {
+        let patterns = vec!["mp3".to_string(), "mov".to_string()];
+        assert!(has_matching_extension(Path::new("/tmp/interview.mp3"), &patterns));
+        assert!(has_matching_extension(Path::new("/tmp/interview.MP3"), &patterns));
+        assert!(has_matching_extension(Path::new("/tmp/call 17.8.2026.MOV"), &patterns));
+    }
+
+    #[test]
+    fn ignores_names_that_only_end_with_the_pattern() {
+        let patterns = vec!["mp3".to_string()];
+        assert!(!has_matching_extension(Path::new("/tmp/notesmp3"), &patterns));
+        assert!(!has_matching_extension(Path::new("/tmp/notes.pdf"), &patterns));
+    }
 }

--- a/desktop/src/lib/media.test.ts
+++ b/desktop/src/lib/media.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { validPath } from './media'
+
+describe('validPath', () => {
+	it('accepts a media extension whatever its case', () => {
+		expect(validPath('/tmp/interview.mp3')).toBe(true)
+		expect(validPath('/tmp/interview.MP3')).toBe(true)
+		expect(validPath('C:\\Users\\me\\call 17.8.2026.MOV')).toBe(true)
+	})
+
+	it('rejects anything else, including a name that merely ends with an extension', () => {
+		expect(validPath('/tmp/notes.pdf')).toBe(false)
+		expect(validPath('/tmp/notesmp3')).toBe(false)
+		expect(validPath('/tmp/recording')).toBe(false)
+	})
+})

--- a/desktop/src/lib/media.ts
+++ b/desktop/src/lib/media.ts
@@ -1,11 +1,18 @@
 import * as config from './config'
 
+const mediaExtensions = [...config.videoExtensions, ...config.audioExtensions]
+
+/**
+ * Whether `path` is a media file we can transcribe. The extension is compared without regard to
+ * case: recorders and phones write `.MP3` and `.MOV`, and those were being rejected silently.
+ */
 export function validPath(path: string) {
-	if (config.videoExtensions.some((ext) => path.endsWith(ext))) {
-		return true
+	const separator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+	const name = path.slice(separator + 1)
+	const dot = name.lastIndexOf('.')
+	if (dot < 1) {
+		return false
 	}
-	if (config.audioExtensions.some((ext) => path.endsWith(ext))) {
-		return true
-	}
-	return false
+
+	return mediaExtensions.includes(name.slice(dot + 1).toLowerCase())
 }


### PR DESCRIPTION
## The problem

A folder of `.MP3` recordings reports **`Files: 0`**, and selecting one through the file dialog silently does nothing.

Both code paths compare the extension case-sensitively against the lowercase lists in `config.ts`:

- `desktop/src-tauri/src/cmd/files.rs` — `patterns.iter().any(|p| file_name.ends_with(p))`; Rust's `str::ends_with` is case-sensitive
- `desktop/src/lib/media.ts` — `path.endsWith(ext)`, no case folding

So `"Appel 17.8.2026.MP3".ends_with("mp3")` is `false`, and the file is dropped without a message.

The single-file path is the more confusing of the two: Windows file dialogs filter case-insensitively, so the dialog **offers** the uppercase file, the user picks it, and `validPath` then discards it with no feedback at all.

Uppercase extensions are not exotic — plenty of voice recorders, phones and dashcams write `.MP3` and `.MOV` by default. In the folder that prompted this, 7 of 9 media files were invisible to Vibe.

## Steps to reproduce

1. Put `recording.MP3` in a folder (uppercase extension, any valid mp3)
2. Home → folder mode → select that folder
3. `Files: 0`

Renaming it to `recording.mp3` makes it appear.

Worth noting the engine is entirely fine with it — `sona transcribe <model> recording.MP3` works. The files are only lost in the UI's filter.

## The change

Both sides now compare the real extension with case folding.

Matching on the extension rather than a trailing substring also fixes a smaller false positive: a file merely *named* `notesmp3`, with no extension at all, used to satisfy `ends_with("mp3")` and be treated as media.

Rust patterns are accepted with or without a leading dot, so callers passing `".mp3"` keep working.

Adds unit tests on both sides, including the uppercase regression, a Windows path whose stem contains dots (`call 17.8.2026.MP3`), and the `notesmp3` false positive.

## Verification

- `cargo fmt --manifest-path Cargo.toml --all -- --check` — clean
- `clippy-driver --test -D warnings` on the new helper and its tests — clean
- The TypeScript matching logic was executed against all the test cases above — all pass

I could not run `cargo clippy --all-targets` over the whole crate or execute the Rust tests locally: this machine has no MSVC linker, so nothing links. The helper and its test module were type-checked and linted in isolation instead. CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
