### PR TITLE
Default dictation to Option+Space on macOS, Ctrl+Space elsewhere

### DIFF
--- a/desktop/src/pages/settings/sections/dictation.tsx
+++ b/desktop/src/pages/settings/sections/dictation.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { m } from '~/paraglide/messages.js'
 import ShortcutRecorder from '~/components/shortcut-recorder'
 import { Switch } from '~/components/ui/switch'
-import { DEFAULT_HOTKEY_SHORTCUT, useHotkeyProvider, type HotkeyActivationMode, type HotkeyOutputMode } from '~/providers/hotkey'
+import { getDefaultHotkeyShortcut, useHotkeyProvider, type HotkeyActivationMode, type HotkeyOutputMode } from '~/providers/hotkey'
 import { SettingsGroup, SettingsRow } from './shared'
 import { getDictationIndicatorEnabled, setDictationIndicatorEnabled } from '~/lib/dictation-indicator'
 
@@ -72,7 +72,7 @@ export function DictationSection() {
 							<ShortcutRecorder
 								value={hotkey.hotkeyShortcut}
 								onChange={hotkey.setHotkeyShortcut}
-								defaultValue={DEFAULT_HOTKEY_SHORTCUT}
+								defaultValue={getDefaultHotkeyShortcut()}
 								onCapturingChange={hotkey.setHotkeyCapturing}
 							/>
 						</SettingsRow>

--- a/desktop/src/providers/hotkey.tsx
+++ b/desktop/src/providers/hotkey.tsx
@@ -19,7 +19,14 @@ import * as config from '~/lib/config'
 // when hotkey-triggered recording finishes
 export let hotkeyRecordingActive = false
 
-export const DEFAULT_HOTKEY_SHORTCUT = 'CmdOrCtrl+Shift+Space'
+/**
+ * Option+Space on macOS, Ctrl+Space elsewhere. Resolved on call rather than at module scope:
+ * reading the platform at import time makes this file unimportable outside a webview.
+ */
+export function getDefaultHotkeyShortcut() {
+	const isMac = navigator.platform.toUpperCase().includes('MAC')
+	return isMac ? 'Alt+Space' : 'Ctrl+Space'
+}
 
 export type HotkeyOutputMode = 'clipboard' | 'type'
 export type HotkeyActivationMode = 'push-to-talk' | 'toggle'
@@ -85,7 +92,7 @@ export function HotkeyProvider({ children }: { children: ReactNode }) {
 	const preferenceRef = useRef(preference)
 
 	const [hotkeyEnabled, setHotkeyEnabled] = usePersisted(CONFIG_KEYS.hotkeyEnabled, false)
-	const [hotkeyShortcut, setHotkeyShortcut] = usePersisted(CONFIG_KEYS.hotkeyShortcut, DEFAULT_HOTKEY_SHORTCUT)
+	const [hotkeyShortcut, setHotkeyShortcut] = usePersisted(CONFIG_KEYS.hotkeyShortcut, getDefaultHotkeyShortcut())
 	const [hotkeyCapturing, setHotkeyCapturingState] = useState(false)
 	const [hotkeyOutputMode, setHotkeyOutputMode] = usePersisted<HotkeyOutputMode>(CONFIG_KEYS.hotkeyOutputMode, 'clipboard')
 	const [hotkeyActivationMode, setHotkeyActivationMode] = usePersisted<HotkeyActivationMode>(CONFIG_KEYS.hotkeyActivationMode, 'push-to-talk')


### PR DESCRIPTION
Default dictation shortcut becomes **Option+Space** on macOS and **Ctrl+Space** on Windows and Linux, replacing `CmdOrCtrl+Shift+Space`. A three-key chord is a lot for something meant to be pressed constantly.

`getDefaultHotkeyShortcut()` resolves the platform on call rather than at module scope, so the module stays importable outside a webview. The promo's key rendering already maps `Alt` to `⌥` on macOS, so it displays correctly with no change.

`usePersisted` only reads with a fallback and never writes it, so this reaches every user who has not picked their own shortcut — not just new installs.

## Worth knowing before this ships

**`Ctrl+Space` is the standard IME toggle on Windows and Linux** for Chinese, Japanese and Korean input. Vibe ships zh-CN, zh-HK, ja-JP and ko-KR locales, so those users exist in numbers, and for them this default will fight their input method. It is also autocomplete in most IDEs.

**`Option+Space` on macOS** normally inserts a non-breaking space; taking it globally removes that.

**A registration clash fails silently.** `hotkey.tsx:333` logs to the console and stops. With a default this much more likely to already be taken, a user whose shortcut is claimed by something else just finds that dictation does nothing, with no explanation. That was tolerable for an unusual chord and is less so now — worth surfacing the failure in the UI as a follow-up.

None of that blocks the change; it is a defaults question, not a correctness one. Flagging so the choice is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
