### PR TITLE
Replace the justfile with a chorefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Tooling
 
-- Tasks: `just` — see `just --list`
+- Tasks: `chore` — see `chore list`
 - JS: `pnpm` only; Python: `uv` standalone scripts (`uv run`)
 
 ## Validation

--- a/chorefile
+++ b/chorefile
@@ -1,0 +1,163 @@
+# Vibe development tasks. Run `chore list` to see them.
+#
+# Replaces the justfile. The Python scripts under scripts/ are still the
+# programs they always were — these tasks call them, they do not reimplement
+# them. The one exception is `setup`, which is pure download-and-place and so
+# is written here directly.
+
+sona=$(read .sona-version)
+bin=desktop/src-tauri/binaries
+
+# Fetch the sona and ffmpeg sidecars for this machine.
+task setup target=$TRIPLE {
+    # $1 is the target: this machine by default, or an explicit triple when
+    # CI cross-compiles. The asset names are sona's own; the triple is also
+    # what the sidecar must be called, because Tauri looks for
+    # `sona-<triple>` beside the binary.
+    if $1 == aarch64-apple-darwin {
+        asset=sona-darwin-arm64-with-ffmpeg.tar.gz
+    } else if $1 == x86_64-apple-darwin {
+        asset=sona-darwin-amd64-with-ffmpeg.tar.gz
+    } else if $1 == x86_64-pc-windows-msvc {
+        asset=sona-windows-amd64-with-ffmpeg.zip
+    } else if $1 == x86_64-unknown-linux-gnu {
+        asset=sona-linux-amd64
+    } else if $1 == aarch64-unknown-linux-gnu {
+        asset=sona-linux-arm64
+    } else {
+        fail "sona publishes no build for $1"
+    }
+
+    # $exe is the *host's* suffix, and $1 may name another platform, so the
+    # suffix has to come from the target rather than from this machine.
+    exe=""
+    if $1 contains windows { exe=.exe }
+
+    mkdir $bin
+    if exists $bin/sona-$1$exe {
+        echo "sidecars for $1 are already in place"
+        return
+    }
+
+    if $OS == linux {
+        # Linux ships the bare binary, with no ffmpeg alongside it.
+        download gh://vibe-transcribe/sona/$sona/$asset $bin/sona-$1
+        chmod 755 $bin/sona-$1
+        echo "installed sona-$1"
+        return
+    }
+
+    # macOS and Windows ship an archive holding sona and ffmpeg. --flatten
+    # drops whatever directories the archive puts them under, so they land in
+    # $bin at a name we know; the moves only rename.
+    mkdir target/sidecars
+    download gh://vibe-transcribe/sona/$sona/$asset target/sidecars/$asset
+    extract target/sidecars/$asset $bin --member sona$exe --flatten
+    extract target/sidecars/$asset $bin --member ffmpeg$exe --flatten
+    move $bin/sona$exe $bin/sona-$1$exe
+    move $bin/ffmpeg$exe $bin/ffmpeg-$1$exe
+    remove target/sidecars/$asset
+    if $OS != windows {
+        chmod 755 $bin/sona-$1
+        chmod 755 $bin/ffmpeg-$1
+    }
+    echo "installed sona-$1 and ffmpeg-$1"
+}
+
+# Install the frontend dependencies.
+task install {
+    cd desktop
+    pnpm install
+}
+
+# Run the app in dev mode.
+task dev {
+    setup
+    cd desktop
+    pnpm exec tauri dev
+}
+
+# Run only the desktop frontend in a browser, with Tauri mocked.
+task dev-web {
+    cd desktop
+    pnpm dev
+}
+
+# Build the app for production.
+task build {
+    setup
+    cd desktop
+    pnpm exec tauri build
+}
+
+# Run the website locally.
+task website {
+    cd website
+    pnpm install
+    pnpm dev
+}
+
+# Run the frontend tests.
+task test {
+    cd desktop
+    pnpm test
+}
+
+# Lint the frontend and Rust, with the flags CI uses.
+task lint {
+    cd desktop
+    pnpm lint
+    cd $ROOT
+    # These match .github/workflows/lint_rust.yml exactly. The justfile's
+    # versions had drifted -- no --all, no --all-targets, no -D warnings --
+    # so a clean `just lint` said nothing about whether CI would pass.
+    cargo fmt --manifest-path Cargo.toml --all -- --check
+    cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings
+}
+
+# Format everything in place.
+task format {
+    pnpm format
+    cargo fmt
+}
+
+# Regenerate the i18n files.
+task i18n {
+    cd desktop
+    pnpm i18n:generate
+}
+
+# Check translation coverage against en-US.
+task check-i18n {
+    uv run scripts/check_i18n.py
+}
+
+# Type-check the desktop app and the website.
+task check-types {
+    pnpm check-types
+}
+
+# Build the browser wasm client into handoff/pwa/public/wasm.
+task phone-wasm {
+    ./handoff/wasm/build.sh
+}
+
+# Run the phone PWA on http://localhost:8088.
+task phone {
+    phone-wasm
+    cd handoff/pwa
+    pnpm install
+    pnpm dev
+}
+
+# Send an audio file to a running Vibe: phone-probe <pairing-url> <file>.
+task phone-probe url file {
+    cd handoff/probe
+    cargo run --quiet -- --url $1 --file ../../$2
+}
+
+# Ask a running Vibe what it supports: phone-caps <pairing-url>.
+task phone-caps url {
+    cd handoff/probe
+    cargo run --quiet -- --url $1 --capabilities
+}

--- a/docs/building.md
+++ b/docs/building.md
@@ -4,15 +4,13 @@
 
 [pnpm](https://pnpm.io/) | [uv](https://docs.astral.sh/uv/) | [Cargo](https://www.rust-lang.org/tools/install)
 
-Optionally install [just](https://github.com/casey/just) to use the shortcuts in the root `justfile` (run `just` to list them):
+Install [chore](https://getchore.github.io/chore/) to use the tasks in the root `chorefile` (run `chore list` to see them):
 
 ```console
+# macOS / Linux
+curl -fsSL https://getchore.github.io/chore/install.sh | sh
 # Windows
-winget install Casey.Just
-# macOS
-brew install just
-# Linux
-sudo apt install just   # or: cargo install just
+irm https://getchore.github.io/chore/install.ps1 | iex
 ```
 
 **Linux**:
@@ -30,36 +28,23 @@ Make sure to install XCode from the AppStore and open it once so it will downloa
 
 ## Build
 
-Run the pre-build script (downloads the Sona runner binary and sets up platform deps):
-
 ```console
-uv run scripts/pre_build.py
+chore dev      # fetch the sidecars, then run the app
+chore build    # fetch the sidecars, then build for production
 ```
 
-Install frontend dependencies from `desktop` folder:
+Both start with `chore setup`, which downloads the sidecars pinned by
+`.sona-version` into `desktop/src-tauri/binaries/`. The same steps by hand:
 
 ```console
+chore setup            # or: uv run scripts/pre_build.py
 cd desktop
 pnpm install
+pnpm exec tauri dev    # or: pnpm exec tauri build
 ```
 
-Start dev mode:
-
-```console
-pnpm exec tauri dev
-```
-
-Or build for production:
-
-```console
-pnpm exec tauri build
-```
-
-You can also do it all in one step:
-
-```console
-uv run scripts/pre_build.py --dev   # or --build
-```
+`pre_build.py` also takes `--target <triple>` for cross-compiles and
+`--dev` / `--build` to chain into Tauri.
 
 ## Build sona locally (dev)
 
@@ -101,6 +86,12 @@ cp desktop/src-tauri/binaries/sona-$(rustc -vV | awk '/host:/ {print $2}') targe
 ## Test
 
 ```console
+chore test     # frontend tests (vitest)
+```
+
+Rust tests:
+
+```console
 export RUST_LOG=trace
 cargo test -- --nocapture
 ```
@@ -108,8 +99,10 @@ cargo test -- --nocapture
 # Lint
 
 ```console
-cargo fmt
-cargo clippy
+chore lint         # eslint, then cargo fmt and clippy with CI's flags
+chore format       # prettier and cargo fmt, in place
+chore check-types  # tsc over desktop and website
+chore check-i18n   # translation coverage against en-US
 ```
 
 # Create new release


### PR DESCRIPTION
`chore` is a single binary that runs tasks through its own interpreter, so `setup`/`dev`/`build`/`lint` behave the same on macOS, Linux and Windows. The tasks call the existing scripts under `scripts/`; only `setup` is written out in the chorefile directly.

`docs/building.md` and `AGENTS.md` now point at `chore list` instead of `just`.

Note: the old `justfile` is still in the tree — nothing references it any more, so it can go in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)