### PR TITLE
Trim the Meet permission row

### DIFF
--- a/desktop/src/pages/settings/sections/recording.tsx
+++ b/desktop/src/pages/settings/sections/recording.tsx
@@ -139,7 +139,7 @@ function MeetPermissionRow({ enabled }: { enabled: boolean }) {
 			<button
 				type="button"
 				onClick={() => void invoke('open_screen_recording_settings')}
-				className="cursor-pointer text-sm font-medium text-primary underline-offset-4 hover:underline">
+				className="cursor-pointer text-xs font-medium text-primary underline-offset-4 hover:underline">
 				{m.openSystemSettings()}
 			</button>
 		</SettingsRow>

--- a/i18n/translations/bg-BG/desktop.json
+++ b/i18n/translations/bg-BG/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Клавишна комбинация",
 	"recordingShortcutInfo": "Натиснете веднъж, за да започнете запис, и отново, за да го спрете.",
 	"meetPermission": "Разпознаване на Google Meet",
-	"meetPermissionInfo": "Разпознаването на разговор в Meet изисква четене на заглавието на прозореца на браузъра, което macOS позволява само с разрешение „Запис на екрана“. Zoom и Teams работят без него.",
+	"meetPermissionInfo": "Изисква разрешение за Запис на екрана. Zoom и Teams работят без него.",
 	"microphonePermission": "Микрофон",
 	"microphonePermissionInfo": "Необходимо за запис на звук от микрофона.",
 	"systemAudioPermission": "Системен звук",

--- a/i18n/translations/ca-AD/desktop.json
+++ b/i18n/translations/ca-AD/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Drecera",
 	"recordingShortcutInfo": "Prem una vegada per iniciar l'enregistrament i una altra per aturar-lo.",
 	"meetPermission": "Detecció de Google Meet",
-	"meetPermissionInfo": "Reconèixer una trucada de Meet implica llegir el títol de la finestra del navegador, cosa que macOS només permet amb el permís de Gravació de pantalla. Zoom i Teams funcionen sense aquest permís.",
+	"meetPermissionInfo": "Necessita el permís de Gravació de pantalla. Zoom i Teams funcionen sense ell.",
 	"microphonePermission": "Micròfon",
 	"microphonePermissionInfo": "Necessari per enregistrar l'àudio del micròfon.",
 	"systemAudioPermission": "Àudio del sistema",

--- a/i18n/translations/cs-CZ/desktop.json
+++ b/i18n/translations/cs-CZ/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Klávesová zkratka",
 	"recordingShortcutInfo": "Jedním stisknutím spusťte nahrávání a dalším je zastavte.",
 	"meetPermission": "Rozpoznávání Google Meet",
-	"meetPermissionInfo": "Rozpoznání hovoru v Meet vyžaduje čtení názvu okna prohlížeče, což macOS umožňuje pouze s oprávněním Nahrávání obrazovky. Zoom a Teams fungují i bez něj.",
+	"meetPermissionInfo": "Vyžaduje oprávnění Nahrávání obrazovky. Zoom a Teams fungují i bez něj.",
 	"microphonePermission": "Mikrofon",
 	"microphonePermissionInfo": "Vyžadováno pro nahrávání zvuku z mikrofonu.",
 	"systemAudioPermission": "Systémový zvuk",

--- a/i18n/translations/de-DE/desktop.json
+++ b/i18n/translations/de-DE/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Kurzbefehl",
 	"recordingShortcutInfo": "Einmal drücken, um die Aufnahme zu starten, und erneut, um sie zu stoppen.",
 	"meetPermission": "Google Meet-Erkennung",
-	"meetPermissionInfo": "Um einen Meet-Anruf zu erkennen, muss der Fenstertitel Ihres Browsers gelesen werden, was macOS nur mit der Berechtigung „Bildschirmaufnahme“ erlaubt. Zoom und Teams funktionieren auch ohne diese Berechtigung.",
+	"meetPermissionInfo": "Benötigt die Berechtigung „Bildschirmaufnahme“. Zoom und Teams funktionieren auch ohne.",
 	"microphonePermission": "Mikrofon",
 	"microphonePermissionInfo": "Erforderlich, um Mikrofonton aufzunehmen.",
 	"systemAudioPermission": "Systemaudio",

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Shortcut",
 	"recordingShortcutInfo": "Press once to start recording and again to stop.",
 	"meetPermission": "Google Meet detection",
-	"meetPermissionInfo": "Recognising a Meet call means reading your browser's window title, which macOS allows only with Screen Recording permission. Zoom and Teams work without it.",
+	"meetPermissionInfo": "Needs Screen Recording permission. Zoom and Teams work without it.",
 	"microphonePermission": "Microphone",
 	"microphonePermissionInfo": "Required to record microphone audio.",
 	"systemAudioPermission": "System audio",

--- a/i18n/translations/es-ES/desktop.json
+++ b/i18n/translations/es-ES/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Atajo",
 	"recordingShortcutInfo": "Pulsa una vez para iniciar la grabación y otra vez para detenerla.",
 	"meetPermission": "Detección de Google Meet",
-	"meetPermissionInfo": "Reconocer una llamada de Meet requiere leer el título de la ventana de tu navegador, algo que macOS solo permite con el permiso de Grabación de pantalla. Zoom y Teams funcionan sin él.",
+	"meetPermissionInfo": "Necesita el permiso de Grabación de pantalla. Zoom y Teams funcionan sin él.",
 	"microphonePermission": "Micrófono",
 	"microphonePermissionInfo": "Necesario para grabar audio del micrófono.",
 	"systemAudioPermission": "Audio del sistema",

--- a/i18n/translations/es-MX/desktop.json
+++ b/i18n/translations/es-MX/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Atajo",
 	"recordingShortcutInfo": "Presiona una vez para iniciar la grabación y otra vez para detenerla.",
 	"meetPermission": "Detección de Google Meet",
-	"meetPermissionInfo": "Reconocer una llamada de Meet requiere leer el título de la ventana de tu navegador, algo que macOS solo permite con el permiso de Grabación de pantalla. Zoom y Teams funcionan sin él.",
+	"meetPermissionInfo": "Necesita el permiso de Grabación de pantalla. Zoom y Teams funcionan sin él.",
 	"microphonePermission": "Micrófono",
 	"microphonePermissionInfo": "Necesario para grabar audio del micrófono.",
 	"systemAudioPermission": "Audio del sistema",

--- a/i18n/translations/fr-FR/desktop.json
+++ b/i18n/translations/fr-FR/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Raccourci",
 	"recordingShortcutInfo": "Appuyez une fois pour démarrer l'enregistrement, puis de nouveau pour l'arrêter.",
 	"meetPermission": "Détection de Google Meet",
-	"meetPermissionInfo": "Reconnaître un appel Meet nécessite de lire le titre de la fenêtre de votre navigateur, ce que macOS n'autorise qu'avec la permission Enregistrement de l'écran. Zoom et Teams fonctionnent sans elle.",
+	"meetPermissionInfo": "Nécessite l'autorisation Enregistrement de l'écran. Zoom et Teams fonctionnent sans.",
 	"microphonePermission": "Microphone",
 	"microphonePermissionInfo": "Requis pour enregistrer le son du microphone.",
 	"systemAudioPermission": "Audio du système",

--- a/i18n/translations/he-IL/desktop.json
+++ b/i18n/translations/he-IL/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "קיצור דרך",
 	"recordingShortcutInfo": "לחצו פעם אחת כדי להתחיל להקליט ופעם נוספת כדי לעצור.",
 	"meetPermission": "זיהוי Google Meet",
-	"meetPermissionInfo": "זיהוי שיחת Meet דורש קריאה של כותרת חלון הדפדפן, ומערכת macOS מאפשרת זאת רק בהרשאת הקלטת מסך. Zoom ו-Teams פועלים גם בלעדיה.",
+	"meetPermissionInfo": "דורש הרשאת הקלטת מסך. Zoom ו-Teams עובדים גם בלעדיה.",
 	"microphonePermission": "מיקרופון",
 	"microphonePermissionInfo": "נדרשת הרשאה להקלטת שמע מהמיקרופון.",
 	"systemAudioPermission": "שמע המערכת",

--- a/i18n/translations/hi-IN/desktop.json
+++ b/i18n/translations/hi-IN/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "शॉर्टकट",
 	"recordingShortcutInfo": "रिकॉर्डिंग शुरू करने के लिए एक बार और बंद करने के लिए फिर से दबाएँ।",
 	"meetPermission": "Google Meet पहचान",
-	"meetPermissionInfo": "Meet कॉल को पहचानने के लिए आपके ब्राउज़र की विंडो का टाइटल पढ़ना ज़रूरी है, जिसकी अनुमति macOS केवल स्क्रीन रिकॉर्डिंग अनुमति के साथ देता है। Zoom और Teams बिना इसके भी काम करते हैं।",
+	"meetPermissionInfo": "स्क्रीन रिकॉर्डिंग अनुमति चाहिए। Zoom और Teams इसके बिना काम करते हैं।",
 	"microphonePermission": "माइक्रोफ़ोन",
 	"microphonePermissionInfo": "माइक्रोफ़ोन ऑडियो रिकॉर्ड करने के लिए आवश्यक।",
 	"systemAudioPermission": "सिस्टम ऑडियो",

--- a/i18n/translations/it-IT/desktop.json
+++ b/i18n/translations/it-IT/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Scorciatoia",
 	"recordingShortcutInfo": "Premi una volta per avviare la registrazione e di nuovo per interromperla.",
 	"meetPermission": "Rilevamento di Google Meet",
-	"meetPermissionInfo": "Riconoscere una chiamata Meet richiede la lettura del titolo della finestra del browser, cosa che macOS consente solo con l'autorizzazione Registrazione schermo. Zoom e Teams funzionano anche senza.",
+	"meetPermissionInfo": "Richiede l'autorizzazione Registrazione schermo. Zoom e Teams funzionano senza.",
 	"microphonePermission": "Microfono",
 	"microphonePermissionInfo": "Necessario per registrare l'audio del microfono.",
 	"systemAudioPermission": "Audio di sistema",

--- a/i18n/translations/ja-JP/desktop.json
+++ b/i18n/translations/ja-JP/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "ショートカット",
 	"recordingShortcutInfo": "1回押すと録音を開始し、もう一度押すと停止します。",
 	"meetPermission": "Google Meetの検出",
-	"meetPermissionInfo": "Meetの通話を認識するには、ブラウザのウィンドウタイトルを読み取る必要があり、macOSでは「画面収録」権限がある場合のみ許可されます。ZoomとTeamsはこの権限がなくても動作します。",
+	"meetPermissionInfo": "「画面収録」の権限が必要です。Zoom と Teams は権限なしで動作します。",
 	"microphonePermission": "マイク",
 	"microphonePermissionInfo": "マイクの音声を録音するために必要です。",
 	"systemAudioPermission": "システムオーディオ",

--- a/i18n/translations/ko-KR/desktop.json
+++ b/i18n/translations/ko-KR/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "단축키",
 	"recordingShortcutInfo": "한 번 누르면 녹음을 시작하고 다시 누르면 중지합니다.",
 	"meetPermission": "Google Meet 감지",
-	"meetPermissionInfo": "Meet 통화를 인식하려면 브라우저 창 제목을 읽어야 하며, macOS는 화면 기록 권한이 있을 때만 이를 허용합니다. Zoom과 Teams는 이 권한 없이도 작동합니다.",
+	"meetPermissionInfo": "화면 기록 권한이 필요합니다. Zoom과 Teams는 없어도 작동합니다.",
 	"microphonePermission": "마이크",
 	"microphonePermissionInfo": "마이크 오디오를 녹음하는 데 필요합니다.",
 	"systemAudioPermission": "시스템 오디오",

--- a/i18n/translations/no-NO/desktop.json
+++ b/i18n/translations/no-NO/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Hurtigtast",
 	"recordingShortcutInfo": "Trykk én gang for å starte opptaket og én gang til for å stoppe.",
 	"meetPermission": "Google Meet-gjenkjenning",
-	"meetPermissionInfo": "Å gjenkjenne en Meet-samtale krever lesing av vindustittelen i nettleseren din, noe macOS bare tillater med tillatelsen Skjermopptak. Zoom og Teams fungerer uten den.",
+	"meetPermissionInfo": "Krever tillatelse til skjermopptak. Zoom og Teams fungerer uten.",
 	"microphonePermission": "Mikrofon",
 	"microphonePermissionInfo": "Kreves for å ta opp lyd fra mikrofonen.",
 	"systemAudioPermission": "Systemlyd",

--- a/i18n/translations/pl-PL/desktop.json
+++ b/i18n/translations/pl-PL/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Skrót",
 	"recordingShortcutInfo": "Naciśnij raz, aby rozpocząć nagrywanie, i ponownie, aby je zatrzymać.",
 	"meetPermission": "Wykrywanie Google Meet",
-	"meetPermissionInfo": "Rozpoznanie rozmowy w Meet wymaga odczytu tytułu okna przeglądarki, na co macOS zezwala tylko z uprawnieniem Nagrywanie ekranu. Zoom i Teams działają bez niego.",
+	"meetPermissionInfo": "Wymaga uprawnienia Nagrywanie ekranu. Zoom i Teams działają bez niego.",
 	"microphonePermission": "Mikrofon",
 	"microphonePermissionInfo": "Wymagane do nagrywania dźwięku z mikrofonu.",
 	"systemAudioPermission": "Dźwięk systemowy",

--- a/i18n/translations/pt-BR/desktop.json
+++ b/i18n/translations/pt-BR/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Atalho",
 	"recordingShortcutInfo": "Pressione uma vez para iniciar a gravação e novamente para parar.",
 	"meetPermission": "Detecção do Google Meet",
-	"meetPermissionInfo": "Reconhecer uma chamada do Meet exige ler o título da janela do seu navegador, algo que o macOS só permite com a permissão de Gravação de tela. Zoom e Teams funcionam sem ela.",
+	"meetPermissionInfo": "Requer permissão de Gravação de tela. Zoom e Teams funcionam sem ela.",
 	"microphonePermission": "Microfone",
 	"microphonePermissionInfo": "Necessário para gravar o áudio do microfone.",
 	"systemAudioPermission": "Áudio do sistema",

--- a/i18n/translations/ru-RU/desktop.json
+++ b/i18n/translations/ru-RU/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Сочетание клавиш",
 	"recordingShortcutInfo": "Нажмите один раз, чтобы начать запись, и ещё раз, чтобы остановить.",
 	"meetPermission": "Распознавание Google Meet",
-	"meetPermissionInfo": "Для распознавания звонка в Meet требуется чтение заголовка окна браузера, а macOS разрешает это только при наличии разрешения «Запись экрана». Zoom и Teams работают без него.",
+	"meetPermissionInfo": "Требуется разрешение «Запись экрана». Zoom и Teams работают без него.",
 	"microphonePermission": "Микрофон",
 	"microphonePermissionInfo": "Требуется для записи звука с микрофона.",
 	"systemAudioPermission": "Системный звук",

--- a/i18n/translations/sv-SE/desktop.json
+++ b/i18n/translations/sv-SE/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Kortkommando",
 	"recordingShortcutInfo": "Tryck en gång för att starta inspelningen och en gång till för att stoppa.",
 	"meetPermission": "Google Meet-identifiering",
-	"meetPermissionInfo": "Att identifiera ett Meet-samtal kräver att fönstertiteln i din webbläsare läses, vilket macOS bara tillåter med behörigheten Skärminspelning. Zoom och Teams fungerar utan den.",
+	"meetPermissionInfo": "Kräver behörighet för Skärminspelning. Zoom och Teams fungerar utan.",
 	"microphonePermission": "Mikrofon",
 	"microphonePermissionInfo": "Krävs för att spela in ljud från mikrofonen.",
 	"systemAudioPermission": "Systemljud",

--- a/i18n/translations/tr-TR/desktop.json
+++ b/i18n/translations/tr-TR/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Kısayol",
 	"recordingShortcutInfo": "Kaydı başlatmak için bir kez, durdurmak için tekrar basın.",
 	"meetPermission": "Google Meet algılama",
-	"meetPermissionInfo": "Bir Meet görüşmesini tanımak, tarayıcınızın pencere başlığını okumayı gerektirir; macOS buna yalnızca Ekran Kaydı izniyle izin verir. Zoom ve Teams bu izin olmadan da çalışır.",
+	"meetPermissionInfo": "Ekran Kaydı izni gerekir. Zoom ve Teams bu izin olmadan çalışır.",
 	"microphonePermission": "Mikrofon",
 	"microphonePermissionInfo": "Mikrofon sesini kaydetmek için gereklidir.",
 	"systemAudioPermission": "Sistem sesi",

--- a/i18n/translations/vi-VN/desktop.json
+++ b/i18n/translations/vi-VN/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "Phím tắt",
 	"recordingShortcutInfo": "Nhấn một lần để bắt đầu ghi âm và nhấn lại để dừng.",
 	"meetPermission": "Phát hiện Google Meet",
-	"meetPermissionInfo": "Nhận diện cuộc gọi Meet yêu cầu đọc tiêu đề cửa sổ trình duyệt của bạn, điều mà macOS chỉ cho phép khi có quyền Ghi màn hình. Zoom và Teams hoạt động mà không cần quyền này.",
+	"meetPermissionInfo": "Cần quyền Ghi màn hình. Zoom và Teams hoạt động mà không cần quyền này.",
 	"microphonePermission": "Micrô",
 	"microphonePermissionInfo": "Cần thiết để ghi âm thanh từ micrô.",
 	"systemAudioPermission": "Âm thanh hệ thống",

--- a/i18n/translations/zh-CN/desktop.json
+++ b/i18n/translations/zh-CN/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "快捷键",
 	"recordingShortcutInfo": "按一次开始录音，再按一次停止。",
 	"meetPermission": "Google Meet 检测",
-	"meetPermissionInfo": "识别 Meet 通话需要读取浏览器的窗口标题，而 macOS 仅在授予「屏幕录制」权限时才允许此操作。Zoom 和 Teams 无需此权限即可使用。",
+	"meetPermissionInfo": "需要「屏幕录制」权限。Zoom 和 Teams 无需此权限即可使用。",
 	"microphonePermission": "麦克风",
 	"microphonePermissionInfo": "录制麦克风音频时需要此权限。",
 	"systemAudioPermission": "系统音频",

--- a/i18n/translations/zh-HK/desktop.json
+++ b/i18n/translations/zh-HK/desktop.json
@@ -246,7 +246,7 @@
 	"recordingShortcut": "快捷鍵",
 	"recordingShortcutInfo": "按一下開始錄音，再按一下停止。",
 	"meetPermission": "Google Meet 偵測",
-	"meetPermissionInfo": "識別 Meet 通話需要讀取瀏覽器的視窗標題，而 macOS 只有在授予「螢幕錄製」權限時才允許此操作。Zoom 和 Teams 毋須此權限即可使用。",
+	"meetPermissionInfo": "需要「螢幕錄製」權限。Zoom 和 Teams 毋須此權限亦可使用。",
 	"microphonePermission": "咪高峰",
 	"microphonePermissionInfo": "錄製咪高峰音訊時需要此權限。",
 	"systemAudioPermission": "系統音訊",


### PR DESCRIPTION
The description explained the mechanism — window titles, why macOS gates them — before getting to the point. The row only needs the permission's name and the fact that Zoom and Teams are unaffected; the link beside it does the rest.

Before: *"Recognising a Meet call means reading your browser's window title, which macOS allows only with Screen Recording permission. Zoom and Teams work without it."*

After: *"Needs Screen Recording permission. Zoom and Teams work without it."*

Shortened in all 21 locales, each using that OS's own name for the permission. The link drops from `text-sm` to `text-xs`, matching the secondary text around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)