### PR TITLE
Stop wasm-opt stripping features the wasm-bindgen glue needs

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -63,8 +63,12 @@ jobs:
                   # exactly, or the CLI refuses to process the module.
                   tool: wasm-bindgen-cli@0.2.122
 
+            # Pinned, not apt: the distro binaryen is older and produces a
+            # different module, which is how a broken wasm shipped once already.
             - name: install binaryen
-              run: sudo apt-get update && sudo apt-get install -y binaryen
+              run: |
+                curl -sSfL https://github.com/WebAssembly/binaryen/releases/download/version_132/binaryen-version_132-x86_64-linux.tar.gz | tar xz
+                echo "$PWD/binaryen-version_132/bin" >> "$GITHUB_PATH"
 
             - name: Build
               run: |

--- a/handoff-wasm/build.sh
+++ b/handoff-wasm/build.sh
@@ -27,8 +27,13 @@ wasm-bindgen ./target/wasm32-unknown-unknown/release/handoff_wasm.wasm \
 # binaryen installed we keep the unoptimized artifact rather than failing.
 WASM="$OUT_DIR/handoff_wasm_bg.wasm"
 if command -v wasm-opt >/dev/null 2>&1; then
-  wasm-opt --enable-nontrapping-float-to-int --enable-bulk-memory -Os \
-    -o "$WASM.opt" "$WASM"
+  # `-all` on purpose. Naming individual --enable-* flags DISABLES every feature
+  # not listed, and older binaryen then strips ones wasm-bindgen's glue relies on
+  # (call-indirect-overlong, reference types). That corrupts the function table and
+  # the module dies at init with:
+  #   WebAssembly.Table.set(): Argument 1 is invalid for table:
+  #   function-typed object must be null (if nullable) or a Wasm function object
+  wasm-opt -all -Os -o "$WASM.opt" "$WASM"
   mv "$WASM.opt" "$WASM"
   echo "wasm-opt: $WASM is now $(wc -c <"$WASM" | tr -d ' ') bytes"
 else


### PR DESCRIPTION
The deployed PWA loaded and then died at init:

```
WebAssembly.Table.set(): Argument 1 is invalid for table:
function-typed object must be null (if nullable) or a Wasm function object
```

## Cause

Naming individual `--enable-*` flags to `wasm-opt` **disables every feature not listed**. `build.sh` named only `nontrapping-float-to-int` and `bulk-memory`.

CI installed binaryen from apt, which is older than the 132 used locally. Comparing the two artifacts' feature sections shows what happened:

```
local     … --enable-reference-types --enable-bulk-memory-opt --enable-call-indirect-overlong
deployed  … --enable-reference-types --enable-bulk-memory-opt
```

`call-indirect-overlong` was stripped, corrupting the function table that wasm-bindgen's glue populates at startup — hence `Table.set()` rejecting a perfectly good Wasm function.

This is why it worked over a local tunnel and failed only once deployed: the two builds were never the same bytes (2,867,722 local vs 2,871,613 deployed).

## Fix

- `wasm-opt -all -Os` — no feature can be stripped regardless of binaryen version. Also happens to produce a slightly smaller module.
- Pin binaryen 132 in CI instead of the distro package, so the deployed artifact matches what was tested locally rather than being a near-miss.

Both changes carry a comment explaining the failure, since `-all` looks like carelessness without the context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)