### PR TITLE
Release 3.1.5

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./gen/schemas/desktop-schema.json",
 	"productName": "vibe",
-	"version": "3.1.4",
+	"version": "3.1.5",
 	"identifier": "github.com.thewh1teagle.vibe",
 	"app": {
 		"macOSPrivateApi": true,


### PR DESCRIPTION
Version bump for the next release. Since v3.1.4 the app has gained generated PDF exports with correct bidi, the redesigned export dialog with remembered options, the reworked DOCX output, a CPU-only transcription setting, faster meeting detection, and translations filled in across all 21 locales — plus the sona sidecar pinned to v0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)