### PR TITLE
Keep phone recordings in a durable outbox, and hold the wake lock

### DIFF
--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      idb:
+        specifier: ^8.0.3
+        version: 8.0.3
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.8)
@@ -894,6 +897,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1869,6 +1875,8 @@ snapshots:
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
+
+  idb@8.0.3: {}
 
   jiti@2.7.0: {}
 

--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Check, Copy, HardDriveDownload, Mic, QrCode, RefreshCw, 
 import { toast } from 'sonner'
 
 import { InstallHint } from '~/components/install-hint'
+import { OutboxCard } from '~/components/outbox-card'
 import { SettingsSheet } from '~/components/settings-sheet'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
@@ -28,7 +29,18 @@ import {
 import { languageLabel } from '~/lib/languages'
 import { canRecord, filenameFor, formatDuration, formatSize, pickMimeType } from '~/lib/recorder'
 import { cn } from '~/lib/style'
-import { requestPersistentStorage } from '~/lib/use-install'
+import {
+	addRecording,
+	blobFor,
+	deleteEntry,
+	getEntry,
+	isStoragePersisted,
+	listOutbox,
+	markAttempt,
+	OutboxFullError,
+	requestPersistentStorage,
+	type OutboxSummary,
+} from '~/lib/outbox'
 import { useWakeLock } from '~/lib/use-wake-lock'
 
 type Phase = 'idle' | 'recording' | 'sending' | 'done' | 'failed'
@@ -55,6 +67,10 @@ export function App() {
 	const [savedPath, setSavedPath] = useState<string | null>(null)
 	const [sizeWarning, setSizeWarning] = useState(false)
 	const [loadingModel, setLoadingModel] = useState(false)
+	// Durable queue of recordings that the desktop has not confirmed yet.
+	const [outbox, setOutbox] = useState<OutboxSummary[]>([])
+	const [persisted, setPersisted] = useState(true)
+	const [activeId, setActiveId] = useState<string | null>(null)
 	const [settingsOpen, setSettingsOpen] = useState(false)
 
 	// What the desktop says it can do. Never assumed locally.
@@ -194,10 +210,27 @@ export function App() {
 
 	/* ------------------------------------------------------------- send --- */
 
-	const send = useCallback(async () => {
+	const refreshOutbox = useCallback(async () => {
+		try {
+			const [entries, persistedNow] = await Promise.all([listOutbox(), isStoragePersisted()])
+			setOutbox(entries)
+			setPersisted(persistedNow)
+		} catch {
+			/* storage unavailable; the in-memory path still works */
+		}
+	}, [])
+
+	const send = useCallback(async (entryId: string) => {
 		const currentPeer = peerRef.current
-		const blob = blobRef.current
-		if (!currentPeer || !blob || sendingRef.current) return
+		if (!currentPeer || sendingRef.current) return
+
+		const entry = await getEntry(entryId)
+		if (!entry) {
+			await refreshOutbox()
+			return
+		}
+		const blob = blobFor(entry)
+		blobRef.current = blob
 
 		// Refuse an upload the desktop is going to reject on arrival — no point
 		// burning cellular data on it. A missing or zero cap means "unknown".
@@ -226,12 +259,15 @@ export function App() {
 		setTranscribePct(null)
 		setSavedPath(null)
 		setLoadingModel(false)
+		setActiveId(entryId)
 		setPhase('sending')
 		setStatus('Connecting to your desktop…')
 
-		const mime = blob.type || 'application/octet-stream'
-		const filename = filenameFor(mime)
-		const wireLang = langRef.current ? langRef.current : null
+		const mime = entry.mime || blob.type || 'application/octet-stream'
+		const filename = entry.filename
+		// The language chosen when the recording was made travels with it, so a
+		// queued recording is not retried under a language picked later.
+		const wireLang = entry.lang
 
 		try {
 			const client = await getClient()
@@ -285,6 +321,9 @@ export function App() {
 						break
 					case 'done':
 						release()
+						// Confirmed terminal success: the only point at which the
+						// recording may be dropped from durable storage.
+						void deleteEntry(entryId).then(refreshOutbox)
 						setLoadingModel(false)
 						if (typeof event.text === 'string') setTranscript(event.text.trim())
 						if (typeof event.savedPath === 'string' && event.savedPath) setSavedPath(event.savedPath)
@@ -296,6 +335,7 @@ export function App() {
 						break
 					case 'error':
 						release()
+						void markAttempt(entryId, event.message).then(refreshOutbox)
 						setLoadingModel(false)
 						setFailure({ code: event.code || 'error', message: event.message || 'The desktop reported an error.' })
 						setPhase('failed')
@@ -313,17 +353,65 @@ export function App() {
 				return 'failed'
 			})
 		} catch (err) {
-			setFailure({ code: 'transport', message: err instanceof Error ? err.message : String(err) })
+			const message = err instanceof Error ? err.message : String(err)
+			void markAttempt(entryId, message).then(refreshOutbox)
+			setFailure({ code: 'transport', message })
 			setPhase('failed')
 			setStatus('')
 		} finally {
 			sendingRef.current = false
+			setActiveId(null)
 			clearStallTimer()
 			// Backstop: covers the transport catch, a stream that ends without a
 			// terminal event, and any path the cases above missed.
 			release()
+			void refreshOutbox()
 		}
-	}, [])
+	}, [refreshOutbox, release, acquire, clearStallTimer])
+
+	/**
+	 * Attempt the oldest pending recording. Deliberately sequential and
+	 * re-entrancy guarded: two sends would fight over one relay connection.
+	 *
+	 * Background Sync would be the natural home for this, but Safari/iOS does
+	 * not implement it, and a retry path that only ever fires on Android would
+	 * mean two different behaviours to reason about. So retries are driven by
+	 * events the phone actually gets: app open, return to foreground, and the
+	 * network coming back.
+	 */
+	const pumpOutbox = useCallback(async () => {
+		if (sendingRef.current || recorderRef.current) return
+		if (!peerRef.current) return
+		try {
+			const entries = await listOutbox()
+			if (entries.length === 0) return
+			await send(entries[0].id)
+		} catch {
+			/* storage unavailable */
+		}
+	}, [send])
+
+	/* ----------------------------------------------------------- outbox --- */
+
+	// On open: show what is queued immediately, then try to drain it.
+	useEffect(() => {
+		if (!peer) return
+		let cancelled = false
+		void (async () => {
+			await refreshOutbox()
+			if (!cancelled) void pumpOutbox()
+		})()
+		return () => {
+			cancelled = true
+		}
+	}, [peer, refreshOutbox, pumpOutbox])
+
+	// Retry when the network returns.
+	useEffect(() => {
+		const onOnline = () => void pumpOutbox()
+		window.addEventListener('online', onOnline)
+		return () => window.removeEventListener('online', onOnline)
+	}, [pumpOutbox])
 
 	/* -------------------------------------------------------- recording --- */
 
@@ -396,7 +484,43 @@ export function App() {
 				setPhase('failed')
 				return
 			}
-			void send()
+
+			// A recording the desktop can never accept should not be queued
+			// forever; say so instead of silently hoarding it.
+			const cap = maxBytesRef.current
+			if (cap > 0 && blob.size > cap) {
+				release()
+				setFailure({
+					code: 'too_large',
+					message: `This recording is ${formatSize(blob.size)}, over your desktop's ${formatSize(cap)} limit. It was not saved or uploaded — record a shorter take.`,
+				})
+				setPhase('failed')
+				setStatus('')
+				return
+			}
+
+			// Write to durable storage BEFORE the first send attempt, so a crash
+			// or a closed tab mid-upload still leaves the recording recoverable.
+			void (async () => {
+				setStatus('Saving recording…')
+				try {
+					const summary = await addRecording({ blob, filename: filenameFor(type), mime: type, lang: langRef.current || null })
+					await refreshOutbox()
+					await send(summary.id)
+				} catch (err) {
+					release()
+					const full = err instanceof OutboxFullError
+					setFailure({
+						code: full ? 'outbox_full' : 'storage',
+						message: full
+							? err.message
+							: `The recording could not be saved on this device: ${err instanceof Error ? err.message : String(err)}. It is still in memory — do not close this tab.`,
+					})
+					setPhase('failed')
+					setStatus('')
+					await refreshOutbox()
+				}
+			})()
 		}
 
 		recorder.onerror = () => {
@@ -410,7 +534,7 @@ export function App() {
 		setElapsed(0)
 		setPhase('recording')
 		void acquire()
-	}, [acquire, release, send])
+	}, [acquire, release, send, refreshOutbox])
 
 	const stopRecording = useCallback(() => {
 		const recorder = recorderRef.current
@@ -446,10 +570,11 @@ export function App() {
 			// Back on screen: the spec dropped our lock, so take it back.
 			reacquireIfWanted()
 			if (sendingRef.current) armStallTimer()
+			else void pumpOutbox()
 		}
 		document.addEventListener('visibilitychange', onVisibility)
 		return () => document.removeEventListener('visibilitychange', onVisibility)
-	}, [stopRecording, reacquireIfWanted, armStallTimer])
+	}, [stopRecording, reacquireIfWanted, armStallTimer, pumpOutbox])
 
 	/* ---------------------------------------------------------- actions --- */
 
@@ -468,6 +593,7 @@ export function App() {
 		release()
 		clearStallTimer()
 		abandonedRef.current = true
+		if (activeId) void deleteEntry(activeId).then(refreshOutbox)
 		blobRef.current = null
 		segmentsRef.current = []
 		setTranscript('')
@@ -478,8 +604,9 @@ export function App() {
 		setSavedPath(null)
 		setSizeWarning(false)
 		setLoadingModel(false)
+		setActiveId(null)
 		setPhase('idle')
-	}, [])
+	}, [activeId, refreshOutbox, release, clearStallTimer])
 
 	const onUnpair = useCallback(() => {
 		clearPeer()
@@ -597,6 +724,15 @@ export function App() {
 				</Card>
 			)}
 
+			<OutboxCard
+				entries={outbox}
+				activeId={activeId}
+				busy={busy}
+				persisted={persisted}
+				onSendNow={() => void pumpOutbox()}
+				onDelete={(id) => void deleteEntry(id).then(refreshOutbox)}
+			/>
+
 			<div className="flex flex-col items-center py-8">
 				<button
 					type="button"
@@ -670,7 +806,7 @@ export function App() {
 						{(failure || phase === 'done') && (
 							<div className="flex flex-wrap gap-2">
 								{failure && hasRecording && (
-									<Button className="h-12 flex-1" onClick={() => void send()}>
+									<Button className="h-12 flex-1" onClick={() => void pumpOutbox()}>
 										<RotateCcw />
 										Retry send
 									</Button>

--- a/pwa/src/components/outbox-card.tsx
+++ b/pwa/src/components/outbox-card.tsx
@@ -1,0 +1,110 @@
+import { AlertTriangle, Clock, Send, Trash2 } from 'lucide-react'
+
+import { Button } from '~/components/ui/button'
+import { Card, CardContent } from '~/components/ui/card'
+import { Spinner } from '~/components/ui/spinner'
+import { formatSize } from '~/lib/recorder'
+import type { OutboxSummary } from '~/lib/outbox'
+
+interface Props {
+	entries: OutboxSummary[]
+	activeId: string | null
+	busy: boolean
+	persisted: boolean
+	onSendNow: () => void
+	onDelete: (id: string) => void
+}
+
+/** "3 minutes ago" in the browser's locale, without pulling in a date library. */
+function relativeTime(timestamp: number): string {
+	const seconds = Math.round((timestamp - Date.now()) / 1000)
+	const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+		['second', 60],
+		['minute', 60],
+		['hour', 24],
+		['day', 7],
+	]
+	let value = seconds
+	for (const [unit, size] of units) {
+		if (Math.abs(value) < size) {
+			try {
+				return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(Math.round(value), unit)
+			} catch {
+				return `${Math.abs(Math.round(value))} ${unit}s ago`
+			}
+		}
+		value /= size
+	}
+	return new Date(timestamp).toLocaleDateString()
+}
+
+/**
+ * The queue is stated plainly. A silent outbox is worse than none: the user
+ * cannot tell whether the recording they just made is safe.
+ */
+export function OutboxCard({ entries, activeId, busy, persisted, onSendNow, onDelete }: Props) {
+	if (entries.length === 0) return null
+
+	const waiting = entries.length
+
+	return (
+		<Card className="stagger-in mb-4 border-primary/30">
+			<CardContent className="space-y-3 pt-6">
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<h2 className="text-base font-semibold">
+							{waiting === 1 ? '1 recording waiting to send' : `${waiting} recordings waiting to send`}
+						</h2>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Saved on this phone. They stay here until your desktop confirms it has them.
+						</p>
+					</div>
+					{busy && <Spinner className="mt-1 size-4 shrink-0" />}
+				</div>
+
+				{!persisted && (
+					<div className="flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/10 p-3">
+						<AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+						<p className="text-xs">
+							This browser has not granted permanent storage, so it may clear these recordings if space runs low. Add the app to
+							your home screen, or send them soon.
+						</p>
+					</div>
+				)}
+
+				<ul className="divide-y divide-border">
+					{entries.map((entry) => {
+						const sending = entry.id === activeId && busy
+						return (
+							<li key={entry.id} className="flex items-center gap-3 py-2.5">
+								<Clock className="size-4 shrink-0 text-muted-foreground" />
+								<div className="min-w-0 flex-1">
+									<p className="truncate text-sm">{relativeTime(entry.createdAt)}</p>
+									<p className="truncate text-xs text-muted-foreground">
+										{formatSize(entry.size)}
+										{entry.lang ? ` · ${entry.lang}` : ''}
+										{entry.attempts > 0 ? ` · ${entry.attempts} ${entry.attempts === 1 ? 'try' : 'tries'}` : ''}
+										{sending ? ' · sending…' : ''}
+									</p>
+								</div>
+								<Button
+									variant="ghost"
+									size="icon"
+									aria-label="Delete recording"
+									disabled={sending}
+									onClick={() => onDelete(entry.id)}>
+									<Trash2 />
+								</Button>
+							</li>
+						)
+					})}
+				</ul>
+
+				<Button className="h-12 w-full" disabled={busy} onClick={onSendNow}>
+					<Send />
+					{busy ? 'Sending…' : 'Send now'}
+				</Button>
+			</CardContent>
+		</Card>
+	)
+}

--- a/pwa/src/lib/outbox.ts
+++ b/pwa/src/lib/outbox.ts
@@ -1,0 +1,192 @@
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
+
+/**
+ * Durable outbox for recordings.
+ *
+ * A recording exists nowhere else until the desktop accepts it: the phone is
+ * the only copy. So audio is written to IndexedDB the moment it is captured —
+ * before the first send is even attempted — and removed only when the desktop
+ * confirms a terminal `done`. A crash, a closed tab, or a desktop that is
+ * asleep therefore costs nothing but time.
+ *
+ * Audio is stored as an `ArrayBuffer`, not a `Blob`. WebKit has a long history
+ * of bugs storing Blobs in IndexedDB (entries that read back empty or with a
+ * lost type, and blobs backed by files that vanish), and an ArrayBuffer is a
+ * plain structured-cloneable value with none of that baggage. The `Blob` is
+ * reconstructed on read from the stored `mime`.
+ */
+
+export interface OutboxEntry {
+	id: string
+	createdAt: number
+	filename: string
+	mime: string
+	/** Whisper language code, or null for auto-detect. */
+	lang: string | null
+	size: number
+	audio: ArrayBuffer
+	/** Bumped each time a send is attempted, for display only. */
+	attempts: number
+	lastError?: string
+}
+
+/** Metadata without the payload — what the UI lists. */
+export type OutboxSummary = Omit<OutboxEntry, 'audio'>
+
+interface HandoffDB extends DBSchema {
+	recordings: {
+		key: string
+		value: OutboxEntry
+		indexes: { createdAt: number }
+	}
+}
+
+const DB_NAME = 'vibe-handoff'
+const DB_VERSION = 1
+const STORE = 'recordings'
+
+/**
+ * Caps. Audio is large and the browser's quota is not ours to fill. When the
+ * outbox is full we refuse the *new* recording rather than evicting an old one:
+ * the new audio is still in memory and the user can act on the message, whereas
+ * silently deleting an older unsent recording destroys the only copy of
+ * something they already believed was safe.
+ */
+export const MAX_ENTRIES = 10
+export const MAX_TOTAL_BYTES = 300 * 1024 * 1024
+
+export class OutboxFullError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'OutboxFullError'
+	}
+}
+
+let dbPromise: Promise<IDBPDatabase<HandoffDB>> | null = null
+
+function getDB(): Promise<IDBPDatabase<HandoffDB>> {
+	if (!dbPromise) {
+		dbPromise = openDB<HandoffDB>(DB_NAME, DB_VERSION, {
+			upgrade(db) {
+				const store = db.createObjectStore(STORE, { keyPath: 'id' })
+				store.createIndex('createdAt', 'createdAt')
+			},
+		}).catch((err) => {
+			dbPromise = null
+			throw err
+		})
+	}
+	return dbPromise
+}
+
+/**
+ * Ask the browser to keep our storage. This matters far more now than it did
+ * for the pairing alone: eviction would destroy queued audio.
+ */
+export async function requestPersistentStorage(): Promise<boolean> {
+	try {
+		if (!navigator.storage?.persist || !navigator.storage.persisted) return false
+		if (await navigator.storage.persisted()) return true
+		return await navigator.storage.persist()
+	} catch {
+		return false
+	}
+}
+
+export async function isStoragePersisted(): Promise<boolean> {
+	try {
+		return (await navigator.storage?.persisted?.()) ?? false
+	} catch {
+		return false
+	}
+}
+
+/** Oldest first — the order they are retried in. */
+export async function listOutbox(): Promise<OutboxSummary[]> {
+	const db = await getDB()
+	const all = await db.getAllFromIndex(STORE, 'createdAt')
+	return all.map(({ audio: _audio, ...rest }) => rest)
+}
+
+export async function getEntry(id: string): Promise<OutboxEntry | undefined> {
+	const db = await getDB()
+	return db.get(STORE, id)
+}
+
+export async function deleteEntry(id: string): Promise<void> {
+	const db = await getDB()
+	await db.delete(STORE, id)
+}
+
+export async function outboxCount(): Promise<number> {
+	const db = await getDB()
+	return db.count(STORE)
+}
+
+/**
+ * Persist a freshly captured recording. Throws `OutboxFullError` when a cap
+ * would be exceeded and on `QuotaExceededError` — never resolves silently
+ * without having written, because the caller's blob is the only other copy.
+ */
+export async function addRecording(input: {
+	blob: Blob
+	filename: string
+	mime: string
+	lang: string | null
+}): Promise<OutboxSummary> {
+	// Persistence is requested before the first write, not after, so the very
+	// first queued recording is already covered.
+	await requestPersistentStorage()
+
+	const db = await getDB()
+	const existing = await db.getAll(STORE)
+	const totalBytes = existing.reduce((sum, entry) => sum + entry.size, 0)
+
+	if (existing.length >= MAX_ENTRIES) {
+		throw new OutboxFullError(
+			`The outbox already holds ${existing.length} unsent recordings. Send or delete one before recording again.`
+		)
+	}
+	if (totalBytes + input.blob.size > MAX_TOTAL_BYTES) {
+		throw new OutboxFullError('The unsent recordings would exceed the storage limit. Send or delete one before recording again.')
+	}
+
+	const entry: OutboxEntry = {
+		id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+		createdAt: Date.now(),
+		filename: input.filename,
+		mime: input.mime,
+		lang: input.lang,
+		size: input.blob.size,
+		audio: await input.blob.arrayBuffer(),
+		attempts: 0,
+	}
+
+	try {
+		await db.put(STORE, entry)
+	} catch (err) {
+		const name = err instanceof Error ? err.name : ''
+		if (name === 'QuotaExceededError') {
+			throw new OutboxFullError('There is no room left on this device to save the recording. Free up space or send a queued one first.')
+		}
+		throw err
+	}
+
+	const { audio: _audio, ...summary } = entry
+	return summary
+}
+
+/** Record an attempt against an entry, for display in the queue. */
+export async function markAttempt(id: string, error?: string): Promise<void> {
+	const db = await getDB()
+	const entry = await db.get(STORE, id)
+	if (!entry) return
+	entry.attempts += 1
+	if (error) entry.lastError = error
+	await db.put(STORE, entry)
+}
+
+/** Reconstruct the Blob for sending. */
+export function blobFor(entry: OutboxEntry): Blob {
+	return new Blob([entry.audio], { type: entry.mime })
+}


### PR DESCRIPTION
Also unblocks the Pages deploy: `pwa/pnpm-lock.yaml` was missing `idb`, so CI's `--frozen-lockfile` install failed and the PWA was never published.

## Durable outbox

A recording lived only in memory. Closing the tab lost it — which is exactly the situation this feature invites: record something in a meeting, desktop asleep or Vibe not running, tab closed, audio gone.

Recordings now go to IndexedDB (via `idb`) **before** the first send attempt, and are deleted **only** on a confirmed `done`. Retries run on app open, on return to the tab, and on regaining network — sequential, oldest first. No Background Sync: Safari doesn't implement it, and two divergent retry paths is worse than one that works everywhere.

Stored as an `ArrayBuffer` and rebuilt into a `Blob` on read, given WebKit's history of Blob-in-IndexedDB bugs. Verified byte-identical through a closed-and-reopened connection.

Caps at 10 entries / 300 MB, and on exceeding them **refuses the new recording rather than evicting an old one** — deleting audio someone already believed was safe is the worse failure, and the refused recording is still in memory so they can act on it. `QuotaExceededError` is surfaced, never swallowed.

## Wake lock

It was released the moment recording stopped, so the screen could sleep during upload and transcription — and on iOS a sleeping screen suspends the page and drops the transcript. It now covers the whole operation, with releases on every terminal path (including unmount mid-transfer), and re-acquires on return to the tab since the spec drops it on hide and never restores it.

Backgrounding mid-transcription still can't be survived — the transcript arrives on one stream with no resume in the protocol — so the failure is now loud instead of silent: a warning while sending, and a 20s stall watchdog that reports the dropped connection and offers retry, rather than sitting on "Transcribing…" forever.

## Verified

Driven against the built app: queue survives killing the tab mid-send and resumes on reopen; ordering is oldest-first; entries persist across failed sends with an incremented attempt count; delete-from-UI works; the `persisted === false` warning shows honestly.

**Not covered:** `getUserMedia` can't be driven headlessly here, so the mic → MediaRecorder half is exercised only by the same code paths, not by a driven test.

## Known follow-up

Retry isn't idempotent on the desktop side yet. If a send half-succeeds — audio saved and transcription started, then the stream dies before `done` — the retry produces a second copy in `~/Documents/Vibe` and a second transcription. The fix is to send the outbox entry id as a `clientId` and have the desktop skip work it has already completed. Deliberately not done here, since it's a wire protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)