### PR TITLE
Bump version to 3.1.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./gen/schemas/desktop-schema.json",
 	"productName": "vibe",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"identifier": "github.com.thewh1teagle.vibe",
 	"app": {
 		"macOSPrivateApi": true,


### PR DESCRIPTION
Version bump for the release that ships phone handoff (#1409, #1411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)