### PR TITLE
Settings live in an editable JSON file, and number fields you can actually use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1632,6 +1632,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futf"
@@ -2355,7 +2364,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2541,6 +2550,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2764,6 +2793,26 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -3090,6 +3139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3238,6 +3288,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,12 +3320,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3302,7 +3379,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3812,7 +3889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4802,7 +4879,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4860,7 +4937,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6130,7 +6207,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6649,7 +6726,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6819,6 +6896,7 @@ dependencies = [
  "hound",
  "libc",
  "libc-stdhandle",
+ "notify",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -7280,7 +7358,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -56,6 +56,8 @@ tracing = { version = "0.1.44", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 glob = "0.3.3"
+# Watch app_config.json for edits made outside the app
+notify = "8"
 
 chrono = "0.4.43"
 crash-handler = "0.7.0"

--- a/desktop/src-tauri/src/cmd/config.rs
+++ b/desktop/src-tauri/src/cmd/config.rs
@@ -1,0 +1,44 @@
+use crate::config::STORE_FILENAME;
+use eyre::{Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use tauri::Manager;
+
+/// Absolute path of `app_config.json`, so the UI (and agents told where to look) can find it.
+#[tauri::command]
+pub fn get_config_path(app_handle: tauri::AppHandle) -> Result<PathBuf> {
+    Ok(app_handle.path().app_config_dir()?.join(STORE_FILENAME))
+}
+
+/// Write the whole config file in a way that never leaves a truncated file behind.
+///
+/// `tauri-plugin-store` saves with a plain `fs::write`, which truncates first: a crash or an
+/// external writer reading mid-save sees half a file. Writing to a sibling temp file, fsyncing it
+/// and renaming over the target makes the swap atomic for any reader (same directory, so the
+/// rename never crosses a filesystem boundary).
+#[tauri::command]
+pub fn write_config_atomically(app_handle: tauri::AppHandle, contents: String) -> Result<()> {
+    // Reject invalid JSON here rather than letting the store fail to parse it on next load.
+    serde_json::from_str::<serde_json::Value>(&contents).context("config contents are not valid JSON")?;
+
+    let config_dir = app_handle.path().app_config_dir()?;
+    fs::create_dir_all(&config_dir).context("create app config directory")?;
+    let path = config_dir.join(STORE_FILENAME);
+    let tmp_path = config_dir.join(format!("{STORE_FILENAME}.tmp"));
+
+    {
+        let mut file = fs::File::create(&tmp_path).context("create temporary config file")?;
+        file.write_all(contents.as_bytes()).context("write temporary config file")?;
+        // fsync before the rename, otherwise the rename can land while the data is still in cache.
+        file.sync_all().context("sync temporary config file")?;
+    }
+
+    fs::rename(&tmp_path, &path).context("rename temporary config file over the config file")?;
+    tracing::debug!("wrote config atomically to {}", path.display());
+
+    // Keep the plugin's in-memory cache in sync with what we just put on disk, so a later
+    // `store.save()` cannot resurrect stale values on top of this write.
+    crate::config_watcher::sync_store_from_disk(&app_handle)?;
+    Ok(())
+}

--- a/desktop/src-tauri/src/cmd/mod.rs
+++ b/desktop/src-tauri/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 pub mod app;
 pub mod audio;
+pub mod config;
 pub mod download;
 pub mod files;
 pub mod permissions;

--- a/desktop/src-tauri/src/config_watcher.rs
+++ b/desktop/src-tauri/src/config_watcher.rs
@@ -1,0 +1,111 @@
+//! Watches `app_config.json` so edits made outside the app (by a person or an agent) take effect
+//! immediately instead of on next launch. `tauri-plugin-store` never re-reads the file on its own.
+
+use crate::config::STORE_FILENAME;
+use eyre::{eyre, Result};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use serde_json::{Map, Value};
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_store::StoreExt;
+
+/// Event emitted after the store was refreshed from an external edit. The plugin's own
+/// `store://change` events are not emitted by `reload*()`, so the frontend needs this one.
+pub const CONFIG_CHANGED_EVENT: &str = "config-changed";
+
+/// Editors and agents write in bursts (truncate + write, or write + rename); coalesce them.
+const DEBOUNCE: Duration = Duration::from_millis(200);
+
+/// Holds the watcher alive in Tauri state; dropping it stops the watch.
+pub struct ConfigWatcher {
+    _watcher: RecommendedWatcher,
+}
+
+/// Reload the store from disk and tell the webviews, but only if disk really differs from what the
+/// app already holds.
+///
+/// This doubles as the self-write filter: every write the app performs (our atomic command, or the
+/// plugin's own `save()`) leaves disk equal to the in-memory cache, so the resulting filesystem
+/// event compares equal here and is dropped. Comparing state rather than tracking a "we are
+/// writing" flag needs no coordination with the plugin and cannot get stuck if a write panics.
+fn reload_if_externally_changed(app: &AppHandle, path: &Path) -> Result<()> {
+    let contents = std::fs::read_to_string(path)?;
+    let on_disk: Map<String, Value> = serde_json::from_str(&contents)?;
+
+    let store = app.store(STORE_FILENAME).map_err(|e| eyre!("{:?}", e))?;
+    let in_memory: Map<String, Value> = store.entries().into_iter().collect();
+    if on_disk == in_memory {
+        return Ok(());
+    }
+
+    // `reload()` merges disk into the cache, which would keep keys the external editor deleted.
+    // The store is created without defaults, so ignoring defaults simply mirrors the file.
+    store.reload_ignore_defaults().map_err(|e| eyre!("{:?}", e))?;
+    tracing::info!("reloaded {} after an external edit", STORE_FILENAME);
+
+    app.emit(CONFIG_CHANGED_EVENT, Value::Object(on_disk))?;
+    Ok(())
+}
+
+/// Reload the store from disk unconditionally (used right after the app writes the file itself).
+pub fn sync_store_from_disk(app: &AppHandle) -> Result<()> {
+    let store = app.store(STORE_FILENAME).map_err(|e| eyre!("{:?}", e))?;
+    store.reload_ignore_defaults().map_err(|e| eyre!("{:?}", e))?;
+    Ok(())
+}
+
+/// Start watching the config file. The returned watcher must be kept alive.
+pub fn start(app: &AppHandle) -> Result<ConfigWatcher> {
+    let config_dir = app.path().app_config_dir()?;
+    let config_path = config_dir.join(STORE_FILENAME);
+
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        // The receiver is dropped only on shutdown; a send failure then is not worth logging.
+        let _ = tx.send(res);
+    })?;
+
+    // Watch the directory, not the file: an atomic save replaces the file by rename, and a watch
+    // registered on the old inode would stop firing after the first such save.
+    watcher.watch(&config_dir, RecursiveMode::NonRecursive)?;
+
+    let app = app.clone();
+    let watched_path = config_path.clone();
+    std::thread::spawn(move || {
+        while let Ok(first) = rx.recv() {
+            let mut touched = event_touches_config(&first);
+            // Drain the rest of the burst before acting on it.
+            while let Ok(next) = rx.recv_timeout(DEBOUNCE) {
+                touched |= event_touches_config(&next);
+            }
+            if !touched || !watched_path.exists() {
+                continue;
+            }
+            if let Err(error) = reload_if_externally_changed(&app, &watched_path) {
+                // A partially written file is normal mid-burst; the next event settles it.
+                tracing::warn!("could not apply external config change: {:?}", error);
+            }
+        }
+        tracing::debug!("config watcher stopped");
+    });
+
+    tracing::debug!("watching {} for external edits", config_path.display());
+    Ok(ConfigWatcher { _watcher: watcher })
+}
+
+/// Match on the file name rather than the full path: platform backends can report the watched
+/// directory through a resolved/aliased prefix, and the app config dir holds other files too.
+fn event_touches_config(event: &notify::Result<Event>) -> bool {
+    match event {
+        Ok(event) => event
+            .paths
+            .iter()
+            .any(|path| path.file_name().is_some_and(|name| name == STORE_FILENAME)),
+        Err(error) => {
+            tracing::warn!("config watcher error: {:?}", error);
+            false
+        }
+    }
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod cleaner;
 mod cli;
 mod cmd;
 mod config;
+mod config_watcher;
 mod diagnostics;
 mod dictation_indicator;
 mod error;
@@ -86,6 +87,8 @@ async fn main() -> Result<()> {
         .invoke_handler(tauri::generate_handler![
             cmd::download::download_file,
             cmd::app::get_cargo_features,
+            cmd::config::write_config_atomically,
+            cmd::config::get_config_path,
             cmd::transcribe::transcribe,
             cmd::files::glob_files,
             cmd::files::pick_media_paths,

--- a/desktop/src-tauri/src/setup.rs
+++ b/desktop/src-tauri/src/setup.rs
@@ -45,6 +45,16 @@ pub fn setup(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     crate::cleaner::clean_updater_files().log_error();
     tracing::debug!("Vibe App Running");
 
+    // Settings live in app_config.json so a person or an agent can edit it directly; the store
+    // plugin never re-reads the file, so a watcher has to push external edits into it.
+    match crate::config_watcher::start(app.handle()) {
+        // Kept in state so the watcher lives as long as the app.
+        Ok(watcher) => {
+            app.manage(watcher);
+        }
+        Err(error) => tracing::error!("could not start config watcher: {:?}", error),
+    }
+
     // Crash handler
 
     let _handler = crash_handler::CrashHandler::attach(unsafe {

--- a/desktop/src/bootstrap.tsx
+++ b/desktop/src/bootstrap.tsx
@@ -1,8 +1,18 @@
 import ReactDOM from 'react-dom/client'
 import './globals.css'
+import { loadConfigStore } from './lib/config-store'
 import { runMigrations } from './lib/migrations'
 import Root from './root'
 
-runMigrations()
+/**
+ * Settings are read synchronously during render, so the config file has to be in memory before the
+ * first paint — otherwise the window opens with the default theme and language and then corrects
+ * itself. Migrations run after the load because they write through the same store.
+ */
+async function start() {
+	await loadConfigStore()
+	runMigrations()
+	ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<Root />)
+}
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<Root />)
+void start()

--- a/desktop/src/components/brand-glyph.tsx
+++ b/desktop/src/components/brand-glyph.tsx
@@ -1,0 +1,36 @@
+import { AudioLines, Boxes } from 'lucide-react'
+import { siNvidia } from 'simple-icons'
+import { cn } from '~/lib/style'
+
+/** OpenAI has no simple-icons entry (trademark policy), so its mark ships with us. */
+export const OPENAI_PATH =
+	'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4066-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.0379-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z'
+
+/** A vendor mark drawn from a 24×24 path, sized like the lucide icons beside it. */
+export function BrandGlyph({ path, title, className }: { path: string; title: string; className?: string }) {
+	return (
+		<svg viewBox="0 0 24 24" role="img" aria-label={title} className={cn('h-3.5 w-3.5 shrink-0', className)}>
+			<path d={path} fill="currentColor" />
+		</svg>
+	)
+}
+
+/**
+ * Who made the model, read off its filename. Whisper builds come from OpenAI, Parakeet/Canary/
+ * Nemotron from NVIDIA's NeMo; Silero's VAD has no mark of its own, so it gets a waveform.
+ */
+export function ModelGlyph({ name, className }: { name: string; className?: string }) {
+	const file = name.toLowerCase()
+
+	if (/whisper|ggml-(tiny|base|small|medium|large)|large-v\d|distil/.test(file)) {
+		return <BrandGlyph path={OPENAI_PATH} title="OpenAI Whisper" className={className} />
+	}
+	if (/parakeet|nemotron|canary|nvidia|nemo/.test(file)) {
+		return <BrandGlyph path={siNvidia.path} title={siNvidia.title} className={className} />
+	}
+	if (/silero|vad/.test(file)) {
+		return <AudioLines className={cn('h-3.5 w-3.5 shrink-0', className)} strokeWidth={1.75} />
+	}
+	// Anything the user brought themselves.
+	return <Boxes className={cn('h-3.5 w-3.5 shrink-0', className)} strokeWidth={1.75} />
+}

--- a/desktop/src/components/model-download-prompt.tsx
+++ b/desktop/src/components/model-download-prompt.tsx
@@ -1,17 +1,16 @@
 import { Download, X } from 'lucide-react'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useLocalStorage } from 'usehooks-ts'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { usePersisted } from '~/lib/config-store'
 import { m } from '~/paraglide/messages.js'
 import { usePreferenceProvider } from '~/providers/preference'
 import { Button } from './ui/button'
 
-const DISMISSED_KEY = 'prefs_no_model_prompt_dismissed'
-
 export default function ModelDownloadPrompt() {
 	const navigate = useNavigate()
 	const preference = usePreferenceProvider()
-	const [dismissed, setDismissed] = useLocalStorage(DISMISSED_KEY, false)
+	const [dismissed, setDismissed] = usePersisted(CONFIG_KEYS.modelPromptDismissed, false)
 
 	useEffect(() => {
 		if (preference.modelPath && dismissed) {

--- a/desktop/src/components/number-field.tsx
+++ b/desktop/src/components/number-field.tsx
@@ -1,0 +1,157 @@
+import { Minus, Plus } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '~/lib/style'
+
+/** Holding a step button repeats it — after a pause, then quickly, like a scrollbar arrow. */
+const REPEAT_DELAY_MS = 400
+const REPEAT_INTERVAL_MS = 60
+
+interface NumberFieldProps {
+	value: number
+	onChange: (value: number) => void
+	min?: number
+	max?: number
+	/** How much one press of − / + moves the value. Also the precision the value is rounded to. */
+	step?: number
+	/** Shown after the number, e.g. "min" or "threads". */
+	suffix?: string
+	/**
+	 * Words for the values that don't read as numbers — 0 meaning "never", -1 meaning "automatic".
+	 * Return undefined to show the number itself.
+	 */
+	format?: (value: number) => string | undefined
+	className?: string
+	'aria-label'?: string
+}
+
+function decimalsOf(step: number) {
+	const text = String(step)
+	const dot = text.indexOf('.')
+	return dot === -1 ? 0 : text.length - dot - 1
+}
+
+/**
+ * A number setting you can nudge or type into: one bordered control with − and + on the ends and
+ * the value in the middle. Browser spinners are tiny, hover-only and unlabelled; these are always
+ * visible, repeat when held, stop at the range's ends and never leave the field in a half-typed
+ * state — the draft is only committed (and clamped) when you leave the field or press Enter.
+ */
+export default function NumberField({ value, onChange, min, max, step = 1, suffix, format, className, ...rest }: NumberFieldProps) {
+	const [draft, setDraft] = useState<string | null>(null)
+	const repeat = useRef<{ delay?: number; interval?: number }>({})
+
+	const decimals = decimalsOf(step)
+	const lowerBound = min ?? Number.NEGATIVE_INFINITY
+	const upperBound = max ?? Number.POSITIVE_INFINITY
+
+	function clamp(next: number) {
+		const bounded = Math.min(upperBound, Math.max(lowerBound, next))
+		return Number(bounded.toFixed(decimals))
+	}
+
+	function nudge(direction: 1 | -1) {
+		onChange(clamp(value + direction * step))
+	}
+
+	function stopRepeating() {
+		window.clearTimeout(repeat.current.delay)
+		window.clearInterval(repeat.current.interval)
+		repeat.current = {}
+	}
+
+	function startRepeating(direction: 1 | -1) {
+		nudge(direction)
+		repeat.current.delay = window.setTimeout(() => {
+			repeat.current.interval = window.setInterval(() => nudge(direction), REPEAT_INTERVAL_MS)
+		}, REPEAT_DELAY_MS)
+	}
+
+	useEffect(() => stopRepeating, [])
+
+	function commit() {
+		if (draft === null) return
+		const parsed = Number(draft.replace(',', '.'))
+		setDraft(null)
+		// Anything unreadable leaves the setting where it was rather than snapping it to zero.
+		if (draft.trim() !== '' && Number.isFinite(parsed)) onChange(clamp(parsed))
+	}
+
+	const atMin = value <= lowerBound
+	const atMax = value >= upperBound
+	const display = draft ?? format?.(value) ?? String(value)
+
+	const stepButton =
+		'flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30'
+
+	return (
+		<div
+			dir="ltr"
+			className={cn('flex h-9 items-center gap-0.5 rounded-full border border-border/70 bg-transparent px-1 transition-colors duration-150', className)}>
+			<button
+				type="button"
+				aria-hidden
+				tabIndex={-1}
+				disabled={atMin}
+				onPointerDown={() => startRepeating(-1)}
+				onPointerUp={stopRepeating}
+				onPointerLeave={stopRepeating}
+				className={stepButton}>
+				<Minus className="h-3.5 w-3.5" />
+			</button>
+
+			<span className="flex min-w-0 flex-1 items-baseline justify-center gap-1">
+				<input
+					inputMode="decimal"
+					autoComplete="off"
+					role="spinbutton"
+					aria-valuenow={value}
+					aria-valuemin={min}
+					aria-valuemax={max}
+					aria-label={rest['aria-label']}
+					value={display}
+					onFocus={(event) => {
+						setDraft(String(value))
+						event.currentTarget.select()
+					}}
+					onChange={(event) => setDraft(event.target.value)}
+					onBlur={commit}
+					onKeyDown={(event) => {
+						if (event.key === 'Enter') {
+							event.preventDefault()
+							commit()
+							event.currentTarget.blur()
+						} else if (event.key === 'Escape') {
+							event.preventDefault()
+							setDraft(null)
+							event.currentTarget.blur()
+						} else if (event.key === 'ArrowUp') {
+							event.preventDefault()
+							setDraft(null)
+							nudge(1)
+						} else if (event.key === 'ArrowDown') {
+							event.preventDefault()
+							setDraft(null)
+							nudge(-1)
+						}
+					}}
+					// Sized to its content so the control stays compact whatever the number is.
+					style={{ width: `${Math.max(2, display.length)}ch` }}
+					className="bg-transparent text-center text-sm tabular-nums text-foreground outline-none"
+				/>
+				{suffix && <span className="shrink-0 text-xs text-muted-foreground">{suffix}</span>}
+			</span>
+
+			<button
+				type="button"
+				aria-hidden
+				tabIndex={-1}
+				disabled={atMax}
+				onPointerDown={() => startRepeating(1)}
+				onPointerUp={stopRepeating}
+				onPointerLeave={stopRepeating}
+				className={stepButton}>
+				<Plus className="h-3.5 w-3.5" />
+			</button>
+		</div>
+	)
+}

--- a/desktop/src/lib/config-keys.ts
+++ b/desktop/src/lib/config-keys.ts
@@ -1,0 +1,112 @@
+/**
+ * Every setting Vibe persists, as one flat, human-readable key.
+ *
+ * The values are the field names inside `app_config.json`: the file is meant to be read and edited
+ * by hand (and by agents), so the names describe the setting rather than the code that reads it.
+ * Never rename a released key without adding a migration — see `lib/migrations`.
+ */
+export const CONFIG_KEYS = {
+	// General
+	displayLanguage: 'general.displayLanguage',
+	theme: 'general.theme',
+	firstRun: 'general.firstRun',
+	skippedSetup: 'general.skippedSetup',
+	analyticsEnabled: 'analytics_enabled',
+
+	// Model
+	modelPath: 'model.path',
+	modelDisplayNames: 'model.displayNames',
+	gpuDevice: 'model.gpuDevice',
+	unloadTimeoutMinutes: 'model.unloadTimeoutMinutes',
+	modelPromptDismissed: 'model.downloadPromptDismissed',
+
+	// Transcription
+	modelOptions: 'transcription.modelOptions',
+	ffmpegOptions: 'transcription.ffmpegOptions',
+	advancedOptions: 'transcription.advancedOptions',
+	recentLanguages: 'transcription.recentLanguages',
+	diarizeEnabled: 'transcription.recognizeSpeakers',
+	stableTimestampsEnabled: 'transcription.stableTimestamps',
+	soundOnFinish: 'transcription.soundOnFinish',
+	focusOnFinish: 'transcription.focusOnFinish',
+	saveTranscripts: 'transcription.saveTranscripts',
+
+	// Recording
+	storeRecordInDocuments: 'recording.storeInDocuments',
+	customRecordingPath: 'recording.customPath',
+	inputDeviceId: 'recording.inputDeviceId',
+	outputDeviceId: 'recording.outputDeviceId',
+
+	// Reading the transcript
+	textAreaDirection: 'transcript.textDirection',
+	textSize: 'transcript.textSize',
+	showTimestamps: 'transcript.showTimestamps',
+	showSpeakers: 'transcript.showSpeakers',
+	textFormatTranscript: 'transcript.exportFormat',
+	textFormatSummary: 'transcript.summaryExportFormat',
+	transcriptTab: 'transcript.tab',
+
+	// Global dictation
+	hotkeyEnabled: 'dictation.enabled',
+	hotkeyShortcut: 'dictation.shortcut',
+	hotkeyOutputMode: 'dictation.outputMode',
+	hotkeyActivationMode: 'dictation.activationMode',
+	hotkeyNormalizeOutput: 'dictation.normalizeOutput',
+
+	// AI summaries
+	llmConfig: 'summarize.llm',
+
+	// Tools
+	ytDlpVersion: 'tools.ytDlpVersion',
+	shouldCheckYtDlpVersion: 'tools.checkYtDlpUpdates',
+
+	// UI state that is remembered but not really a setting
+	homeTab: 'ui.homeTab',
+} as const
+
+export type ConfigKey = (typeof CONFIG_KEYS)[keyof typeof CONFIG_KEYS]
+
+/**
+ * Where each setting used to live in `localStorage`. Used once, by the migration that moves an
+ * existing install into the config file; new code only ever uses `CONFIG_KEYS`.
+ */
+export const LEGACY_LOCAL_STORAGE_KEYS: Record<string, ConfigKey> = {
+	prefs_display_language: CONFIG_KEYS.displayLanguage,
+	prefs_theme: CONFIG_KEYS.theme,
+	prefs_first_localstorage_read: CONFIG_KEYS.firstRun,
+	prefs_skipped_setup: CONFIG_KEYS.skippedSetup,
+	prefs_model_path: CONFIG_KEYS.modelPath,
+	prefs_model_display_names: CONFIG_KEYS.modelDisplayNames,
+	prefs_gpu_device: CONFIG_KEYS.gpuDevice,
+	prefs_unload_timeout_minutes: CONFIG_KEYS.unloadTimeoutMinutes,
+	'vibe:model-download-prompt-dismissed': CONFIG_KEYS.modelPromptDismissed,
+	prefs_modal_args: CONFIG_KEYS.modelOptions,
+	prefs_ffmpeg_options: CONFIG_KEYS.ffmpegOptions,
+	prefs_advanced_transcribe_options: CONFIG_KEYS.advancedOptions,
+	prefs_recent_languages: CONFIG_KEYS.recentLanguages,
+	prefs_diarize_enabled: CONFIG_KEYS.diarizeEnabled,
+	prefs_stable_timestamps_enabled: CONFIG_KEYS.stableTimestampsEnabled,
+	prefs_sound_on_finish: CONFIG_KEYS.soundOnFinish,
+	prefs_focus_on_finish: CONFIG_KEYS.focusOnFinish,
+	prefs_save_transcripts: CONFIG_KEYS.saveTranscripts,
+	prefs_store_record_in_documents: CONFIG_KEYS.storeRecordInDocuments,
+	prefs_custom_recording_path: CONFIG_KEYS.customRecordingPath,
+	prefs_input_device_id: CONFIG_KEYS.inputDeviceId,
+	prefs_output_device_id: CONFIG_KEYS.outputDeviceId,
+	prefs_textarea_direction: CONFIG_KEYS.textAreaDirection,
+	prefs_transcript_text_size: CONFIG_KEYS.textSize,
+	prefs_transcript_show_timestamps: CONFIG_KEYS.showTimestamps,
+	prefs_transcript_show_speakers: CONFIG_KEYS.showSpeakers,
+	prefs_text_format_transcript: CONFIG_KEYS.textFormatTranscript,
+	prefs_text_format_summary: CONFIG_KEYS.textFormatSummary,
+	prefs_transcript_tab: CONFIG_KEYS.transcriptTab,
+	prefs_hotkey_enabled: CONFIG_KEYS.hotkeyEnabled,
+	prefs_hotkey_shortcut: CONFIG_KEYS.hotkeyShortcut,
+	prefs_hotkey_output_mode: CONFIG_KEYS.hotkeyOutputMode,
+	prefs_hotkey_activation_mode: CONFIG_KEYS.hotkeyActivationMode,
+	prefs_hotkey_normalize_output: CONFIG_KEYS.hotkeyNormalizeOutput,
+	prefs_llm_config: CONFIG_KEYS.llmConfig,
+	prefs_ytdlp_version: CONFIG_KEYS.ytDlpVersion,
+	prefs_should_check_ytdlp_version: CONFIG_KEYS.shouldCheckYtDlpVersion,
+	prefs_home_tab: CONFIG_KEYS.homeTab,
+}

--- a/desktop/src/lib/config-store.ts
+++ b/desktop/src/lib/config-store.ts
@@ -1,0 +1,104 @@
+import { listen } from '@tauri-apps/api/event'
+import { load, type Store } from '@tauri-apps/plugin-store'
+import { useCallback, useRef, useSyncExternalStore } from 'react'
+import * as config from '~/lib/config'
+
+/**
+ * Settings live in `app_config.json` next to the app's other data, not in `localStorage`: the file
+ * survives a cleared webview, every window sees the same values, and a person (or an agent) can
+ * open it and edit it.
+ *
+ * Reads have to be synchronous for React, so the whole file is pulled into a cache once at boot and
+ * kept fresh by the store's change events — which also cover writes from another window.
+ */
+/**
+ * Emitted by the Rust file watcher after someone edited `app_config.json` outside the app. The
+ * store's own reload is silent (it only emits on set/delete/clear), so this carries the whole file.
+ */
+const CONFIG_CHANGED_EVENT = 'config-changed'
+
+let store: Store | null = null
+const cache = new Map<string, unknown>()
+const listeners = new Map<string, Set<() => void>>()
+
+function notify(key: string) {
+	for (const listener of listeners.get(key) ?? []) listener()
+}
+
+/** Must finish before the first render, or every setting would flash its default. */
+export async function loadConfigStore() {
+	try {
+		// autoSave batches the disk writes: a slider being dragged costs one save, not fifty.
+		store = await load(config.storeFilename, { autoSave: 300, defaults: {} })
+		for (const [key, value] of await store.entries()) cache.set(key, value)
+		await store.onChange((key, value) => {
+			if (value === undefined) cache.delete(key)
+			else cache.set(key, value)
+			notify(key)
+		})
+		await listen<Record<string, unknown>>(CONFIG_CHANGED_EVENT, ({ payload }) => applyExternalConfig(payload))
+	} catch (error) {
+		// A broken or unreadable file must not stop the app: every setting falls back to its default.
+		console.error('failed to load the config store:', error)
+	}
+}
+
+/** Replace the cache with a config file edited from outside, waking only the keys that moved. */
+function applyExternalConfig(next: Record<string, unknown> | null) {
+	const incoming = next ?? {}
+	const keys = new Set([...cache.keys(), ...Object.keys(incoming)])
+	for (const key of keys) {
+		const before = cache.get(key)
+		const after = incoming[key]
+		if (JSON.stringify(before) === JSON.stringify(after)) continue
+		if (key in incoming) cache.set(key, after)
+		else cache.delete(key)
+		notify(key)
+	}
+}
+
+export function readConfig<T>(key: string, fallback: T): T {
+	return cache.has(key) ? (cache.get(key) as T) : fallback
+}
+
+export function writeConfig<T>(key: string, value: T) {
+	cache.set(key, value)
+	notify(key)
+	// Fire and forget, like the old localStorage write: the screen must not wait on the disk.
+	void store?.set(key, value)
+}
+
+function subscribe(key: string, listener: () => void) {
+	const existing = listeners.get(key) ?? new Set<() => void>()
+	existing.add(listener)
+	listeners.set(key, existing)
+	return () => {
+		existing.delete(listener)
+		if (existing.size === 0) listeners.delete(key)
+	}
+}
+
+/**
+ * Drop-in replacement for `useLocalStorage`: same tuple, same functional-update setter, but the
+ * value is stored in the config file and shared across windows.
+ */
+export function usePersisted<T>(key: string, initial: T): [T, (value: T | ((previous: T) => T)) => void] {
+	// Callers pass object literals as defaults; pinning the first one keeps the snapshot identity
+	// stable while the key is missing, which useSyncExternalStore requires.
+	const fallback = useRef(initial)
+
+	const value = useSyncExternalStore(
+		useCallback((listener: () => void) => subscribe(key, listener), [key]),
+		useCallback(() => readConfig(key, fallback.current), [key]),
+	)
+
+	const setValue = useCallback(
+		(next: T | ((previous: T) => T)) => {
+			const resolved = typeof next === 'function' ? (next as (previous: T) => T)(readConfig(key, fallback.current)) : next
+			writeConfig(key, resolved)
+		},
+		[key],
+	)
+
+	return [value, setValue]
+}

--- a/desktop/src/lib/config.ts
+++ b/desktop/src/lib/config.ts
@@ -1,4 +1,5 @@
 export const aboutURL = 'https://thewh1teagle.github.io/vibe/'
+export const repoURL = 'https://github.com/thewh1teagle/vibe'
 export const updateVersionURL = 'https://github.com/thewh1teagle/vibe/releases/latest'
 export const modelsDocURL = 'https://thewh1teagle.github.io/vibe/docs#models'
 export const discordURL = 'https://discord.gg/EcxWSstQN8'

--- a/desktop/src/lib/logs.ts
+++ b/desktop/src/lib/logs.ts
@@ -1,6 +1,8 @@
 import { app } from '@tauri-apps/api'
 import { invoke } from '@tauri-apps/api/core'
 import { ls } from './fs'
+import { CONFIG_KEYS } from './config-keys'
+import { readConfig } from './config-store'
 import * as os from '@tauri-apps/plugin-os'
 
 export async function getPrettyVersion() {
@@ -29,7 +31,7 @@ export async function getAppInfo() {
 		.filter((e) => e.name?.endsWith('.bin'))
 		.map((e) => e.name)
 		.join(', ')
-	const defaultModel = localStorage.getItem('prefs_model_path')?.split('/')?.pop() ?? 'Not Found'
+	const defaultModel = readConfig<string | null>(CONFIG_KEYS.modelPath, null)?.split('/')?.pop() ?? 'Not Found'
 	const cargoFeatures = (await invoke<string[]>('get_cargo_features')) || 'n/a'
 	return [
 		`App Version: ${appVersion}`,

--- a/desktop/src/lib/migrations/index.ts
+++ b/desktop/src/lib/migrations/index.ts
@@ -1,4 +1,5 @@
 import { migrateLegacyLocale } from './migrate-legacy-locale'
+import { migratePrefsToConfig } from './migrate-prefs-to-config'
 
 /**
  * Local storage migration versioning
@@ -11,8 +12,14 @@ import { migrateLegacyLocale } from './migrate-legacy-locale'
  * The stored version advances only after a migration succeeds, so keep each
  * migration idempotent to make retries safe.
  */
-const migrations = [{ version: 1, run: migrateLegacyLocale }]
+const migrations = [
+	{ version: 1, run: migrateLegacyLocale },
+	{ version: 2, run: migratePrefsToConfig },
+]
 const MIGRATION_VERSION_KEY = 'vibe:migration-version'
+
+/** The version a fully migrated install sits at — the last entry above. */
+export const LATEST_MIGRATION_VERSION = migrations[migrations.length - 1].version
 
 function readMigrationVersion() {
 	const version = Number(localStorage.getItem(MIGRATION_VERSION_KEY) ?? 0)

--- a/desktop/src/lib/migrations/migrate-prefs-to-config.ts
+++ b/desktop/src/lib/migrations/migrate-prefs-to-config.ts
@@ -1,0 +1,23 @@
+import { LEGACY_LOCAL_STORAGE_KEYS } from '~/lib/config-keys'
+import { writeConfig, readConfig } from '~/lib/config-store'
+
+/**
+ * Move every setting out of `localStorage` and into `app_config.json`.
+ *
+ * `useLocalStorage` stored JSON, so each value is parsed before it is written; anything unreadable
+ * is skipped rather than carried over broken. The old entries are left in place — a user who
+ * downgrades keeps their settings, and the migration only runs once anyway.
+ */
+export function migratePrefsToConfig() {
+	for (const [legacyKey, configKey] of Object.entries(LEGACY_LOCAL_STORAGE_KEYS)) {
+		const raw = localStorage.getItem(legacyKey)
+		if (raw === null) continue
+		// Never overwrite a value the config file already holds.
+		if (readConfig(configKey, undefined) !== undefined) continue
+		try {
+			writeConfig(configKey, JSON.parse(raw))
+		} catch {
+			console.warn('skipping unreadable setting during config migration:', legacyKey)
+		}
+	}
+}

--- a/desktop/src/lib/migrations/migrations.test.ts
+++ b/desktop/src/lib/migrations/migrations.test.ts
@@ -2,7 +2,9 @@
 
 import { beforeEach, describe, expect, it } from 'vitest'
 import { localStorageKey } from '~/paraglide/runtime.js'
-import { runMigrations } from '.'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { readConfig } from '~/lib/config-store'
+import { LATEST_MIGRATION_VERSION, runMigrations } from '.'
 
 describe('local storage migrations', () => {
 	beforeEach(() => {
@@ -16,7 +18,7 @@ describe('local storage migrations', () => {
 		runMigrations()
 
 		expect(localStorage.getItem(localStorageKey)).toBe('fr-FR')
-		expect(localStorage.getItem('vibe:migration-version')).toBe('1')
+		expect(localStorage.getItem('vibe:migration-version')).toBe(String(LATEST_MIGRATION_VERSION))
 
 		localStorage.setItem('prefs_display_language', JSON.stringify('he-IL'))
 		runMigrations()
@@ -31,6 +33,19 @@ describe('local storage migrations', () => {
 		runMigrations()
 
 		expect(localStorage.getItem(localStorageKey)).toBe('he-IL')
-		expect(localStorage.getItem('vibe:migration-version')).toBe('1')
+		expect(localStorage.getItem('vibe:migration-version')).toBe(String(LATEST_MIGRATION_VERSION))
+	})
+
+	it('copies settings out of local storage into the config file', () => {
+		localStorage.setItem('prefs_theme', JSON.stringify('dark'))
+		localStorage.setItem('prefs_hotkey_shortcut', JSON.stringify('Alt+Space'))
+		// Unparseable leftovers are skipped rather than carried over broken.
+		localStorage.setItem('prefs_save_transcripts', '{oops')
+
+		runMigrations()
+
+		expect(readConfig(CONFIG_KEYS.theme, null)).toBe('dark')
+		expect(readConfig(CONFIG_KEYS.hotkeyShortcut, null)).toBe('Alt+Space')
+		expect(readConfig(CONFIG_KEYS.saveTranscripts, 'untouched')).toBe('untouched')
 	})
 })

--- a/desktop/src/pages/home/hooks/use-recording.ts
+++ b/desktop/src/pages/home/hooks/use-recording.ts
@@ -1,8 +1,9 @@
 import { emit } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
 import { type SetStateAction, useContext, useEffect, useState } from 'react'
-import { useLocalStorage } from 'usehooks-ts'
 import type { AudioDevice } from '~/lib/audio'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { usePersisted } from '~/lib/config-store'
 import { startKeepAwake, stopKeepAwake } from '~/lib/keep-awake'
 import { ensureSystemAudioPermission } from '~/lib/permissions'
 import { ErrorModalContext } from '~/providers/error-modal'
@@ -12,8 +13,8 @@ export function useRecording(onBeforeStart: () => void) {
 	const preference = usePreferenceProvider()
 	const { setState: setErrorModal } = useContext(ErrorModalContext)
 	const [devices, setDevices] = useState<AudioDevice[]>([])
-	const [savedInputDeviceId, setSavedInputDeviceId] = useLocalStorage<string | null>('prefs_input_device_id', null)
-	const [savedOutputDeviceId, setSavedOutputDeviceId] = useLocalStorage<string | null>('prefs_output_device_id', null)
+	const [savedInputDeviceId, setSavedInputDeviceId] = usePersisted<string | null>(CONFIG_KEYS.inputDeviceId, null)
+	const [savedOutputDeviceId, setSavedOutputDeviceId] = usePersisted<string | null>(CONFIG_KEYS.outputDeviceId, null)
 	const [inputDevice, setInputDevice] = useState<AudioDevice | null>(null)
 	const [outputDevice, setOutputDevice] = useState<AudioDevice | null>(null)
 	const [isRecording, setIsRecording] = useState(false)

--- a/desktop/src/pages/home/hooks/use-summarization.ts
+++ b/desktop/src/pages/home/hooks/use-summarization.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { m } from '~/paraglide/messages.js'
 import { toast } from 'sonner'
-import { useLocalStorage } from 'usehooks-ts'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { usePersisted } from '~/lib/config-store'
 import { Claude, type Llm, Ollama, OpenAICompatible } from '~/lib/llm'
 import * as transcript from '~/lib/transcript'
 import { usePreferenceProvider } from '~/providers/preference'
@@ -11,7 +12,7 @@ export function useSummarization() {
 	const [llm, setLlm] = useState<Llm | null>(null)
 	const [segments, setSegments] = useState<transcript.Segment[] | null>(null)
 	const [summarizing, setSummarizing] = useState(false)
-	const [transcriptTab, setTranscriptTab] = useLocalStorage<'transcript' | 'summary'>('prefs_transcript_tab', 'transcript')
+	const [transcriptTab, setTranscriptTab] = usePersisted<'transcript' | 'summary'>(CONFIG_KEYS.transcriptTab, 'transcript')
 
 	useEffect(() => {
 		const config = preference.llmConfig

--- a/desktop/src/pages/main/hooks/use-transcript-view.ts
+++ b/desktop/src/pages/main/hooks/use-transcript-view.ts
@@ -1,4 +1,5 @@
-import { useLocalStorage } from 'usehooks-ts'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { usePersisted } from '~/lib/config-store'
 
 export type TranscriptTextSize = 'sm' | 'md' | 'lg'
 
@@ -16,9 +17,9 @@ export interface TranscriptViewOptions {
 
 /** Reading preferences for the transcript page — they belong to the view, not to a transcription run. */
 export function useTranscriptViewOptions(): TranscriptViewOptions {
-	const [textSize, setTextSize] = useLocalStorage<TranscriptTextSize>('prefs_transcript_text_size', 'md')
-	const [showTimestamps, setShowTimestamps] = useLocalStorage<boolean>('prefs_transcript_show_timestamps', true)
-	const [showSpeakers, setShowSpeakers] = useLocalStorage<boolean>('prefs_transcript_show_speakers', true)
+	const [textSize, setTextSize] = usePersisted<TranscriptTextSize>(CONFIG_KEYS.textSize, 'md')
+	const [showTimestamps, setShowTimestamps] = usePersisted<boolean>(CONFIG_KEYS.showTimestamps, true)
+	const [showSpeakers, setShowSpeakers] = usePersisted<boolean>(CONFIG_KEYS.showSpeakers, true)
 	return { textSize, setTextSize, showTimestamps, setShowTimestamps, showSpeakers, setShowSpeakers }
 }
 

--- a/desktop/src/pages/settings/sections/advanced.tsx
+++ b/desktop/src/pages/settings/sections/advanced.tsx
@@ -2,11 +2,11 @@ import { useContext } from 'react'
 import { m } from '~/paraglide/messages.js'
 import { UpdaterContext, devToolsEnabled } from '~/providers/updater'
 import { Switch } from '~/components/ui/switch'
-import { Input } from '~/components/ui/input'
+import NumberField from '~/components/number-field'
 import { ReactComponent as CopyIcon } from '~/icons/copy.svg'
 import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
 import { ReactComponent as ResetIcon } from '~/icons/reset.svg'
-import { ActionRow, SettingsGroup, SettingsRow, rowControlClass, type SettingsViewModel } from './shared'
+import { ActionRow, SettingsGroup, SettingsRow, type SettingsViewModel } from './shared'
 
 export function AdvancedSection({ vm }: { vm: SettingsViewModel }) {
 	const { fakeUpdate, setFakeUpdate } = useContext(UpdaterContext)
@@ -29,19 +29,16 @@ export function AdvancedSection({ vm }: { vm: SettingsViewModel }) {
 
 			<SettingsGroup title={m.modelMemory()}>
 				<SettingsRow label={m.unloadModelAfterInactivity()} description={`${m.unloadModelAfterInactivityInfo()} ${m.zeroMeansNever()}`}>
-					<Input
-						type="number"
+					<NumberField
+						aria-label={m.unloadModelAfterInactivity()}
+						value={vm.preference.unloadTimeoutMinutes}
 						min={0}
 						max={1440}
-						step={1}
-						value={vm.preference.unloadTimeoutMinutes}
-						onChange={(event) => {
-							const minutes = Number(event.target.value)
-							if (Number.isFinite(minutes)) vm.preference.setUnloadTimeoutMinutes(Math.min(1440, Math.max(0, Math.floor(minutes))))
-						}}
-						className={`w-24 text-end ${rowControlClass}`}
+						step={5}
+						suffix={m.minutes()}
+						format={(minutes) => (minutes === 0 ? m.never() : undefined)}
+						onChange={vm.preference.setUnloadTimeoutMinutes}
 					/>
-					<span className="text-sm text-muted-foreground">{m.minutes()}</span>
 				</SettingsRow>
 			</SettingsGroup>
 

--- a/desktop/src/pages/settings/sections/api.tsx
+++ b/desktop/src/pages/settings/sections/api.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { Bot } from 'lucide-react'
+import { Bot, FileJson } from 'lucide-react'
 import { m } from '~/paraglide/messages.js'
 import { ReactComponent as CopyIcon } from '~/icons/copy.svg'
 import { ReactComponent as LinkIcon } from '~/icons/link.svg'
@@ -32,6 +32,11 @@ export function ApiSection({ vm }: { vm: SettingsViewModel }) {
 				/>
 				<ActionRow label={m.copyCurlExample()} icon={<CopyIcon className="h-4 w-4" />} disabled={!vm.apiBaseUrl} onClick={vm.copyCurlExample} />
 				<ActionRow label={m.copyAgentSkill()} icon={<Bot className="h-4 w-4" />} disabled={!vm.apiBaseUrl} onClick={vm.copyAgentSkill} />
+			</SettingsGroup>
+
+			{/* The settings file is the other half of the agent story: it works whether or not the API runs. */}
+			<SettingsGroup>
+				<ActionRow label={m.configFile()} icon={<FileJson className="h-4 w-4" />} onClick={vm.revealConfigFile} />
 			</SettingsGroup>
 		</div>
 	)

--- a/desktop/src/pages/settings/sections/models.tsx
+++ b/desktop/src/pages/settings/sections/models.tsx
@@ -4,10 +4,12 @@ import { m } from '~/paraglide/messages.js'
 import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
 import { ReactComponent as LinkIcon } from '~/icons/link.svg'
 import { ReactComponent as WrenchIcon } from '~/icons/wrench.svg'
+import NumberField from '~/components/number-field'
 import { Input } from '~/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
 import { ActionRow, IconAction, SettingsGroup, SettingsRow, rowControlClass, type SettingsViewModel } from './shared'
 import { getFriendlyModelName } from '~/lib/model'
+import { ModelGlyph } from '~/components/brand-glyph'
 
 export function ModelsSection({ vm }: { vm: SettingsViewModel }) {
 	const [editingPath, setEditingPath] = useState<string | null>(null)
@@ -61,7 +63,10 @@ export function ModelsSection({ vm }: { vm: SettingsViewModel }) {
 								<SelectContent>
 									{vm.models.map((model, index) => (
 										<SelectItem key={index} value={model.path}>
-											{vm.preference.modelDisplayNames[model.path] ?? getFriendlyModelName(model.name)}
+											<span className="flex items-center gap-2">
+												<ModelGlyph name={model.name} className="text-muted-foreground" />
+												{vm.preference.modelDisplayNames[model.path] ?? getFriendlyModelName(model.name)}
+											</span>
 										</SelectItem>
 									))}
 								</SelectContent>
@@ -98,15 +103,14 @@ export function ModelsSection({ vm }: { vm: SettingsViewModel }) {
 								</SelectContent>
 							</Select>
 						) : (
-							<Input
-								type="number"
-								value={vm.preference.gpuDevice ?? ''}
-								onChange={(e) => {
-									const val = e.target.value
-									vm.preference.setGpuDevice(val === '' ? null : parseInt(val, 10))
-								}}
-								placeholder={m.gpuDevicePlaceholder()}
-								className={`w-40 ${rowControlClass}`}
+							<NumberField
+								aria-label={m.gpuDevice()}
+								value={vm.preference.gpuDevice ?? -1}
+								min={-1}
+								max={16}
+								// Below zero means "no device pinned" — the placeholder the empty field used to show.
+								format={(device) => (device < 0 ? m.auto() : undefined)}
+								onChange={(value) => vm.preference.setGpuDevice(value < 0 ? null : value)}
 							/>
 						)}
 					</SettingsRow>

--- a/desktop/src/pages/settings/sections/summarize.tsx
+++ b/desktop/src/pages/settings/sections/summarize.tsx
@@ -1,11 +1,13 @@
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { Check, Copy, ExternalLink } from 'lucide-react'
 import { siClaude, siOllama } from 'simple-icons'
+import { OPENAI_PATH } from '~/components/brand-glyph'
 import { m } from '~/paraglide/messages.js'
 import { getLocale } from '~/paraglide/runtime.js'
 import { ReactComponent as LinkIcon } from '~/icons/link.svg'
 import * as config from '~/lib/config'
 import { defaultClaudeConfig, defaultOllamaConfig, defaultOpenAIConfig } from '~/lib/llm'
+import NumberField from '~/components/number-field'
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { Switch } from '~/components/ui/switch'
@@ -23,10 +25,6 @@ function LabelWithLink({ label, tooltip, onClick }: { label: string; tooltip: st
 		</span>
 	)
 }
-
-/** OpenAI has no simple-icons entry (trademark policy), so its mark ships with us. */
-const OPENAI_PATH =
-	'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4066-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.0379-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z'
 
 /** Brand marks for the LLM providers, so the picker reads at a glance. */
 const platformIcons: Record<string, { path: string; title: string }> = {
@@ -179,11 +177,13 @@ export function SummarizeSection({ vm }: { vm: SettingsViewModel }) {
 				)}
 
 				<SettingsRow label={m.maxTokens()} description={m.infoMaxTokens()}>
-					<Input
-						type="number"
-						onChange={(e) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, maxTokens: vm.parseIntOr(e.target.value, 1) })}
-						value={vm.preference.llmConfig?.maxTokens}
-						className={`w-24 text-end ${rowControlClass}`}
+					<NumberField
+						aria-label={m.maxTokens()}
+						value={vm.preference.llmConfig?.maxTokens ?? 0}
+						min={256}
+						max={32768}
+						step={256}
+						onChange={(value) => vm.preference.setLlmConfig({ ...vm.preference.llmConfig, maxTokens: value })}
 					/>
 				</SettingsRow>
 

--- a/desktop/src/pages/settings/sections/tuning.tsx
+++ b/desktop/src/pages/settings/sections/tuning.tsx
@@ -1,16 +1,18 @@
 import { message } from '@tauri-apps/plugin-dialog'
 import { RotateCcw, Wand2 } from 'lucide-react'
 import { m } from '~/paraglide/messages.js'
+import NumberField from '~/components/number-field'
 import { Input } from '~/components/ui/input'
 import { Switch } from '~/components/ui/switch'
 import { Textarea } from '~/components/ui/textarea'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
 import { ActionRow, SettingsField, SettingsGroup, SettingsNote, SettingsRow, rowControlClass, type SettingsViewModel } from './shared'
 
-const numberInputClass = 'w-24 text-end'
 const textareaClass = 'min-h-24 max-h-60 w-full resize-none overflow-y-auto rounded-lg bg-muted/40 text-sm'
 
 export function TuningSection({ vm }: { vm: SettingsViewModel }) {
+	// More threads than cores only makes decoding slower, so the stepper stops there.
+	const maxThreads = Math.max(1, navigator.hardwareConcurrency || 8)
 	const promptLength = vm.preference.modelOptions?.init_prompt?.length ?? 0
 	const isGreedy = vm.preference.modelOptions.sampling_strategy === 'greedy'
 
@@ -44,14 +46,15 @@ export function TuningSection({ vm }: { vm: SettingsViewModel }) {
 				</SettingsRow>
 
 				<SettingsRow label={m.maxSentenceLen()} description={m.infoMaxSentenceLen()}>
-					<Input
-						type="number"
-						value={vm.preference.modelOptions.max_sentence_len}
-						onChange={(e) => {
+					<NumberField
+						aria-label={m.maxSentenceLen()}
+						value={vm.preference.modelOptions.max_sentence_len ?? 0}
+						min={0}
+						max={512}
+						onChange={(value) => {
 							if (!vm.preference.modelOptions.word_timestamps) message(m.pleaseEnableWordTimestamps())
-							vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_sentence_len: vm.parseIntOr(e.target.value, 1) })
+							vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_sentence_len: value })
 						}}
-						className={`${numberInputClass} ${rowControlClass}`}
 					/>
 				</SettingsRow>
 
@@ -89,48 +92,50 @@ export function TuningSection({ vm }: { vm: SettingsViewModel }) {
 				</SettingsRow>
 
 				<SettingsRow label={isGreedy ? m.bestOf() : m.beamSize()} description={isGreedy ? m.greedyInfo() : m.beamInfo()}>
-					<Input
-						type="number"
-						step={1}
+					<NumberField
+						aria-label={isGreedy ? m.bestOf() : m.beamSize()}
 						value={isGreedy ? (vm.preference.modelOptions.best_of ?? 5) : (vm.preference.modelOptions.beam_size ?? 5)}
-						onChange={(e) => {
-							const val = vm.parseIntOr(e.target.value, 5)
+						min={1}
+						max={10}
+						onChange={(value) => {
 							if (isGreedy) {
-								vm.preference.setModelOptions({ ...vm.preference.modelOptions, best_of: val })
+								vm.preference.setModelOptions({ ...vm.preference.modelOptions, best_of: value })
 							} else {
-								vm.preference.setModelOptions({ ...vm.preference.modelOptions, beam_size: val })
+								vm.preference.setModelOptions({ ...vm.preference.modelOptions, beam_size: value })
 							}
 						}}
-						className={`${numberInputClass} ${rowControlClass}`}
 					/>
 				</SettingsRow>
 
 				<SettingsRow label={m.temperature()} description={m.infoTemperature()}>
-					<Input
-						type="number"
+					<NumberField
+						aria-label={m.temperature()}
+						value={vm.preference.modelOptions.temperature ?? 0}
+						min={0}
+						max={1}
 						step={0.1}
-						value={vm.preference.modelOptions.temperature}
-						onChange={(e) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, temperature: parseFloat(e.target.value) || 0 })}
-						className={`${numberInputClass} ${rowControlClass}`}
+						onChange={(value) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, temperature: value })}
 					/>
 				</SettingsRow>
 
 				<SettingsRow label={m.maxTextCtx()} description={m.infoMaxTextCtx()}>
-					<Input
-						type="number"
-						step={1}
+					<NumberField
+						aria-label={m.maxTextCtx()}
 						value={vm.preference.modelOptions.max_text_ctx ?? 0}
-						onChange={(e) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_text_ctx: vm.parseIntOr(e.target.value, 0) })}
-						className={`${numberInputClass} ${rowControlClass}`}
+						min={0}
+						max={16384}
+						step={64}
+						onChange={(value) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, max_text_ctx: value })}
 					/>
 				</SettingsRow>
 
 				<SettingsRow label={m.threads()} description={m.infoThreads()}>
-					<Input
-						type="number"
-						value={vm.preference.modelOptions.n_threads}
-						onChange={(e) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, n_threads: vm.parseIntOr(e.target.value, 1) })}
-						className={`${numberInputClass} ${rowControlClass}`}
+					<NumberField
+						aria-label={m.threads()}
+						value={vm.preference.modelOptions.n_threads ?? 1}
+						min={1}
+						max={maxThreads}
+						onChange={(value) => vm.preference.setModelOptions({ ...vm.preference.modelOptions, n_threads: value })}
 					/>
 				</SettingsRow>
 			</SettingsGroup>

--- a/desktop/src/pages/settings/view-model.ts
+++ b/desktop/src/pages/settings/view-model.ts
@@ -333,17 +333,62 @@ export function viewModel() {
 		toast.success('cURL example copied to clipboard')
 	}
 
+	/**
+	 * Sona's `/skill` covers the transcription API only. An agent working on someone's behalf also
+	 * needs to know where Vibe keeps its settings and how to change them safely, so that part is
+	 * appended here rather than baked into the runner.
+	 */
 	async function copyAgentSkill() {
 		if (!apiBaseUrl) return
 		try {
 			const res = await tauriFetch(`${apiBaseUrl}/skill`)
 			const text = await res.text()
-			await clipboard.writeText(text)
+			await clipboard.writeText(`${text.trimEnd()}\n\n${await settingsSkillSection()}`)
 			toast.success(m.agentInstructionsCopied())
 		} catch (error) {
 			console.error(error)
 			toast.error(m.localApiUnreachable())
 		}
+	}
+
+	/** Show the settings file in the file manager, so it can be opened, edited or handed to an agent. */
+	async function revealConfigFile() {
+		try {
+			const path = await invoke<string>('get_config_path')
+			await invoke('open_path', { path })
+		} catch (error) {
+			console.error('failed to reveal the config file:', error)
+			toast.error(String(error))
+		}
+	}
+
+	async function settingsSkillSection() {
+		const path = await invoke<string>('get_config_path').catch(() => null)
+		return [
+			'# Vibe settings',
+			'',
+			'Vibe keeps every setting in one JSON file, safe to read and edit:',
+			'',
+			path ? `  ${path}` : '  (ask the user to open Settings → API & Agents → Config file)',
+			'',
+			'Keys are flat and named after the setting they control, for example:',
+			'',
+			'~~~json',
+			'{',
+			'  "general.theme": "dark",',
+			'  "general.displayLanguage": "en-US",',
+			'  "transcription.recognizeSpeakers": false,',
+			'  "transcription.modelOptions": { "lang": "en", "n_threads": 4 },',
+			'  "dictation.shortcut": "CmdOrCtrl+Shift+Space"',
+			'}',
+			'~~~',
+			'',
+			'Vibe watches the file, so an edit applies immediately — no restart, and no need to ask the',
+			'user to reopen the app. Write the whole file atomically (write a temporary file beside it,',
+			'then rename it over the original) so Vibe can never read a half-written config.',
+			'',
+			`Source and docs: ${config.repoURL}`,
+		].join('\n')
 	}
 
 	async function stopApiServer() {
@@ -413,6 +458,7 @@ export function viewModel() {
 		refreshApiServerStatus,
 		copyCurlExample,
 		copyAgentSkill,
+		revealConfigFile,
 		preference: preference,
 		askAndReset,
 		openModelPath,

--- a/desktop/src/providers/hotkey.tsx
+++ b/desktop/src/providers/hotkey.tsx
@@ -3,8 +3,9 @@ import { invoke } from '@tauri-apps/api/core'
 import { emit, listen } from '@tauri-apps/api/event'
 import { register, unregister, isRegistered } from '@tauri-apps/plugin-global-shortcut'
 import * as clipboard from '@tauri-apps/plugin-clipboard-manager'
-import { useLocalStorage } from 'usehooks-ts'
 import { AudioDevice } from '~/lib/audio'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { usePersisted } from '~/lib/config-store'
 import { Claude, Llm, Ollama, OpenAICompatible } from '~/lib/llm'
 import * as transcript from '~/lib/transcript'
 import { usePreferenceProvider } from '~/providers/preference'
@@ -73,13 +74,13 @@ export function HotkeyProvider({ children }: { children: ReactNode }) {
 	const preference = usePreferenceProvider()
 	const preferenceRef = useRef(preference)
 
-	const [hotkeyEnabled, setHotkeyEnabled] = useLocalStorage('prefs_hotkey_enabled', false)
-	const [hotkeyShortcut, setHotkeyShortcut] = useLocalStorage('prefs_hotkey_shortcut', DEFAULT_HOTKEY_SHORTCUT)
+	const [hotkeyEnabled, setHotkeyEnabled] = usePersisted(CONFIG_KEYS.hotkeyEnabled, false)
+	const [hotkeyShortcut, setHotkeyShortcut] = usePersisted(CONFIG_KEYS.hotkeyShortcut, DEFAULT_HOTKEY_SHORTCUT)
 	const [hotkeyCapturing, setHotkeyCapturingState] = useState(false)
-	const [hotkeyOutputMode, setHotkeyOutputMode] = useLocalStorage<HotkeyOutputMode>('prefs_hotkey_output_mode', 'clipboard')
-	const [hotkeyActivationMode, setHotkeyActivationMode] = useLocalStorage<HotkeyActivationMode>('prefs_hotkey_activation_mode', 'push-to-talk')
+	const [hotkeyOutputMode, setHotkeyOutputMode] = usePersisted<HotkeyOutputMode>(CONFIG_KEYS.hotkeyOutputMode, 'clipboard')
+	const [hotkeyActivationMode, setHotkeyActivationMode] = usePersisted<HotkeyActivationMode>(CONFIG_KEYS.hotkeyActivationMode, 'push-to-talk')
 	const shortcutOperationRef = useRef<Promise<void>>(Promise.resolve())
-	const [hotkeyNormalizeOutput, setHotkeyNormalizeOutput] = useLocalStorage('prefs_hotkey_normalize_output', true)
+	const [hotkeyNormalizeOutput, setHotkeyNormalizeOutput] = usePersisted(CONFIG_KEYS.hotkeyNormalizeOutput, true)
 	const [isHotkeyRecording, setIsHotkeyRecording] = useState(false)
 
 	const isHotkeyRecordingRef = useRef(false)

--- a/desktop/src/providers/preference.tsx
+++ b/desktop/src/providers/preference.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, SetStateAction, createContext, useContext, useEffect, useRef, useState } from 'react'
-import { useLocalStorage } from 'usehooks-ts'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { load } from '@tauri-apps/plugin-store'
 import * as config from '~/lib/config'
+import { CONFIG_KEYS } from '~/lib/config-keys'
+import { usePersisted } from '~/lib/config-store'
 import { TextFormat } from '~/components/format-select'
 import { ModifyState } from '~/lib/types'
 import { supportedLanguages } from '~/lib/i18n'
@@ -152,41 +153,41 @@ const defaultOptions = {
 // Preference provider component
 export function PreferenceProvider({ children }: { children: ReactNode }) {
 	const previousLanguage = useRef(getLocale())
-	const [language, setLanguage] = useLocalStorage('prefs_display_language', defaultDisplayLanguage)
-	const [isFirstRun, setIsFirstRun] = useLocalStorage('prefs_first_localstorage_read', true)
+	const [language, setLanguage] = usePersisted(CONFIG_KEYS.displayLanguage, defaultDisplayLanguage)
+	const [isFirstRun, setIsFirstRun] = usePersisted(CONFIG_KEYS.firstRun, true)
 
-	const [modelPath, setModelPath] = useLocalStorage<string | null>('prefs_model_path', null)
+	const [modelPath, setModelPath] = usePersisted<string | null>(CONFIG_KEYS.modelPath, null)
 	const [modelMetadata, setModelMetadata] = useState<ModelMetadata | null>(null)
-	const [modelDisplayNames, setModelDisplayNames] = useLocalStorage<Record<string, string>>('prefs_model_display_names', {})
-	const [skippedSetup, setSkippedSetup] = useLocalStorage<boolean>('prefs_skipped_setup', false)
-	const [textAreaDirection, setTextAreaDirection] = useLocalStorage<Direction>('prefs_textarea_direction', 'ltr')
-	const [textFormatTranscript, setTextFormatTranscript] = useLocalStorage<TextFormat>('prefs_text_format_transcript', 'pdf')
-	const [textFormatSummary, setTextFormatSummary] = useLocalStorage<TextFormat>('prefs_text_format_summary', 'md')
+	const [modelDisplayNames, setModelDisplayNames] = usePersisted<Record<string, string>>(CONFIG_KEYS.modelDisplayNames, {})
+	const [skippedSetup, setSkippedSetup] = usePersisted<boolean>(CONFIG_KEYS.skippedSetup, false)
+	const [textAreaDirection, setTextAreaDirection] = usePersisted<Direction>(CONFIG_KEYS.textAreaDirection, 'ltr')
+	const [textFormatTranscript, setTextFormatTranscript] = usePersisted<TextFormat>(CONFIG_KEYS.textFormatTranscript, 'pdf')
+	const [textFormatSummary, setTextFormatSummary] = usePersisted<TextFormat>(CONFIG_KEYS.textFormatSummary, 'md')
 	const isMounted = useRef<boolean>(false)
-	const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('prefs_theme', systemIsDark ? 'dark' : 'light')
-	const [homeTab, setHomeTab] = useLocalStorage<HomeTab>('prefs_home_tab', 'file')
+	const [theme, setTheme] = usePersisted<'dark' | 'light'>(CONFIG_KEYS.theme, systemIsDark ? 'dark' : 'light')
+	const [homeTab, setHomeTab] = usePersisted<HomeTab>(CONFIG_KEYS.homeTab, 'file')
 
-	const [soundOnFinish, setSoundOnFinish] = useLocalStorage('prefs_sound_on_finish', defaultOptions.soundOnFinish)
-	const [focusOnFinish, setFocusOnFinish] = useLocalStorage('prefs_focus_on_finish', defaultOptions.focusOnFinish)
-	const [modelOptions, setModelOptions] = useLocalStorage<ModelOptions>('prefs_modal_args', defaultOptions.modelOptions)
-	const [ffmpegOptions, setFfmpegOptions] = useLocalStorage<FfmpegOptions>('prefs_ffmpeg_options', defaultOptions.ffmpegOptions)
-	const [storeRecordInDocuments, setStoreRecordInDocuments] = useLocalStorage('prefs_store_record_in_documents', defaultOptions.storeRecordInDocuments)
-	const [customRecordingPath, setCustomRecordingPath] = useLocalStorage<string | null>('prefs_custom_recording_path', null)
-	const [llmConfig, setLlmConfig] = useLocalStorage<LlmConfig>('prefs_llm_config', defaultOptions.llmConfig)
-	const [ytDlpVersion, setYtDlpVersion] = useLocalStorage<string | null>('prefs_ytdlp_version', null)
-	const [shouldCheckYtDlpVersion, setShouldCheckYtDlpVersion] = useLocalStorage<boolean>('prefs_should_check_ytdlp_version', true)
-	const [advancedTranscribeOptions, setAdvancedTranscribeOptions] = useLocalStorage<AdvancedTranscribeOptions>('prefs_advanced_transcribe_options', {
+	const [soundOnFinish, setSoundOnFinish] = usePersisted(CONFIG_KEYS.soundOnFinish, defaultOptions.soundOnFinish)
+	const [focusOnFinish, setFocusOnFinish] = usePersisted(CONFIG_KEYS.focusOnFinish, defaultOptions.focusOnFinish)
+	const [modelOptions, setModelOptions] = usePersisted<ModelOptions>(CONFIG_KEYS.modelOptions, defaultOptions.modelOptions)
+	const [ffmpegOptions, setFfmpegOptions] = usePersisted<FfmpegOptions>(CONFIG_KEYS.ffmpegOptions, defaultOptions.ffmpegOptions)
+	const [storeRecordInDocuments, setStoreRecordInDocuments] = usePersisted(CONFIG_KEYS.storeRecordInDocuments, defaultOptions.storeRecordInDocuments)
+	const [customRecordingPath, setCustomRecordingPath] = usePersisted<string | null>(CONFIG_KEYS.customRecordingPath, null)
+	const [llmConfig, setLlmConfig] = usePersisted<LlmConfig>(CONFIG_KEYS.llmConfig, defaultOptions.llmConfig)
+	const [ytDlpVersion, setYtDlpVersion] = usePersisted<string | null>(CONFIG_KEYS.ytDlpVersion, null)
+	const [shouldCheckYtDlpVersion, setShouldCheckYtDlpVersion] = usePersisted<boolean>(CONFIG_KEYS.shouldCheckYtDlpVersion, true)
+	const [advancedTranscribeOptions, setAdvancedTranscribeOptions] = usePersisted<AdvancedTranscribeOptions>(CONFIG_KEYS.advancedOptions, {
 		includeSubFolders: false,
 		saveNextToAudioFile: true,
 		skipIfExists: true,
 	})
 
-	const [recentLanguages, setRecentLanguages] = useLocalStorage<{ code: string; ts: number }[]>('prefs_recent_languages', [])
-	const [diarizeEnabled, setDiarizeEnabled] = useLocalStorage<boolean>('prefs_diarize_enabled', false)
-	const [stableTimestampsEnabled, setStableTimestampsEnabled] = useLocalStorage<boolean>('prefs_stable_timestamps_enabled', false)
-	const [gpuDevice, setGpuDevice] = useLocalStorage<number | null>('prefs_gpu_device', null)
-	const [unloadTimeoutMinutes, setUnloadTimeoutMinutes] = useLocalStorage<number>('prefs_unload_timeout_minutes', 5)
-	const [saveTranscripts, setSaveTranscripts] = useLocalStorage<boolean>('prefs_save_transcripts', true)
+	const [recentLanguages, setRecentLanguages] = usePersisted<{ code: string; ts: number }[]>(CONFIG_KEYS.recentLanguages, [])
+	const [diarizeEnabled, setDiarizeEnabled] = usePersisted<boolean>(CONFIG_KEYS.diarizeEnabled, false)
+	const [stableTimestampsEnabled, setStableTimestampsEnabled] = usePersisted<boolean>(CONFIG_KEYS.stableTimestampsEnabled, false)
+	const [gpuDevice, setGpuDevice] = usePersisted<number | null>(CONFIG_KEYS.gpuDevice, null)
+	const [unloadTimeoutMinutes, setUnloadTimeoutMinutes] = usePersisted<number>(CONFIG_KEYS.unloadTimeoutMinutes, 5)
+	const [saveTranscripts, setSaveTranscripts] = usePersisted<boolean>(CONFIG_KEYS.saveTranscripts, true)
 
 	const [analyticsEnabled, setAnalyticsEnabledLocal] = useState(true)
 	useEffect(() => {

--- a/i18n/translations/ca-AD/desktop.json
+++ b/i18n/translations/ca-AD/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Mantén també ⌘, ⌃, ⌥ o ⇧",
 	"changeShortcut": "Canviar la drecera",
 	"inProgress": "En curs",
-	"queued": "A la cua"
+	"queued": "A la cua",
+	"never": "Mai",
+	"configFile": "Fitxer de configuració"
 }

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -438,5 +438,7 @@
 	"textDirection": "Text direction",
 	"pressShortcutKeys": "Press the keys…",
 	"shortcutNeedsModifier": "Hold ⌘, ⌃, ⌥ or ⇧ as well",
-	"changeShortcut": "Change shortcut"
+	"changeShortcut": "Change shortcut",
+	"never": "Never",
+	"configFile": "Config file"
 }

--- a/i18n/translations/es-ES/desktop.json
+++ b/i18n/translations/es-ES/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Mantén también ⌘, ⌃, ⌥ o ⇧",
 	"changeShortcut": "Cambiar el atajo",
 	"inProgress": "En curso",
-	"queued": "En cola"
+	"queued": "En cola",
+	"never": "Nunca",
+	"configFile": "Archivo de configuración"
 }

--- a/i18n/translations/es-MX/desktop.json
+++ b/i18n/translations/es-MX/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Mantén también ⌘, ⌃, ⌥ o ⇧",
 	"changeShortcut": "Cambiar el atajo",
 	"inProgress": "En curso",
-	"queued": "En cola"
+	"queued": "En cola",
+	"never": "Nunca",
+	"configFile": "Archivo de configuración"
 }

--- a/i18n/translations/fr-FR/desktop.json
+++ b/i18n/translations/fr-FR/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Maintenez aussi ⌘, ⌃, ⌥ ou ⇧",
 	"changeShortcut": "Modifier le raccourci",
 	"inProgress": "En cours",
-	"queued": "En attente"
+	"queued": "En attente",
+	"never": "Jamais",
+	"configFile": "Fichier de configuration"
 }

--- a/i18n/translations/he-IL/desktop.json
+++ b/i18n/translations/he-IL/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "החזיקו גם ⌘, ⌃, ⌥ או ⇧",
 	"changeShortcut": "שינוי קיצור הדרך",
 	"inProgress": "בתהליך",
-	"queued": "בתור"
+	"queued": "בתור",
+	"never": "אף פעם",
+	"configFile": "קובץ הגדרות"
 }

--- a/i18n/translations/hi-IN/desktop.json
+++ b/i18n/translations/hi-IN/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "साथ में ⌘, ⌃, ⌥ या ⇧ भी दबाए रखें",
 	"changeShortcut": "शॉर्टकट बदलें",
 	"inProgress": "चल रहा है",
-	"queued": "कतार में"
+	"queued": "कतार में",
+	"never": "कभी नहीं",
+	"configFile": "कॉन्फ़िग फ़ाइल"
 }

--- a/i18n/translations/it-IT/desktop.json
+++ b/i18n/translations/it-IT/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Tieni premuto anche ⌘, ⌃, ⌥ o ⇧",
 	"changeShortcut": "Cambia scorciatoia",
 	"inProgress": "In corso",
-	"queued": "In coda"
+	"queued": "In coda",
+	"never": "Mai",
+	"configFile": "File di configurazione"
 }

--- a/i18n/translations/ja-JP/desktop.json
+++ b/i18n/translations/ja-JP/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "⌘、⌃、⌥、⇧ も一緒に押してください",
 	"changeShortcut": "ショートカットを変更",
 	"inProgress": "処理中",
-	"queued": "待機中"
+	"queued": "待機中",
+	"never": "しない",
+	"configFile": "設定ファイル"
 }

--- a/i18n/translations/ko-KR/desktop.json
+++ b/i18n/translations/ko-KR/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "⌘, ⌃, ⌥ 또는 ⇧ 도 함께 누르세요",
 	"changeShortcut": "단축키 변경",
 	"inProgress": "진행 중",
-	"queued": "대기 중"
+	"queued": "대기 중",
+	"never": "안 함",
+	"configFile": "설정 파일"
 }

--- a/i18n/translations/no-NO/desktop.json
+++ b/i18n/translations/no-NO/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Hold også ⌘, ⌃, ⌥ eller ⇧",
 	"changeShortcut": "Endre hurtigtast",
 	"inProgress": "Pågår",
-	"queued": "I kø"
+	"queued": "I kø",
+	"never": "Aldri",
+	"configFile": "Konfigurasjonsfil"
 }

--- a/i18n/translations/pl-PL/desktop.json
+++ b/i18n/translations/pl-PL/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Przytrzymaj też ⌘, ⌃, ⌥ lub ⇧",
 	"changeShortcut": "Zmień skrót",
 	"inProgress": "W toku",
-	"queued": "W kolejce"
+	"queued": "W kolejce",
+	"never": "Nigdy",
+	"configFile": "Plik konfiguracyjny"
 }

--- a/i18n/translations/pt-BR/desktop.json
+++ b/i18n/translations/pt-BR/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Segure também ⌘, ⌃, ⌥ ou ⇧",
 	"changeShortcut": "Alterar atalho",
 	"inProgress": "Em andamento",
-	"queued": "Na fila"
+	"queued": "Na fila",
+	"never": "Nunca",
+	"configFile": "Arquivo de configuração"
 }

--- a/i18n/translations/ru-RU/desktop.json
+++ b/i18n/translations/ru-RU/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Удерживайте также ⌘, ⌃, ⌥ или ⇧",
 	"changeShortcut": "Изменить сочетание клавиш",
 	"inProgress": "Выполняется",
-	"queued": "В очереди"
+	"queued": "В очереди",
+	"never": "Никогда",
+	"configFile": "Файл конфигурации"
 }

--- a/i18n/translations/sv-SE/desktop.json
+++ b/i18n/translations/sv-SE/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Håll även ned ⌘, ⌃, ⌥ eller ⇧",
 	"changeShortcut": "Ändra kortkommando",
 	"inProgress": "Pågår",
-	"queued": "I kö"
+	"queued": "I kö",
+	"never": "Aldrig",
+	"configFile": "Konfigurationsfil"
 }

--- a/i18n/translations/tr-TR/desktop.json
+++ b/i18n/translations/tr-TR/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "⌘, ⌃, ⌥ veya ⇧ tuşunu da basılı tutun",
 	"changeShortcut": "Kısayolu değiştir",
 	"inProgress": "Devam ediyor",
-	"queued": "Sırada"
+	"queued": "Sırada",
+	"never": "Asla",
+	"configFile": "Yapılandırma dosyası"
 }

--- a/i18n/translations/vi-VN/desktop.json
+++ b/i18n/translations/vi-VN/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "Giữ thêm ⌘, ⌃, ⌥ hoặc ⇧",
 	"changeShortcut": "Đổi phím tắt",
 	"inProgress": "Đang xử lý",
-	"queued": "Trong hàng đợi"
+	"queued": "Trong hàng đợi",
+	"never": "Không bao giờ",
+	"configFile": "Tệp cấu hình"
 }

--- a/i18n/translations/zh-CN/desktop.json
+++ b/i18n/translations/zh-CN/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "请同时按住 ⌘、⌃、⌥ 或 ⇧",
 	"changeShortcut": "更改快捷键",
 	"inProgress": "进行中",
-	"queued": "排队中"
+	"queued": "排队中",
+	"never": "从不",
+	"configFile": "配置文件"
 }

--- a/i18n/translations/zh-HK/desktop.json
+++ b/i18n/translations/zh-HK/desktop.json
@@ -438,5 +438,7 @@
 	"shortcutNeedsModifier": "請同時按住 ⌘、⌃、⌥ 或 ⇧",
 	"changeShortcut": "更改快速鍵",
 	"inProgress": "進行中",
-	"queued": "排隊中"
+	"queued": "排隊中",
+	"never": "永不",
+	"configFile": "設定檔"
 }

--- a/website/src/globals.css
+++ b/website/src/globals.css
@@ -518,14 +518,15 @@
 	--mock-accent-ink: #ffffff;
 }
 .dark {
-	--mock-surface: #181818;
-	--mock-sidebar: #212121;
-	--mock-muted: #242424;
-	--mock-line: #303030;
+	/* ChatGPT's arrangement: the rail is the darkest surface, the content sits a step above it. */
+	--mock-surface: #212121;
+	--mock-sidebar: #0f0f0f;
+	--mock-muted: #2b2b2b;
+	--mock-line: #343434;
 	--mock-ink: #ececec;
-	--mock-ink-muted: #9a9a9a;
-	--mock-faint: #3a3a3a;
-	--mock-active: #2a2a2a;
+	--mock-ink-muted: #9b9b9b;
+	--mock-faint: #3d3d3d;
+	--mock-active: #303030;
 	--mock-accent: #4c8bff;
 	--mock-accent-ink: #0d1117;
 }


### PR DESCRIPTION
## Config out of localStorage

Every setting now lives in `app_config.json` — the store file that already held `analytics_enabled` — instead of `localStorage`. Keys are flat and named after the setting (`general.theme`, `dictation.shortcut`, `transcription.recognizeSpeakers`, `summarize.llm`), because people and agents read this file.

- **`lib/config-store.ts`** — the file is cached at boot so reads stay synchronous for React; `usePersisted` is a one-for-one replacement for `useLocalStorage` (same tuple, same functional setter) built on `useSyncExternalStore`. Writes batch through the store's `autoSave: 300`, and `store.onChange` keeps every window in sync.
- **`lib/config-keys.ts`** — one table of key names plus the old→new mapping.
- **Migration v2** copies the `prefs_*` entries across once, skips anything unparseable, never overwrites a key the file already has, and leaves the old entries in place so a downgrade still works.
- **File watcher (Rust)** — an edit made outside the app is picked up live. It watches the directory, not the file, because an atomic save replaces the inode; self-writes are filtered by comparing disk against the store's entries. The plugin's `reload()` emits nothing (confirmed in its source), so the watcher emits `config-changed` with the whole file and the frontend diffs it into the cache.
- **`write_config_atomically`** — the plugin saves with a plain `fs::write`; this writes a temp file beside the target and renames over it.
- **Agent Skill instructions** now include the config path, the key shape and the repo link — Sona's `/skill` only covers the transcription API. Settings → API & Agents can reveal the file.

## Number fields

One control replaces all eight number inputs in settings: a pill with **−** and **+** on the ends, always visible, repeating when held, stopping (and dimming) at the range's ends. The value is still typable — the draft isn't clamped mid-typing, Enter/blur commits, Escape reverts, arrows step, garbage leaves the setting alone. Zero reads as **"Never"** for the unload timeout and −1 as **"Auto"** for the GPU device, replacing the empty-box-with-a-placeholder trick.

Ranges: threads 1–`hardwareConcurrency`, best-of/beam 1–10, temperature 0–1 by 0.1, context 0–16384 by 64, sentence length 0–512, max tokens 256–32768 by 256, unload 0–1440 by 5.

## Also
- Model vendor icons in the model picker: Whisper → OpenAI, Parakeet/Nemotron/Canary → NVIDIA, Silero → waveform, anything else → generic.
- The website's dark hero mock follows ChatGPT's arrangement (rail darker than the content).
- `never` and `configFile` translated into all 18 non-English locales; every locale is complete at 442 keys.

## Checks
`prettier` clean · `eslint` 0 errors · `vitest` 5/5 · `cargo fmt` clean · `cargo clippy` 0 warnings · `cargo test` 6/6

Not verified in-app: the Claude in Chrome extension was disconnected for this round, so the number fields and the hero palette have not been eyeballed in a running window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)