### PR TITLE
Bump version to 3.1.2

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./gen/schemas/desktop-schema.json",
 	"productName": "vibe",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"identifier": "github.com.thewh1teagle.vibe",
 	"app": {
 		"macOSPrivateApi": true,


### PR DESCRIPTION
Release bump ahead of cutting v3.1.2.

Since 3.1.1:

- **#1424 — settings reset to default on every restart.** The config store's read path was blocked by a missing capability, so `app_config.json` was written correctly and never read back. This is the reason to ship. (#1426)
- **Sidecar deaths now say why.** Exit code and signal are kept and reported, stderr is drained to EOF and the tail retained, and a mid-stream death reads as a death instead of a decode error. Pairs with sona v0.4.1. (#1422)
- **Corrupt model files are caught** by magic and size before publish, swept on start, and offered a re-download instead of being listed as installed. (#1422)
- **A CPU without AVX2 is named** rather than dying anonymously. (#1425)
- **yt-dlp stops nagging** on every launch, and the VC++ runtime check now compares versions instead of mere presence. (#1427)
- Telemetry can answer basic questions: persistent install id, one terminal event per transcription, error tails that survive truncation. (#1422)

To sign and notarize, dispatch the release workflow with `sign-macos` and `sign-windows` both enabled; the Windows path needs the remote sign server running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
