### PR TITLE
Build the phone PWA on Linux so its wasm client compiles

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,61 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    # Built on Linux on purpose: the iroh client pulls in `ring`, which compiles C
+    # for wasm32, and the macOS runners' Apple clang has no wasm target.
+    pwa:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  package_json_file: pwa/package.json
+
+            - name: setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: setup Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  targets: wasm32-unknown-unknown
+
+            - name: cache Rust build
+              uses: Swatinem/rust-cache@v2
+              with:
+                  workspaces: handoff-wasm
+
+            - name: install wasm-bindgen-cli
+              uses: taiki-e/install-action@v2
+              with:
+                  # Must match the pinned `wasm-bindgen` dependency in handoff-wasm/Cargo.toml
+                  # exactly, or the CLI refuses to process the module.
+                  tool: wasm-bindgen-cli@0.2.122
+
+            - name: install binaryen
+              run: sudo apt-get update && sudo apt-get install -y binaryen
+
+            - name: Build
+              run: |
+                ./handoff-wasm/build.sh
+                pnpm --dir pwa install
+                pnpm --dir pwa build
+              env:
+                PWA_BASE: /vibe/phone/
+
+            - name: Upload phone PWA
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pwa-dist
+                  path: pwa/dist
+                  if-no-files-found: error
+
     build:
+        needs: pwa
         runs-on: macos-latest
         steps:
             - name: Checkout
@@ -58,37 +112,11 @@ jobs:
               env:
                 GH_TOKEN: ${{ github.token }}
 
-            # The phone PWA ships inside the same Pages artifact, at /vibe/phone/.
-            # Its iroh client is Rust compiled to wasm, so it needs a toolchain.
-            - name: setup Rust for the wasm client
-              uses: dtolnay/rust-toolchain@stable
+            - name: Download phone PWA
+              uses: actions/download-artifact@v5
               with:
-                  targets: wasm32-unknown-unknown
-
-            - name: cache Rust build
-              uses: Swatinem/rust-cache@v2
-              with:
-                  workspaces: handoff-wasm
-
-            - name: install wasm-bindgen-cli
-              uses: taiki-e/install-action@v2
-              with:
-                  # Must match the pinned `wasm-bindgen` dependency in handoff-wasm/Cargo.toml
-                  # exactly, or the CLI refuses to process the module.
-                  tool: wasm-bindgen-cli@0.2.122
-
-            - name: install binaryen
-              run: brew install binaryen
-
-            - name: Build phone PWA
-              run: |
-                ./handoff-wasm/build.sh
-                pnpm --dir pwa install
-                pnpm --dir pwa build
-                mkdir -p website/dist/phone
-                cp -R pwa/dist/. website/dist/phone/
-              env:
-                PWA_BASE: /vibe/phone/
+                  name: pwa-dist
+                  path: website/dist/phone
 
             - name: Setup Pages
               uses: actions/configure-pages@v6


### PR DESCRIPTION
The Pages deploy for #1411 failed and never published the PWA.

`ring` (pulled in by the iroh client's `tls-ring` feature) compiles C for `wasm32-unknown-unknown`. The macOS runners ship Apple clang, which has no wasm target:

```
error: unable to create target: 'No available targets are compatible with triple "wasm32-unknown-unknown"'
error: failed to run custom build command for `ring v0.17.14`
```

It built locally only because that machine happens to have LLVM 18 on PATH — a difference between the dev box and CI that nothing surfaced.

Moves the wasm client and PWA build into their own `ubuntu-latest` job, where clang targets wasm out of the box, and passes `pwa/dist` to the website job as an artifact. The website job keeps running on macOS, unchanged apart from downloading that artifact instead of building it.

`if-no-files-found: error` on the upload, so a silently empty PWA can never be published as a green deploy again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)