### PR TITLE
Name the AVX2 crash instead of reporting a mystery death

### DIFF
--- a/desktop/src-tauri/src/sona/process.rs
+++ b/desktop/src-tauri/src/sona/process.rs
@@ -43,6 +43,30 @@ pub(super) fn describe_exit(status: ExitStatus) -> String {
     }
 }
 
+/// An illegal instruction from a binary that runs everywhere else means the CPU is
+/// missing an instruction set the build assumes. Naming it here is what turns these
+/// reports from a bare "sona process died" into something identifiable.
+fn illegal_instruction_hint(status: ExitStatus) -> Option<&'static str> {
+    const MESSAGE: &str = "This looks like a CPU without AVX2 support: sona is built to require it, so it stops on the first instruction it cannot run. Vibe cannot transcribe on this machine.";
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if status.signal() == Some(4) {
+            return Some(MESSAGE);
+        }
+    }
+    #[cfg(windows)]
+    {
+        // STATUS_ILLEGAL_INSTRUCTION, which Windows surfaces as the exit code.
+        if status.code() == Some(0xC000_001D_u32 as i32) {
+            return Some(MESSAGE);
+        }
+    }
+    let _ = status;
+    None
+}
+
 #[cfg(unix)]
 fn signal_name(signal: i32) -> Option<&'static str> {
     #[cfg(target_os = "linux")]
@@ -280,6 +304,9 @@ impl SonaProcess {
         let status = self.exit_status()?;
         let stderr = self.stderr_after_exit().await;
         let mut message = format!("{context} ({})", describe_exit(status));
+        if let Some(hint) = illegal_instruction_hint(status) {
+            message.push_str(&format!("\n\n{hint}"));
+        }
         if !stderr.is_empty() {
             message.push_str(&format!("\n\nsona stderr: {stderr}"));
         }

--- a/desktop/src/providers/hotkey.tsx
+++ b/desktop/src/providers/hotkey.tsx
@@ -3,7 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { emit, listen } from '@tauri-apps/api/event'
 import { register, unregister, isRegistered } from '@tauri-apps/plugin-global-shortcut'
 import * as clipboard from '@tauri-apps/plugin-clipboard-manager'
-import { trackTranscribeFailed, trackTranscribeStarted, trackTranscribeSucceeded } from '~/lib/analytics'
+import { trackAvx2NotSupported, trackTranscribeFailed, trackTranscribeStarted, trackTranscribeSucceeded } from '~/lib/analytics'
 import { AudioDevice } from '~/lib/audio'
 import { CONFIG_KEYS } from '~/lib/config-keys'
 import { usePersisted } from '~/lib/config-store'
@@ -190,6 +190,15 @@ export function HotkeyProvider({ children }: { children: ReactNode }) {
 			if (!isHotkeyRecordingRef.current) return
 
 			const { path } = event.payload
+
+			// Same gate the other transcription paths use: without AVX2 sona dies on its
+			// first instruction, so stop before spawning it.
+			if (!(await invoke<boolean>('is_avx2_enabled'))) {
+				trackAvx2NotSupported()
+				finishIndicator('error', { message: m.avx2NotSupported() })
+				return
+			}
+
 			showIndicator('transcribing')
 
 			// Dictation is a transcription like any other: one start, one terminal event.


### PR DESCRIPTION
Partly addresses #1404 — item 4 only, not the fallback build.

A CPU without AVX2 kills `sona` on its first instruction. Until now that surfaced as the generic `sona process died`, which is exactly why #981 and #1097 were so hard to identify from the reports. The exit status is now kept, so the illegal instruction can be named: SIGILL on unix, `STATUS_ILLEGAL_INSTRUCTION` (`0xC000001D`) on Windows.

It lives in `death_report`, so it covers every path — the app, the CLI and the phone handoff — rather than only the UI.

Global dictation (`hotkey.tsx`) was also the one transcription path with no AVX2 gate: the other three check and show a message, dictation just spawned sona and let it die. It now checks like the rest.

## Not in scope

This does **not** fix #1404. A baseline non-AVX2 build plus runtime selection of the right sidecar is still open; this only makes the failure identifiable instead of anonymous.

## Verification

`cargo check`/`clippy`/`fmt`/`test` clean (35 tests), `tsc` clean.

The Windows branch could not be compiled here — the full crate cannot cross-compile from macOS because `ring` and `aws-lc-sys` need MSVC tooling. I extracted the function into a standalone crate and compiled it for `x86_64-pc-windows-msvc` and for the host, both clean, which checks the `cfg` split but not its integration. Worth an eye on CI for the Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)