### PR TITLE
Format the handoff model settings read

### DIFF
--- a/desktop/src-tauri/src/handoff/transcribe.rs
+++ b/desktop/src-tauri/src/handoff/transcribe.rs
@@ -348,7 +348,10 @@ pub(super) fn model_settings(app_handle: &tauri::AppHandle) -> Option<ModelSetti
         .get(CONFIG_KEY_GPU_DEVICE)
         .and_then(|value| value.as_i64())
         .map(|value| value as i32);
-    let no_gpu = store.get(CONFIG_KEY_NO_GPU).and_then(|value| value.as_bool()).unwrap_or(false);
+    let no_gpu = store
+        .get(CONFIG_KEY_NO_GPU)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
     let unload_timeout_minutes = store
         .get(CONFIG_KEY_UNLOAD_TIMEOUT_MINUTES)
         .and_then(|value| value.as_u64())


### PR DESCRIPTION
The `no_gpu` lookup added in #1457 was written on one line while the `gpu_device` and `unload_timeout_minutes` reads either side of it wrap across four. `cargo fmt` disagrees, and the fmt job on #1460 failed for it.

Formatting only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)