### PR TITLE
Retry transcription on GPU out-of-memory

### DIFF
--- a/desktop/src/lib/analytics.ts
+++ b/desktop/src/lib/analytics.ts
@@ -8,6 +8,7 @@ export const analyticsEvents = {
 	TRANSCRIBE_SUCCEEDED: 'transcribe_succeeded',
 	TRANSCRIBE_FAILED: 'transcribe_failed',
 	TRANSCRIBE_CANCELLED: 'transcribe_cancelled',
+	GPU_OUT_OF_MEMORY: 'gpu_out_of_memory',
 } as const
 
 /** Which of the four transcription entry points an event came from. */
@@ -77,6 +78,14 @@ export function trackTranscribeFailed(source: TranscribeSource, path: string, op
 }
 
 /** The user stopped this run. The backend returns the partial result as a success, so only the UI knows. */
+/**
+ * The GPU ran out of memory mid-run and the model was reloaded on the CPU. `signal` says how it
+ * showed: an error code from sona, or the process aborting on the allocation.
+ */
+export function trackGpuOutOfMemory(source: TranscribeSource, options: { signal: 'error_code' | 'process_death' }) {
+	void trackAnalyticsEvent(analyticsEvents.GPU_OUT_OF_MEMORY, { source, signal: options.signal })
+}
+
 export function trackTranscribeCancelled(source: TranscribeSource, path: string) {
 	return trackAnalyticsEvent(analyticsEvents.TRANSCRIBE_CANCELLED, {
 		source,

--- a/desktop/src/lib/config-keys.ts
+++ b/desktop/src/lib/config-keys.ts
@@ -20,6 +20,8 @@ export const CONFIG_KEYS = {
 	modelDisplayNames: 'model.displayNames',
 	gpuDevice: 'model.gpuDevice',
 	noGpu: 'model.noGpu',
+	/** Models that ran out of GPU memory here, loaded on the CPU from then on. */
+	gpuOutOfMemoryModels: 'model.gpuOutOfMemoryModels',
 	unloadTimeoutMinutes: 'model.unloadTimeoutMinutes',
 	modelPromptDismissed: 'model.downloadPromptDismissed',
 

--- a/desktop/src/lib/gpu-memory.ts
+++ b/desktop/src/lib/gpu-memory.ts
@@ -1,0 +1,15 @@
+import { CONFIG_KEYS } from './config-keys'
+import { readConfig, writeConfig } from './config-store'
+
+/**
+ * Whether this model has run out of GPU memory on this machine before. The verdict is kept per
+ * model: a smaller one may still fit, and the user did not ask to give up the GPU everywhere.
+ */
+export function gpuOutOfMemoryBefore(modelPath: string | null): boolean {
+	return modelPath !== null && readConfig<string[]>(CONFIG_KEYS.gpuOutOfMemoryModels, []).includes(modelPath)
+}
+
+export function rememberGpuOutOfMemory(modelPath: string | null) {
+	if (modelPath === null || gpuOutOfMemoryBefore(modelPath)) return
+	writeConfig(CONFIG_KEYS.gpuOutOfMemoryModels, [...readConfig<string[]>(CONFIG_KEYS.gpuOutOfMemoryModels, []), modelPath])
+}

--- a/desktop/src/lib/sona-errors.test.ts
+++ b/desktop/src/lib/sona-errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isGpuOutOfMemory, sonaErrorCodes } from './sona-errors'
+
+describe('isGpuOutOfMemory', () => {
+	it('trusts the code sona reports on a failed GPU allocation', () => {
+		expect(isGpuOutOfMemory(sonaErrorCodes.GPU_OUT_OF_MEMORY, 'vk::Device::allocateMemory: ErrorOutOfDeviceMemory')).toBe(true)
+	})
+
+	it('reads the abort message when the allocation killed the process', () => {
+		const report = 'sona process died during transcription (exited with code -1073740791)\n\nsona stderr: memory allocation of 1610612736 bytes failed'
+		expect(isGpuOutOfMemory(sonaErrorCodes.INTERNAL_ERROR, report)).toBe(true)
+	})
+
+	it('leaves system memory exhaustion alone, since the CPU would fail the same way', () => {
+		expect(isGpuOutOfMemory(sonaErrorCodes.OUT_OF_MEMORY, 'failed to allocate 3 GiB')).toBe(false)
+	})
+
+	it('does not read memory into an unrelated death or stream failure', () => {
+		expect(isGpuOutOfMemory(sonaErrorCodes.INTERNAL_ERROR, 'sona process died during transcription (killed by signal 9)')).toBe(false)
+		expect(isGpuOutOfMemory(sonaErrorCodes.INTERNAL_ERROR, 'failed to read sona event line: invalid json')).toBe(false)
+	})
+})

--- a/desktop/src/lib/sona-errors.ts
+++ b/desktop/src/lib/sona-errors.ts
@@ -3,6 +3,10 @@ export const sonaErrorCodes = {
 	INVALID_AUDIO: 'invalid_audio',
 	BUSY: 'busy',
 	NO_MODEL: 'no_model',
+	/** The GPU could not allocate; reloading on the CPU is the one thing a client can do about it. */
+	GPU_OUT_OF_MEMORY: 'gpu_out_of_memory',
+	/** System memory ran out, so the CPU would fail the same way. */
+	OUT_OF_MEMORY: 'out_of_memory',
 	INTERNAL_ERROR: 'internal_error',
 } as const
 
@@ -23,6 +27,20 @@ export function isUserError(code: string): code is UserErrorCode {
 const SONA_DIED_PREFIX = 'sona process died'
 
 export type FatalRunError = 'no_model' | 'engine_died'
+
+/** What Rust prints before aborting when an allocation fails; the process dies without an error code. */
+const ALLOCATION_FAILED = /memory allocation of \d+ bytes failed/
+
+/**
+ * Whether the GPU ran out of memory. sona names it with a code when it can answer at all; when the
+ * allocation aborts the process instead, the only evidence is the stderr in the death report, and
+ * the caller decides whether the GPU was even in use. A plain `out_of_memory` is system RAM, which
+ * the CPU cannot fix, so it stays false.
+ */
+export function isGpuOutOfMemory(code: string | undefined, message: string): boolean {
+	if (code === sonaErrorCodes.GPU_OUT_OF_MEMORY) return true
+	return message.includes(SONA_DIED_PREFIX) && ALLOCATION_FAILED.test(message)
+}
 
 /**
  * Why this error dooms every file still queued behind the one that hit it, or `null` when it only

--- a/desktop/src/pages/batch/view-model.tsx
+++ b/desktop/src/pages/batch/view-model.tsx
@@ -4,6 +4,7 @@ import { m } from '~/paraglide/messages.js'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { TextFormat, formatExtensions } from '~/components/format-select'
 import { Segment, Transcript, asCsv, asJson, asSrt, asText, asVtt } from '~/lib/transcript'
+import { gpuOutOfMemoryBefore } from '~/lib/gpu-memory'
 import { fatalRunError, isUserError } from '~/lib/sona-errors'
 import { NamedPath } from '~/lib/types'
 import { pathToNamedPath } from '~/lib/fs'
@@ -164,6 +165,7 @@ export function viewModel() {
 		const loadResult = await invoke<string>('load_model', {
 			modelPath: preference.modelPath,
 			gpuDevice: preference.gpuDevice,
+			noGpu: preference.noGpu || gpuOutOfMemoryBefore(preference.modelPath),
 			unloadTimeoutMinutes: preference.unloadTimeoutMinutes,
 		})
 		if (loadResult === 'gpu_fallback') {

--- a/desktop/src/pages/main/hooks/use-transcribe-queue.ts
+++ b/desktop/src/pages/main/hooks/use-transcribe-queue.ts
@@ -5,12 +5,13 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import successSound from '~/assets/success.mp3'
 import { m } from '~/paraglide/messages.js'
-import { trackTranscribeCancelled, trackTranscribeFailed, trackTranscribeStarted, trackTranscribeSucceeded } from '~/lib/analytics'
+import { trackGpuOutOfMemory, trackTranscribeCancelled, trackTranscribeFailed, trackTranscribeStarted, trackTranscribeSucceeded } from '~/lib/analytics'
 import * as config from '~/lib/config'
 import { KEEP_AWAKE, startKeepAwake, stopKeepAwake } from '~/lib/keep-awake'
 import { validPath } from '~/lib/media'
 import { autoProjectName } from '~/lib/project-name'
-import { fatalRunError, isUserError } from '~/lib/sona-errors'
+import { gpuOutOfMemoryBefore, rememberGpuOutOfMemory } from '~/lib/gpu-memory'
+import { fatalRunError, isGpuOutOfMemory, isUserError, sonaErrorCodes } from '~/lib/sona-errors'
 import type { Segment, SpeakerNames, Transcript } from '~/lib/transcript'
 import {
 	notifyTranscriptsChanged,
@@ -109,6 +110,22 @@ async function buildSharedOptions(preference: Preference) {
 		...(preference.diarizeEnabled ? { diarize_model: `${modelsFolder}/${config.diarizeModelFilename}` } : {}),
 		...(preference.stableTimestampsEnabled || requiresVad ? { vad_model: `${modelsFolder}/${config.vadModelFilename}` } : {}),
 		...(preference.stableTimestampsEnabled ? { stable_timestamps: true } : {}),
+	}
+}
+
+/** Reload the current model on the CPU. False when even that failed, so the original error stands. */
+async function reloadOnCpu(preference: Preference): Promise<boolean> {
+	try {
+		await invoke('load_model', {
+			modelPath: preference.modelPath,
+			gpuDevice: preference.gpuDevice,
+			noGpu: true,
+			unloadTimeoutMinutes: preference.unloadTimeoutMinutes,
+		})
+		return true
+	} catch (error) {
+		console.error('reloading on the CPU after the GPU ran out of memory failed', error)
+		return false
 	}
 }
 
@@ -284,12 +301,16 @@ export function useTranscribeQueue(): TranscribeQueue {
 				return
 			}
 
+			// Once the GPU runs out of memory the rest of the run stays on the CPU, and so does
+			// this model on every later launch: a loaded model that fits can still overflow once
+			// the working buffers of a long file or diarization arrive.
+			let onCpu = current.noGpu || gpuOutOfMemoryBefore(current.modelPath)
 			let shared: Record<string, unknown>
 			try {
 				const loadResult = await invoke<string>('load_model', {
 					modelPath: current.modelPath,
 					gpuDevice: current.gpuDevice,
-					noGpu: current.noGpu,
+					noGpu: onCpu,
 					unloadTimeoutMinutes: current.unloadTimeoutMinutes,
 				})
 				if (loadResult === 'gpu_fallback') toast.warning(m.gpuFallbackToCpu(), { position: 'bottom-center', duration: 8000 })
@@ -346,6 +367,15 @@ export function useTranscribeQueue(): TranscribeQueue {
 						trackTranscribeCancelled('main', next.path)
 					} else {
 						const { code, message } = errorParts(error)
+						if (!onCpu && isGpuOutOfMemory(code, message) && (await reloadOnCpu(current))) {
+							onCpu = true
+							rememberGpuOutOfMemory(current.modelPath)
+							trackGpuOutOfMemory('main', { signal: code === sonaErrorCodes.GPU_OUT_OF_MEMORY ? 'error_code' : 'process_death' })
+							toast.warning(m.gpuFallbackToCpu(), { position: 'bottom-center', duration: 8000 })
+							// Back to the queue for one more try; on the CPU an overflow is the plain error.
+							patch(next.id, { status: 'queued', progress: 0 })
+							continue
+						}
 						patch(next.id, { status: 'error', progress: 0, error: message })
 						const userError = Boolean(code && isUserError(code))
 						trackTranscribeFailed('main', next.path, { errorMessage: message, userError })

--- a/desktop/src/providers/hotkey.tsx
+++ b/desktop/src/providers/hotkey.tsx
@@ -6,6 +6,7 @@ import * as clipboard from '@tauri-apps/plugin-clipboard-manager'
 import { trackTranscribeFailed, trackTranscribeStarted, trackTranscribeSucceeded } from '~/lib/analytics'
 import { AudioDevice } from '~/lib/audio'
 import { CONFIG_KEYS } from '~/lib/config-keys'
+import { gpuOutOfMemoryBefore } from '~/lib/gpu-memory'
 import { usePersisted } from '~/lib/config-store'
 import { Claude, Llm, Ollama, OpenAICompatible } from '~/lib/llm'
 import { withoutUnsupportedOptions } from '~/lib/model'
@@ -205,7 +206,7 @@ export function HotkeyProvider({ children }: { children: ReactNode }) {
 				await invoke('load_model', {
 					modelPath,
 					gpuDevice: preferenceRef.current.gpuDevice,
-					noGpu: preferenceRef.current.noGpu,
+					noGpu: preferenceRef.current.noGpu || gpuOutOfMemoryBefore(modelPath),
 					unloadTimeoutMinutes: preferenceRef.current.unloadTimeoutMinutes,
 				})
 				const requiresVad = preferenceRef.current.modelMetadata?.capabilities.requires_vad ?? false


### PR DESCRIPTION
Rewritten on top of #1494 so it lands where transcription actually runs. Thanks @mikemikimike for the report and the first pass.

sona v0.6.3 (vibe-transcribe/sona#46) reports a failed GPU allocation as `gpu_out_of_memory` on the response, the streaming error event, and model load. When the allocation aborts the process instead, the only evidence is the `memory allocation of N bytes failed` line in its stderr, which the desktop already captures in the death report.

- `isGpuOutOfMemory` in `sona-errors.ts` reads the code first and the abort text as fallback; a plain `out_of_memory` (system RAM) stays false since the CPU would fail the same way
- The transcribe queue (the routed path; `pages/home/hooks/use-transcription.ts` is not) reloads the model with `noGpu`, requeues the file for one more try, toasts `gpuFallbackToCpu`, and keeps the CPU for the rest of the run
- The verdict is kept per model in `model.gpuOutOfMemoryModels`, so the next launch starts on the CPU; batch and dictation read it at load. Batch also now honours the `noGpu` setting, which it skipped before
- One analytics event, `gpu_out_of_memory`, with the source and whether the code or the process death signalled it
- Unit test for the classifier

Not in this PR: a way to clear the per-model verdict from Settings. Deleting the entry in `app_config.json` works meanwhile.

Closes #1471

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna