### PR TITLE
Stop aborting on quit when the analytics flush runs

### DIFF
--- a/desktop/src-tauri/src/analytics.rs
+++ b/desktop/src-tauri/src/analytics.rs
@@ -116,7 +116,12 @@ pub fn flush_events_bounded(app_handle: &AppHandle, timeout: Duration) {
     }
     let (sender, receiver) = std::sync::mpsc::channel();
     let handle = app_handle.clone();
+    // flush_events_blocking ends in a reqwest call, which panics without a tokio runtime in
+    // scope. A bare thread has none, and the release profile aborts on panic, so that panic
+    // took the whole app down on quit rather than just losing the flush. Carry the runtime in.
+    let runtime = tauri::async_runtime::handle();
     std::thread::spawn(move || {
+        let _guard = runtime.inner().enter();
         handle.flush_events_blocking();
         let _ = sender.send(());
     });


### PR DESCRIPTION
**3.1.2 aborts every time the app is closed.** Regression from the app-exit event added in #1422.

## Cause

`flush_events_bounded` runs the analytics flush on a bare `std::thread::spawn` so a slow ingest host cannot hold up quitting. That flush is `futures::executor::block_on(self.flush())`, which ends in a reqwest call — and **reqwest panics without a tokio runtime in scope**. A plain thread has none.

`Cargo.toml:13` sets `panic = "abort"` for release, so a panic on any thread kills the process. Instead of losing one analytics flush, quitting aborts the app.

The crash report reads exactly that way: thread 0 parked in `semaphore_timedwait_trap` (the `recv_timeout`), thread 48 running Rust's panic path straight into `abort()`.

## Fix

Capture the Tauri tokio handle and `enter()` it inside the spawned thread. Same call site is used by the CLI (`cli.rs:89`, `:129`), so that path is fixed too.

## Why it got through

Dev builds unwind instead of aborting — the thread dies quietly, the flush times out after 2 s, the app quits fine. `cargo check`, `clippy`, `cargo test` and a real `tauri dev` session all passed while shipping a build that aborts on every quit. Only the release profile reproduces it.

So this time it was verified the only way that means anything: built the release bundle, launched it, quit it. **No crash report from the test build**, while the installed 3.1.2 produces one on every close. All six crash reports on this machine trace to `/Applications/vibe.app`; none to the fixed bundle.

`cargo clippy` clean, `cargo test` 37 passed, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
