### PR TITLE
Take several links at once, skip the ones that fail, and clear the box on Transcribe

### DIFF
--- a/desktop/src/lib/ytdlp.test.ts
+++ b/desktop/src/lib/ytdlp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isNewerVersion } from './ytdlp'
+import { isNewerVersion, parseMediaLinks } from './ytdlp'
 
 describe('isNewerVersion', () => {
 	it('compares calendar versions by number, not as strings', () => {
@@ -28,5 +28,16 @@ describe('isNewerVersion', () => {
 	it('never prompts on a candidate it cannot parse', () => {
 		expect(isNewerVersion('nightly', '2026.08.19')).toBe(false)
 		expect(isNewerVersion('', '2026.08.19')).toBe(false)
+	})
+})
+
+describe('parseMediaLinks', () => {
+	it('takes one link per line, or several on a line, without repeats', () => {
+		expect(parseMediaLinks('https://a.example/1\nhttps://a.example/2\r\n\n  https://a.example/1 https://a.example/3  ')).toEqual([
+			'https://a.example/1',
+			'https://a.example/2',
+			'https://a.example/3',
+		])
+		expect(parseMediaLinks('   ')).toEqual([])
 	})
 })

--- a/desktop/src/lib/ytdlp.ts
+++ b/desktop/src/lib/ytdlp.ts
@@ -56,3 +56,8 @@ export async function downloadAudio(url: string) {
 	await invoke<string>('download_audio', { url, outPath })
 	return outPath
 }
+
+/** Every link in the box, one per line or several separated by spaces, without repeats. */
+export function parseMediaLinks(input: string): string[] {
+	return [...new Set(input.split(/\s+/).filter(Boolean))]
+}

--- a/desktop/src/mock-tauri/handlers/media-misc.ts
+++ b/desktop/src/mock-tauri/handlers/media-misc.ts
@@ -153,6 +153,8 @@ export const mediaMiscHandlers: CommandHandlerMap = {
 	set_tray: async () => null,
 
 	download_audio: async (args) => {
+		// A link with "fail" in it stands in for a site yt-dlp cannot fetch.
+		if (String(args?.url ?? '').includes('fail')) throw new Error(`[mock] yt-dlp could not download ${String(args?.url)}`)
 		const outPath = String(args?.outPath ?? `${APP_LOCAL_DATA}/tmp.m4a`)
 		let cancelled = false
 		const unsub = onMockEvent('ytdlp-cancel', () => {

--- a/desktop/src/pages/home/hooks/use-audio-download.ts
+++ b/desktop/src/pages/home/hooks/use-audio-download.ts
@@ -16,7 +16,14 @@ const FALLBACK_YTDLP_VERSION = '2026.08.19'
 /** yt-dlp ships almost daily; asking GitHub more often than weekly only produces noise. */
 const UPDATE_CHECK_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000
 
-export function useAudioDownload(transcribe: (path: string) => Promise<void>) {
+/** Where a multi-link download is: which link is being fetched, out of how many. */
+export interface DownloadBatch {
+	index: number
+	total: number
+	url: string
+}
+
+export function useAudioDownload(transcribe: (paths: string[]) => Promise<void>) {
 	const preference = usePreferenceProvider()
 	const { setFiles } = useFilesContext()
 	const progressToast = useToastProvider()
@@ -24,6 +31,7 @@ export function useAudioDownload(transcribe: (path: string) => Promise<void>) {
 	const [audioUrl, setAudioUrl] = useState('')
 	const [downloadingAudio, setDownloadingAudio] = useState(false)
 	const [ytdlpProgress, setYtDlpProgress] = useState<number | null>(null)
+	const [batch, setBatch] = useState<DownloadBatch | null>(null)
 	const cancelYtDlpRef = useRef(false)
 	const switchingToLinkRef = useRef(false)
 
@@ -130,32 +138,65 @@ export function useAudioDownload(transcribe: (path: string) => Promise<void>) {
 		}
 	}
 
+	/**
+	 * Fetch every link in the box, then hand all that landed to the queue at once. A link that
+	 * fails is skipped, not fatal: the others still download and the skipped ones are listed at
+	 * the end. The box is emptied as soon as the run starts so the next links can be pasted.
+	 */
 	async function downloadAudio() {
-		if (!audioUrl) return
-		setYtDlpProgress(0)
+		const urls = ytDlp.parseMediaLinks(audioUrl)
+		if (!urls.length) return
+		setAudioUrl('')
+		cancelYtDlpRef.current = false
 		setDownloadingAudio(true)
-		let downloaded = false
+		const downloaded: string[] = []
+		const failed: { url: string; error: unknown }[] = []
 		try {
-			const outPath = await ytDlp.downloadAudio(audioUrl)
-			downloaded = true
-			if (cancelYtDlpRef.current) {
-				cancelYtDlpRef.current = false
-				return
+			for (const [index, url] of urls.entries()) {
+				if (cancelYtDlpRef.current) break
+				setBatch({ index, total: urls.length, url })
+				setYtDlpProgress(0)
+				try {
+					const outPath = await ytDlp.downloadAudio(url)
+					// A cancelled download resolves with a file that was never finished.
+					if (cancelYtDlpRef.current) break
+					downloaded.push(outPath)
+				} catch (error) {
+					console.error(`download failed for ${url}`, error)
+					failed.push({ url, error })
+				}
 			}
-			preference.setHomeTab('file')
-			setFiles([{ name: 'audio.m4a', path: outPath }])
-			await transcribe(outPath)
-		} catch (error) {
-			console.error(error)
-			setErrorModal?.({ log: String(error), open: true })
-			// A site that stopped working is usually an extractor yt-dlp has already fixed, so this
-			// is the moment the update is worth interrupting for — throttle and "later" don't apply.
-			// A transcription that fails afterwards says nothing about yt-dlp, hence the guard.
-			if (!downloaded) void offerYtDlpUpdate(true)
 		} finally {
+			cancelYtDlpRef.current = false
 			setDownloadingAudio(false)
 			setYtDlpProgress(null)
+			setBatch(null)
 		}
+
+		if (downloaded.length) {
+			preference.setHomeTab('file')
+			setFiles(downloaded.map((path) => ({ name: 'audio.m4a', path })))
+			try {
+				await transcribe(downloaded)
+			} catch (error) {
+				console.error(error)
+				setErrorModal?.({ log: String(error), open: true })
+			}
+		}
+
+		if (!failed.length) return
+		if (!downloaded.length) {
+			setErrorModal?.({ log: failed.map(({ url, error }) => `${url}\n${String(error)}`).join('\n\n'), open: true })
+			// A site that stopped working is usually an extractor yt-dlp has already fixed, so this
+			// is the moment the update is worth interrupting for — throttle and "later" don't apply.
+			void offerYtDlpUpdate(true)
+			return
+		}
+		notify.warning(m.linksSkipped({ count: String(failed.length), total: String(urls.length) }), {
+			description: failed.map(({ url }) => url).join('\n'),
+			position: 'bottom-center',
+			duration: 10000,
+		})
 	}
 
 	return {
@@ -163,6 +204,7 @@ export function useAudioDownload(transcribe: (path: string) => Promise<void>) {
 		cancelYtDlpDownload,
 		ytdlpProgress,
 		setYtDlpProgress,
+		batch,
 		switchToLinkTab,
 		audioUrl,
 		setAudioUrl,

--- a/desktop/src/pages/home/view-model.ts
+++ b/desktop/src/pages/home/view-model.ts
@@ -85,7 +85,9 @@ export function viewModel() {
 		downloadAudio,
 		downloadingAudio,
 		setDownloadingAudio,
-	} = useAudioDownload(transcribe)
+	} = useAudioDownload(async (paths) => {
+		for (const path of paths) await transcribe(path)
+	})
 
 	const { updateApp, availableUpdate } = useContext(UpdaterContext)
 

--- a/desktop/src/pages/main/components/idle-hero.tsx
+++ b/desktop/src/pages/main/components/idle-hero.tsx
@@ -2,11 +2,11 @@ import { listen } from '@tauri-apps/api/event'
 import { AnimatePresence, motion } from 'framer-motion'
 import { FolderOpen, Link2, Mic, Square, Upload } from 'lucide-react'
 import { siFacebook, siInstagram, siTiktok, siX, siYoutube } from 'simple-icons'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { m } from '~/paraglide/messages.js'
 import AudioDeviceInput from '~/components/audio-device-input'
 import { Button } from '~/components/ui/button'
-import { Input } from '~/components/ui/input'
+import { Textarea } from '~/components/ui/textarea'
 import { Spinner } from '~/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
 import { cn } from '~/lib/style'
@@ -159,6 +159,18 @@ const linkSources: { title: string; path: string }[] = [
 
 function LinkPanel() {
 	const { link, preference } = useSession()
+	const linkBoxRef = useRef<HTMLTextAreaElement>(null)
+
+	// The box grows with the links pasted into it (up to its max height), and shrinks back when
+	// it is emptied. The WebView on macOS has no `field-sizing`, so this does it by hand.
+	useLayoutEffect(() => {
+		const box = linkBoxRef.current
+		if (!box) return
+		box.style.height = 'auto'
+		box.style.height = `${box.scrollHeight}px`
+		// No scrollbar until the box is actually full, or an empty box shows a stub of one.
+		box.style.overflowY = box.scrollHeight > box.clientHeight ? 'auto' : 'hidden'
+	}, [link.audioUrl])
 
 	if (link.downloadingAudio) {
 		const percent = link.ytdlpProgress ?? 0
@@ -186,9 +198,14 @@ function LinkPanel() {
 						)}
 					</div>
 
-					{link.audioUrl && (
+					{link.batch && (
 						<p dir="ltr" className="truncate text-center text-[12px] text-muted-foreground/80">
-							{link.audioUrl}
+							{link.batch.total > 1 && (
+								<span className="me-2 font-medium text-muted-foreground">
+									{m.linkOfTotal({ current: String(link.batch.index + 1), total: String(link.batch.total) })}
+								</span>
+							)}
+							{link.batch.url}
 						</p>
 					)}
 				</div>
@@ -206,15 +223,22 @@ function LinkPanel() {
 
 	return (
 		<div className="flex w-full flex-col items-center gap-5 py-2.5">
-			<div className="flex w-full items-center gap-3">
-				<Input
-					type="text"
+			<div className="flex w-full items-start gap-3">
+				{/* One line tall until more links are pasted; Enter sends, Shift+Enter adds a line. */}
+				<Textarea
+					ref={linkBoxRef}
+					rows={1}
 					value={link.audioUrl}
 					onChange={(event) => link.setAudioUrl(event.target.value)}
-					onKeyDown={(event) => (event.key === 'Enter' ? link.downloadAudio() : null)}
+					onKeyDown={(event) => {
+						if (event.key === 'Enter' && !event.shiftKey) {
+							event.preventDefault()
+							void link.downloadAudio()
+						}
+					}}
 					// Short enough to stay fully readable when the window is narrow.
 					placeholder={m.pasteMediaLink()}
-					className="h-10 min-w-0 flex-1 rounded-xl px-3.5 text-sm"
+					className="max-h-32 min-h-10 min-w-0 flex-1 resize-none rounded-xl px-3.5 py-2.5 text-sm leading-5"
 				/>
 				<Button
 					onClick={() => link.downloadAudio()}

--- a/desktop/src/pages/main/session.tsx
+++ b/desktop/src/pages/main/session.tsx
@@ -119,10 +119,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 		),
 	)
 
-	/** A downloaded file remains explicitly URL-sourced after it lands on disk. */
-	const transcribeOne = useCallback(
-		async (filePath: string) => {
-			await enqueuePaths([filePath], 'url')
+	/** Downloaded files remain explicitly URL-sourced after they land on disk. */
+	const transcribeDownloads = useCallback(
+		async (paths: string[]) => {
+			await enqueuePaths(paths, 'url')
 		},
 		[enqueuePaths],
 	)
@@ -132,7 +132,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 		() => ({ ...manualRecording, isRecording: manualRecording.isRecording || recordingShortcut.isShortcutRecording }),
 		[manualRecording, recordingShortcut.isShortcutRecording],
 	)
-	const link = useAudioDownload(transcribeOne)
+	const link = useAudioDownload(transcribeDownloads)
 
 	useEffect(() => {
 		recordingShortcut.setNormalRecordingActive(recording.isRecording)

--- a/i18n/translations/bg-BG/desktop.json
+++ b/i18n/translations/bg-BG/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Пуснете аудио, видео или папка тук",
 	"orClickToBrowse": "или щракнете, за да прегледате файловете си",
 	"dropToAddToQueue": "Пуснете, за да добавите към опашката",
-	"pasteMediaLink": "Поставете видео или аудио връзка",
+	"pasteMediaLink": "Поставете видео или аудио връзки, по една на ред",
 	"worksWith": "Работи с",
 	"moreSources": "+1000 други",
 	"fromFile": "Файл",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Избраният модел не използва подсказки. Тази подсказка се пази за връщане към Whisper модел.",
 	"assignSpeaker": "Задаване на говорещ",
 	"newSpeaker": "Нов говорещ",
-	"speakerOfThisLine": "Този ред"
+	"speakerOfThisLine": "Този ред",
+	"linkOfTotal": "{current} от {total}",
+	"linksSkipped": "{count} от {total} връзки не можаха да бъдат изтеглени"
 }

--- a/i18n/translations/ca-AD/desktop.json
+++ b/i18n/translations/ca-AD/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Deixa aquí àudio, vídeo o una carpeta",
 	"orClickToBrowse": "o fes clic per triar els teus fitxers",
 	"dropToAddToQueue": "Deixa-ho anar per afegir-ho a la cua",
-	"pasteMediaLink": "Enganxa un enllaç de vídeo o àudio",
+	"pasteMediaLink": "Enganxa enllaços de vídeo o àudio, un per línia",
 	"worksWith": "Funciona amb",
 	"moreSources": "+1000 més",
 	"fromFile": "Fitxer",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "El model seleccionat no fa servir indicacions. Aquesta es conserva per quan tornis a un model Whisper.",
 	"assignSpeaker": "Assigna un parlant",
 	"newSpeaker": "Parlant nou",
-	"speakerOfThisLine": "Aquesta línia"
+	"speakerOfThisLine": "Aquesta línia",
+	"linkOfTotal": "{current} de {total}",
+	"linksSkipped": "No s'han pogut baixar {count} de {total} enllaços"
 }

--- a/i18n/translations/cs-CZ/desktop.json
+++ b/i18n/translations/cs-CZ/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Přetáhněte sem zvuk, video nebo složku",
 	"orClickToBrowse": "nebo klikněte a vyberte soubory",
 	"dropToAddToQueue": "Přetažením přidáte do fronty",
-	"pasteMediaLink": "Vložte odkaz na video nebo zvuk",
+	"pasteMediaLink": "Vložte odkazy na video nebo zvuk, každý na samostatný řádek",
 	"worksWith": "Funguje s",
 	"moreSources": "+1000 dalších",
 	"fromFile": "Soubor",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Vybraný model nepoužívá výzvy. Tato výzva zůstane uložena pro návrat k modelu Whisper.",
 	"assignSpeaker": "Přiřadit mluvčího",
 	"newSpeaker": "Nový mluvčí",
-	"speakerOfThisLine": "Tento řádek"
+	"speakerOfThisLine": "Tento řádek",
+	"linkOfTotal": "{current} z {total}",
+	"linksSkipped": "{count} z {total} odkazů se nepodařilo stáhnout"
 }

--- a/i18n/translations/de-DE/desktop.json
+++ b/i18n/translations/de-DE/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Audio, Video oder einen Ordner hier ablegen",
 	"orClickToBrowse": "oder klicken, um Ihre Dateien zu durchsuchen",
 	"dropToAddToQueue": "Ablegen, um zur Warteschlange hinzuzufügen",
-	"pasteMediaLink": "Einen Video- oder Audio-Link einfügen",
+	"pasteMediaLink": "Video- oder Audio-Links einfügen, einen pro Zeile",
 	"worksWith": "Funktioniert mit",
 	"moreSources": "+1000 weitere",
 	"fromFile": "Datei",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Das gewählte Modell verwendet keine Prompts. Dieser Prompt bleibt für den Wechsel zurück zu einem Whisper-Modell erhalten.",
 	"assignSpeaker": "Sprecher zuweisen",
 	"newSpeaker": "Neuer Sprecher",
-	"speakerOfThisLine": "Diese Zeile"
+	"speakerOfThisLine": "Diese Zeile",
+	"linkOfTotal": "{current} von {total}",
+	"linksSkipped": "{count} von {total} Links konnten nicht heruntergeladen werden"
 }

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Drop audio, video or a folder here",
 	"orClickToBrowse": "or click to browse your files",
 	"dropToAddToQueue": "Drop to add to the queue",
-	"pasteMediaLink": "Paste a video or audio link",
+	"pasteMediaLink": "Paste video or audio links, one per line",
 	"worksWith": "Works with",
 	"moreSources": "+1000 more",
 	"fromFile": "File",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "The selected model does not use prompts. This prompt is kept for when you switch back to a Whisper model.",
 	"assignSpeaker": "Assign speaker",
 	"newSpeaker": "New speaker",
-	"speakerOfThisLine": "This line"
+	"speakerOfThisLine": "This line",
+	"linkOfTotal": "{current} of {total}",
+	"linksSkipped": "{count} of {total} links could not be downloaded"
 }

--- a/i18n/translations/es-ES/desktop.json
+++ b/i18n/translations/es-ES/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Arrastra aquí audio, vídeo o una carpeta",
 	"orClickToBrowse": "o haz clic para elegir tus archivos",
 	"dropToAddToQueue": "Suelta para añadir a la cola",
-	"pasteMediaLink": "Pega un enlace de vídeo o audio",
+	"pasteMediaLink": "Pega enlaces de vídeo o audio, uno por línea",
 	"worksWith": "Funciona con",
 	"moreSources": "+1000 más",
 	"fromFile": "Archivo",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "El modelo seleccionado no usa indicaciones. Esta se conserva para cuando vuelvas a un modelo Whisper.",
 	"assignSpeaker": "Asignar hablante",
 	"newSpeaker": "Nuevo hablante",
-	"speakerOfThisLine": "Esta línea"
+	"speakerOfThisLine": "Esta línea",
+	"linkOfTotal": "{current} de {total}",
+	"linksSkipped": "No se pudieron descargar {count} de {total} enlaces"
 }

--- a/i18n/translations/es-MX/desktop.json
+++ b/i18n/translations/es-MX/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Arrastra aquí audio, video o una carpeta",
 	"orClickToBrowse": "o haz clic para elegir tus archivos",
 	"dropToAddToQueue": "Suelta para añadir a la cola",
-	"pasteMediaLink": "Pega un enlace de video o audio",
+	"pasteMediaLink": "Pega enlaces de video o audio, uno por línea",
 	"worksWith": "Funciona con",
 	"moreSources": "+1000 más",
 	"fromFile": "Archivo",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "El modelo seleccionado no usa indicaciones. Esta se conserva para cuando vuelvas a un modelo Whisper.",
 	"assignSpeaker": "Asignar hablante",
 	"newSpeaker": "Nuevo hablante",
-	"speakerOfThisLine": "Esta línea"
+	"speakerOfThisLine": "Esta línea",
+	"linkOfTotal": "{current} de {total}",
+	"linksSkipped": "No se pudieron descargar {count} de {total} enlaces"
 }

--- a/i18n/translations/fr-FR/desktop.json
+++ b/i18n/translations/fr-FR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Déposez ici un fichier audio, une vidéo ou un dossier",
 	"orClickToBrowse": "ou cliquez pour parcourir vos fichiers",
 	"dropToAddToQueue": "Déposez pour ajouter à la file",
-	"pasteMediaLink": "Collez un lien vidéo ou audio",
+	"pasteMediaLink": "Collez des liens vidéo ou audio, un par ligne",
 	"worksWith": "Compatible avec",
 	"moreSources": "+1000 autres",
 	"fromFile": "Fichier",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Le modèle sélectionné n'utilise pas de prompt. Celui-ci est conservé pour un retour à un modèle Whisper.",
 	"assignSpeaker": "Attribuer un locuteur",
 	"newSpeaker": "Nouveau locuteur",
-	"speakerOfThisLine": "Cette ligne"
+	"speakerOfThisLine": "Cette ligne",
+	"linkOfTotal": "{current} sur {total}",
+	"linksSkipped": "{count} liens sur {total} n'ont pas pu être téléchargés"
 }

--- a/i18n/translations/he-IL/desktop.json
+++ b/i18n/translations/he-IL/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "גררו לכאן אודיו, וידאו או תיקייה",
 	"orClickToBrowse": "או לחצו כדי לבחור קבצים",
 	"dropToAddToQueue": "שחררו כדי להוסיף לתור",
-	"pasteMediaLink": "הדביקו קישור לווידאו או לאודיו",
+	"pasteMediaLink": "הדביקו קישורי וידאו או אודיו, אחד בכל שורה",
 	"worksWith": "עובד עם",
 	"moreSources": "+1000 נוספים",
 	"fromFile": "קובץ",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "המודל שנבחר אינו משתמש בהנחיות. ההנחיה נשמרת למקרה שתחזרו למודל Whisper.",
 	"assignSpeaker": "שיוך דובר",
 	"newSpeaker": "דובר חדש",
-	"speakerOfThisLine": "שורה זו"
+	"speakerOfThisLine": "שורה זו",
+	"linkOfTotal": "{current} מתוך {total}",
+	"linksSkipped": "{count} מתוך {total} קישורים לא ניתנים להורדה"
 }

--- a/i18n/translations/hi-IN/desktop.json
+++ b/i18n/translations/hi-IN/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "ऑडियो, वीडियो या फ़ोल्डर यहाँ छोड़ें",
 	"orClickToBrowse": "या फ़ाइलें चुनने के लिए क्लिक करें",
 	"dropToAddToQueue": "कतार में जोड़ने के लिए यहाँ छोड़ें",
-	"pasteMediaLink": "वीडियो या ऑडियो लिंक पेस्ट करें",
+	"pasteMediaLink": "वीडियो या ऑडियो लिंक चिपकाएँ, प्रति पंक्ति एक",
 	"worksWith": "इनके साथ काम करता है",
 	"moreSources": "+1000 और",
 	"fromFile": "फ़ाइल",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "चुना गया मॉडल प्रॉम्प्ट का उपयोग नहीं करता। यह प्रॉम्प्ट Whisper मॉडल पर लौटने के लिए सुरक्षित रखा गया है।",
 	"assignSpeaker": "वक्ता निर्धारित करें",
 	"newSpeaker": "नया वक्ता",
-	"speakerOfThisLine": "यह पंक्ति"
+	"speakerOfThisLine": "यह पंक्ति",
+	"linkOfTotal": "{total} में से {current}",
+	"linksSkipped": "{total} में से {count} लिंक डाउनलोड नहीं हो सके"
 }

--- a/i18n/translations/it-IT/desktop.json
+++ b/i18n/translations/it-IT/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Trascina qui audio, video o una cartella",
 	"orClickToBrowse": "oppure fai clic per scegliere i file",
 	"dropToAddToQueue": "Rilascia per aggiungere alla coda",
-	"pasteMediaLink": "Incolla un link video o audio",
+	"pasteMediaLink": "Incolla link video o audio, uno per riga",
 	"worksWith": "Funziona con",
 	"moreSources": "+1000 altri",
 	"fromFile": "File",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Il modello selezionato non usa prompt. Questo prompt viene conservato per quando tornerai a un modello Whisper.",
 	"assignSpeaker": "Assegna parlante",
 	"newSpeaker": "Nuovo parlante",
-	"speakerOfThisLine": "Questa riga"
+	"speakerOfThisLine": "Questa riga",
+	"linkOfTotal": "{current} di {total}",
+	"linksSkipped": "Impossibile scaricare {count} link su {total}"
 }

--- a/i18n/translations/ja-JP/desktop.json
+++ b/i18n/translations/ja-JP/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "音声・動画・フォルダをここにドロップ",
 	"orClickToBrowse": "またはクリックしてファイルを選択",
 	"dropToAddToQueue": "ドロップしてキューに追加",
-	"pasteMediaLink": "動画または音声のリンクを貼り付け",
+	"pasteMediaLink": "動画または音声のリンクを1行に1つ貼り付け",
 	"worksWith": "対応サービス",
 	"moreSources": "他1000件以上",
 	"fromFile": "ファイル",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "選択中のモデルはプロンプトを使用しません。このプロンプトは Whisper モデルに戻したときのために保持されます。",
 	"assignSpeaker": "話者を割り当て",
 	"newSpeaker": "新しい話者",
-	"speakerOfThisLine": "この行"
+	"speakerOfThisLine": "この行",
+	"linkOfTotal": "{total} 件中 {current} 件目",
+	"linksSkipped": "{total} 件中 {count} 件のリンクをダウンロードできませんでした"
 }

--- a/i18n/translations/ko-KR/desktop.json
+++ b/i18n/translations/ko-KR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "오디오, 비디오 또는 폴더를 여기에 놓으세요",
 	"orClickToBrowse": "또는 클릭해서 파일을 선택하세요",
 	"dropToAddToQueue": "놓으면 대기열에 추가됩니다",
-	"pasteMediaLink": "비디오 또는 오디오 링크를 붙여넣으세요",
+	"pasteMediaLink": "동영상 또는 오디오 링크를 한 줄에 하나씩 붙여넣기",
 	"worksWith": "지원 사이트",
 	"moreSources": "+1000개 더",
 	"fromFile": "파일",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "선택한 모델은 프롬프트를 사용하지 않습니다. 이 프롬프트는 Whisper 모델로 돌아갈 때를 위해 보관됩니다.",
 	"assignSpeaker": "화자 지정",
 	"newSpeaker": "새 화자",
-	"speakerOfThisLine": "이 줄"
+	"speakerOfThisLine": "이 줄",
+	"linkOfTotal": "{total}개 중 {current}",
+	"linksSkipped": "링크 {total}개 중 {count}개를 다운로드하지 못했습니다"
 }

--- a/i18n/translations/no-NO/desktop.json
+++ b/i18n/translations/no-NO/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Slipp lyd, video eller en mappe her",
 	"orClickToBrowse": "eller klikk for å bla gjennom filene dine",
 	"dropToAddToQueue": "Slipp for å legge til i køen",
-	"pasteMediaLink": "Lim inn en video- eller lydlenke",
+	"pasteMediaLink": "Lim inn video- eller lydlenker, én per linje",
 	"worksWith": "Fungerer med",
 	"moreSources": "+1000 flere",
 	"fromFile": "Fil",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Den valgte modellen bruker ikke prompt. Denne beholdes til du bytter tilbake til en Whisper-modell.",
 	"assignSpeaker": "Tilordne taler",
 	"newSpeaker": "Ny taler",
-	"speakerOfThisLine": "Denne linjen"
+	"speakerOfThisLine": "Denne linjen",
+	"linkOfTotal": "{current} av {total}",
+	"linksSkipped": "{count} av {total} lenker kunne ikke lastes ned"
 }

--- a/i18n/translations/pl-PL/desktop.json
+++ b/i18n/translations/pl-PL/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Upuść tutaj audio, wideo lub folder",
 	"orClickToBrowse": "lub kliknij, aby wybrać pliki",
 	"dropToAddToQueue": "Upuść, aby dodać do kolejki",
-	"pasteMediaLink": "Wklej link do wideo lub audio",
+	"pasteMediaLink": "Wklej linki do wideo lub audio, po jednym w wierszu",
 	"worksWith": "Działa z",
 	"moreSources": "+1000 innych",
 	"fromFile": "Plik",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Wybrany model nie używa podpowiedzi. Ta podpowiedź zostanie zachowana na wypadek powrotu do modelu Whisper.",
 	"assignSpeaker": "Przypisz mówcę",
 	"newSpeaker": "Nowy mówca",
-	"speakerOfThisLine": "Ta linia"
+	"speakerOfThisLine": "Ta linia",
+	"linkOfTotal": "{current} z {total}",
+	"linksSkipped": "Nie udało się pobrać {count} z {total} linków"
 }

--- a/i18n/translations/pt-BR/desktop.json
+++ b/i18n/translations/pt-BR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Solte aqui áudio, vídeo ou uma pasta",
 	"orClickToBrowse": "ou clique para escolher seus arquivos",
 	"dropToAddToQueue": "Solte para adicionar à fila",
-	"pasteMediaLink": "Cole um link de vídeo ou áudio",
+	"pasteMediaLink": "Cole links de vídeo ou áudio, um por linha",
 	"worksWith": "Funciona com",
 	"moreSources": "+1000 outros",
 	"fromFile": "Arquivo",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "O modelo selecionado não usa prompts. Este prompt fica guardado para quando você voltar a um modelo Whisper.",
 	"assignSpeaker": "Atribuir falante",
 	"newSpeaker": "Novo falante",
-	"speakerOfThisLine": "Esta linha"
+	"speakerOfThisLine": "Esta linha",
+	"linkOfTotal": "{current} de {total}",
+	"linksSkipped": "{count} de {total} links não puderam ser baixados"
 }

--- a/i18n/translations/ru-RU/desktop.json
+++ b/i18n/translations/ru-RU/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Перетащите сюда аудио, видео или папку",
 	"orClickToBrowse": "или нажмите, чтобы выбрать файлы",
 	"dropToAddToQueue": "Отпустите, чтобы добавить в очередь",
-	"pasteMediaLink": "Вставьте ссылку на видео или аудио",
+	"pasteMediaLink": "Вставьте ссылки на видео или аудио, по одной в строке",
 	"worksWith": "Работает с",
 	"moreSources": "+1000 других",
 	"fromFile": "Файл",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Выбранная модель не использует подсказки. Эта подсказка сохранится на случай возврата к модели Whisper.",
 	"assignSpeaker": "Назначить говорящего",
 	"newSpeaker": "Новый говорящий",
-	"speakerOfThisLine": "Эта строка"
+	"speakerOfThisLine": "Эта строка",
+	"linkOfTotal": "{current} из {total}",
+	"linksSkipped": "Не удалось скачать {count} из {total} ссылок"
 }

--- a/i18n/translations/sv-SE/desktop.json
+++ b/i18n/translations/sv-SE/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Släpp ljud, video eller en mapp här",
 	"orClickToBrowse": "eller klicka för att välja filer",
 	"dropToAddToQueue": "Släpp för att lägga till i kön",
-	"pasteMediaLink": "Klistra in en video- eller ljudlänk",
+	"pasteMediaLink": "Klistra in video- eller ljudlänkar, en per rad",
 	"worksWith": "Fungerar med",
 	"moreSources": "+1000 fler",
 	"fromFile": "Fil",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Den valda modellen använder inte prompter. Denna sparas tills du byter tillbaka till en Whisper-modell.",
 	"assignSpeaker": "Tilldela talare",
 	"newSpeaker": "Ny talare",
-	"speakerOfThisLine": "Den här raden"
+	"speakerOfThisLine": "Den här raden",
+	"linkOfTotal": "{current} av {total}",
+	"linksSkipped": "{count} av {total} länkar kunde inte laddas ner"
 }

--- a/i18n/translations/tr-TR/desktop.json
+++ b/i18n/translations/tr-TR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Ses, video veya klasörü buraya bırakın",
 	"orClickToBrowse": "ya da dosyalarınıza göz atmak için tıklayın",
 	"dropToAddToQueue": "Kuyruğa eklemek için bırakın",
-	"pasteMediaLink": "Video veya ses bağlantısı yapıştırın",
+	"pasteMediaLink": "Video veya ses bağlantılarını her satıra bir tane yapıştırın",
 	"worksWith": "Şunlarla çalışır",
 	"moreSources": "+1000 daha",
 	"fromFile": "Dosya",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Seçili model istem kullanmaz. Bu istem, bir Whisper modeline geri döndüğünüzde kullanılmak üzere saklanır.",
 	"assignSpeaker": "Konuşmacı ata",
 	"newSpeaker": "Yeni konuşmacı",
-	"speakerOfThisLine": "Bu satır"
+	"speakerOfThisLine": "Bu satır",
+	"linkOfTotal": "{current} / {total}",
+	"linksSkipped": "{total} bağlantıdan {count} tanesi indirilemedi"
 }

--- a/i18n/translations/vi-VN/desktop.json
+++ b/i18n/translations/vi-VN/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Kéo thả âm thanh, video hoặc thư mục vào đây",
 	"orClickToBrowse": "hoặc bấm để chọn tệp",
 	"dropToAddToQueue": "Thả để thêm vào hàng đợi",
-	"pasteMediaLink": "Dán liên kết video hoặc âm thanh",
+	"pasteMediaLink": "Dán liên kết video hoặc âm thanh, mỗi dòng một liên kết",
 	"worksWith": "Hoạt động với",
 	"moreSources": "+1000 nguồn khác",
 	"fromFile": "Tệp",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "Mô hình đã chọn không dùng lời nhắc. Lời nhắc này được giữ lại cho khi bạn quay về mô hình Whisper.",
 	"assignSpeaker": "Gán người nói",
 	"newSpeaker": "Người nói mới",
-	"speakerOfThisLine": "Dòng này"
+	"speakerOfThisLine": "Dòng này",
+	"linkOfTotal": "{current} / {total}",
+	"linksSkipped": "Không tải được {count} trong {total} liên kết"
 }

--- a/i18n/translations/zh-CN/desktop.json
+++ b/i18n/translations/zh-CN/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "将音频、视频或文件夹拖到这里",
 	"orClickToBrowse": "或点击浏览文件",
 	"dropToAddToQueue": "拖放即可加入队列",
-	"pasteMediaLink": "粘贴视频或音频链接",
+	"pasteMediaLink": "粘贴视频或音频链接，每行一个",
 	"worksWith": "支持",
 	"moreSources": "以及 1000 多个网站",
 	"fromFile": "文件",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "所选模型不使用提示词。此提示词会保留，以便切换回 Whisper 模型时使用。",
 	"assignSpeaker": "指定说话人",
 	"newSpeaker": "新说话人",
-	"speakerOfThisLine": "此行"
+	"speakerOfThisLine": "此行",
+	"linkOfTotal": "第 {current} 个，共 {total} 个",
+	"linksSkipped": "{total} 个链接中有 {count} 个无法下载"
 }

--- a/i18n/translations/zh-HK/desktop.json
+++ b/i18n/translations/zh-HK/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "將音頻、影片或資料夾拖到此處",
 	"orClickToBrowse": "或按一下瀏覽你的檔案",
 	"dropToAddToQueue": "拖放即可加入佇列",
-	"pasteMediaLink": "貼上影片或音頻連結",
+	"pasteMediaLink": "貼上影片或音訊連結，每行一個",
 	"worksWith": "支援",
 	"moreSources": "以及 1000 多個網站",
 	"fromFile": "檔案",
@@ -590,5 +590,7 @@
 	"promptIgnoredByModel": "所選模型不使用提示詞。此提示詞會保留，以便切換回 Whisper 模型時使用。",
 	"assignSpeaker": "指定說話者",
 	"newSpeaker": "新說話者",
-	"speakerOfThisLine": "此行"
+	"speakerOfThisLine": "此行",
+	"linkOfTotal": "第 {current} 個，共 {total} 個",
+	"linksSkipped": "{total} 個連結中有 {count} 個無法下載"
 }


### PR DESCRIPTION
- The link box is a small auto-growing textarea: one link per line, or several on a line (deduplicated). Enter sends, Shift+Enter adds a line. No scrollbar until it is actually full.
- The box is cleared as soon as the run starts.
- Links download one after the other. A failing link is skipped; everything that landed is enqueued together at the end, and a toast lists the skipped links. When every link fails, the error modal opens with each link's error and the yt-dlp update is offered as before.
- The download view shows "n of m" and the current link.
- In browser mock mode, a link containing `fail` simulates a site yt-dlp cannot fetch.

Type-check, ESLint, vitest (new test for the link parser), and the i18n audit pass. Three strings changed or added in all 22 locales.

https://claude.ai/code/session_01D6otLfmjwFoGyypYnwx8XF