### PR TITLE
Show queued links as a list under the box instead of a growing textarea

### DIFF
--- a/desktop/src/mock-tauri/handlers/media-misc.ts
+++ b/desktop/src/mock-tauri/handlers/media-misc.ts
@@ -2,6 +2,8 @@ import { emitMockEvent, onMockEvent } from '../event-bus'
 import { APP_LOCAL_DATA, DOCUMENTS_FOLDER, HOME_FOLDER, virtualFs } from '../state'
 import type { CommandHandlerMap } from '../types'
 
+let tempPathCounter = 0
+
 interface MockAudioDevice {
 	isDefault: boolean
 	isInput: boolean
@@ -134,7 +136,8 @@ export const mediaMiscHandlers: CommandHandlerMap = {
 
 	get_default_projects_path: () => `${DOCUMENTS_FOLDER}/Vibe`,
 
-	get_temp_path: (args) => `${APP_LOCAL_DATA}/tmp.${String(args?.ext ?? 'tmp')}`,
+	// Unique like the real one: several downloads in a row must not land on the same file.
+	get_temp_path: (args) => `${APP_LOCAL_DATA}/tmp-${(tempPathCounter += 1)}.${String(args?.ext ?? 'tmp')}`,
 
 	get_agent_paths: () => ({ sona: `${APP_LOCAL_DATA}/sona`, vibe: `${APP_LOCAL_DATA}/vibe` }),
 

--- a/desktop/src/pages/home/hooks/use-audio-download.ts
+++ b/desktop/src/pages/home/hooks/use-audio-download.ts
@@ -32,6 +32,8 @@ export function useAudioDownload(transcribe: (paths: string[]) => Promise<void>)
 	const [downloadingAudio, setDownloadingAudio] = useState(false)
 	const [ytdlpProgress, setYtDlpProgress] = useState<number | null>(null)
 	const [batch, setBatch] = useState<DownloadBatch | null>(null)
+	/** Links waiting under the box, added by pasting several at once or with the add button. */
+	const [queuedLinks, setQueuedLinks] = useState<string[]>([])
 	const cancelYtDlpRef = useRef(false)
 	const switchingToLinkRef = useRef(false)
 
@@ -138,15 +140,31 @@ export function useAudioDownload(transcribe: (paths: string[]) => Promise<void>)
 		}
 	}
 
+	/** Move the box's text into the list, or the given text; repeats are dropped. */
+	function queueLinks(text = audioUrl) {
+		const links = ytDlp.parseMediaLinks(text)
+		if (!links.length) return
+		setQueuedLinks((current) => [...new Set([...current, ...links])])
+		setAudioUrl('')
+	}
+
+	function removeQueuedLink(url: string) {
+		setQueuedLinks((current) => current.filter((link) => link !== url))
+	}
+
+	/** Everything a click on Transcribe would fetch: the list, then whatever is still in the box. */
+	const pendingLinks = [...new Set([...queuedLinks, ...ytDlp.parseMediaLinks(audioUrl)])]
+
 	/**
-	 * Fetch every link in the box, then hand all that landed to the queue at once. A link that
-	 * fails is skipped, not fatal: the others still download and the skipped ones are listed at
-	 * the end. The box is emptied as soon as the run starts so the next links can be pasted.
+	 * Fetch every pending link, then hand all that landed to the queue at once. A link that fails
+	 * is skipped, not fatal: the others still download and the skipped ones are listed at the end.
+	 * The box and the list are emptied as soon as the run starts so the next links can go in.
 	 */
 	async function downloadAudio() {
-		const urls = ytDlp.parseMediaLinks(audioUrl)
+		const urls = pendingLinks
 		if (!urls.length) return
 		setAudioUrl('')
+		setQueuedLinks([])
 		cancelYtDlpRef.current = false
 		setDownloadingAudio(true)
 		const downloaded: string[] = []
@@ -208,6 +226,10 @@ export function useAudioDownload(transcribe: (paths: string[]) => Promise<void>)
 		switchToLinkTab,
 		audioUrl,
 		setAudioUrl,
+		queuedLinks,
+		queueLinks,
+		removeQueuedLink,
+		pendingLinks,
 		downloadAudio,
 		downloadingAudio,
 		setDownloadingAudio,

--- a/desktop/src/pages/main/components/idle-hero.tsx
+++ b/desktop/src/pages/main/components/idle-hero.tsx
@@ -1,15 +1,16 @@
 import { listen } from '@tauri-apps/api/event'
 import { AnimatePresence, motion } from 'framer-motion'
-import { FolderOpen, Link2, Mic, Square, Upload } from 'lucide-react'
+import { FolderOpen, Link2, Mic, Plus, Square, Upload, X } from 'lucide-react'
 import { siFacebook, siInstagram, siTiktok, siX, siYoutube } from 'simple-icons'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { m } from '~/paraglide/messages.js'
 import AudioDeviceInput from '~/components/audio-device-input'
 import { Button } from '~/components/ui/button'
-import { Textarea } from '~/components/ui/textarea'
+import { Input } from '~/components/ui/input'
 import { Spinner } from '~/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
 import { cn } from '~/lib/style'
+import { parseMediaLinks } from '~/lib/ytdlp'
 import { useSession, type IdlePanel } from '../session'
 import QuietRow from './quiet-row'
 
@@ -159,18 +160,6 @@ const linkSources: { title: string; path: string }[] = [
 
 function LinkPanel() {
 	const { link, preference } = useSession()
-	const linkBoxRef = useRef<HTMLTextAreaElement>(null)
-
-	// The box grows with the links pasted into it (up to its max height), and shrinks back when
-	// it is emptied. The WebView on macOS has no `field-sizing`, so this does it by hand.
-	useLayoutEffect(() => {
-		const box = linkBoxRef.current
-		if (!box) return
-		box.style.height = 'auto'
-		box.style.height = `${box.scrollHeight}px`
-		// No scrollbar until the box is actually full, or an empty box shows a stub of one.
-		box.style.overflowY = box.scrollHeight > box.clientHeight ? 'auto' : 'hidden'
-	}, [link.audioUrl])
 
 	if (link.downloadingAudio) {
 		const percent = link.ytdlpProgress ?? 0
@@ -222,33 +211,90 @@ function LinkPanel() {
 	}
 
 	return (
-		<div className="flex w-full flex-col items-center gap-5 py-2.5">
-			<div className="flex w-full items-start gap-3">
-				{/* One line tall until more links are pasted; Enter sends, Shift+Enter adds a line. */}
-				<Textarea
-					ref={linkBoxRef}
-					rows={1}
-					value={link.audioUrl}
-					onChange={(event) => link.setAudioUrl(event.target.value)}
-					onKeyDown={(event) => {
-						if (event.key === 'Enter' && !event.shiftKey) {
+		<motion.div layout className="flex w-full flex-col items-center gap-5 py-2.5">
+			<motion.div layout="position" className="flex w-full items-center gap-3">
+				<div className="relative min-w-0 flex-1">
+					<Input
+						type="text"
+						value={link.audioUrl}
+						onChange={(event) => link.setAudioUrl(event.target.value)}
+						onKeyDown={(event) => (event.key === 'Enter' ? void link.downloadAudio() : null)}
+						// Several links pasted together go straight into the list; one stays in the box.
+						onPaste={(event) => {
+							const pasted = event.clipboardData.getData('text')
+							if (parseMediaLinks(pasted).length < 2) return
 							event.preventDefault()
-							void link.downloadAudio()
-						}
-					}}
-					// Short enough to stay fully readable when the window is narrow.
-					placeholder={m.pasteMediaLink()}
-					className="max-h-32 min-h-10 min-w-0 flex-1 resize-none rounded-xl px-3.5 py-2.5 text-sm leading-5"
-				/>
+							link.queueLinks(`${link.audioUrl} ${pasted}`)
+						}}
+						// Short enough to stay fully readable when the window is narrow.
+						placeholder={link.queuedLinks.length ? m.pasteAnotherLink() : m.pasteMediaLink()}
+						className={cn('h-10 min-w-0 rounded-xl px-3.5 text-sm', link.audioUrl && 'pe-10')}
+					/>
+					{/* The way to build a list by hand: park this link and type the next one. */}
+					{link.audioUrl && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									aria-label={m.addLink()}
+									onClick={() => link.queueLinks()}
+									className="absolute end-1.5 top-1/2 flex h-7 w-7 -translate-y-1/2 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/80">
+									<Plus className="h-4 w-4" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>{m.addLink()}</TooltipContent>
+						</Tooltip>
+					)}
+				</div>
 				<Button
 					onClick={() => link.downloadAudio()}
-					disabled={!preference.modelPath || !link.audioUrl}
-					className="h-10 shrink-0 rounded-xl px-4 disabled:opacity-40">
+					disabled={!preference.modelPath || link.pendingLinks.length === 0}
+					// Wide enough for the count, so the box beside it never changes size.
+					className="h-10 w-32 shrink-0 rounded-xl px-4 disabled:opacity-40">
 					{m.transcribe()}
+					{link.pendingLinks.length > 1 && (
+						<span className="rounded-full bg-primary-foreground/20 px-1.5 text-[11px] font-semibold tabular-nums">{link.pendingLinks.length}</span>
+					)}
 				</Button>
-			</div>
+			</motion.div>
 
-			<div className="flex flex-col items-center gap-3">
+			{/* Links waiting their turn, each removable until the run starts. The list keeps the */}
+			{/* card's width and scrolls vertically once it holds more than a few, so nothing else */}
+			{/* moves; rows slide in and out, and the card's own re-centring is animated with them. */}
+			<AnimatePresence initial={false}>
+				{link.queuedLinks.length > 0 && (
+					<motion.ul key="queued-links" layout className="flex max-h-28 w-full flex-col gap-1 overflow-y-auto overscroll-contain">
+						<AnimatePresence initial={false}>
+							{link.queuedLinks.map((url) => (
+								<motion.li
+									key={url}
+									layout
+									initial={{ height: 0, opacity: 0 }}
+									animate={{ height: 'auto', opacity: 1 }}
+									exit={{ height: 0, opacity: 0 }}
+									transition={{ duration: 0.18, ease: 'easeOut' }}
+									className="group shrink-0 overflow-hidden rounded-lg text-[13px] text-muted-foreground transition-colors duration-150 hover:bg-muted/60">
+									<div className="flex items-center gap-2.5 px-2 py-1">
+										<Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
+										<span dir="ltr" className="min-w-0 flex-1 truncate text-start text-foreground/90">
+											{url}
+										</span>
+										<button
+											type="button"
+											aria-label={m.removeLink()}
+											onClick={() => link.removeQueuedLink(url)}
+											className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/80">
+											<X className="h-3.5 w-3.5" />
+										</button>
+									</div>
+								</motion.li>
+							))}
+						</AnimatePresence>
+					</motion.ul>
+				)}
+			</AnimatePresence>
+
+			<motion.div layout="position" className="flex flex-col items-center gap-3">
 				<p className="text-[11px] font-medium tracking-[0.08em] text-muted-foreground/80 uppercase">{m.worksWith()}</p>
 				<div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-3 text-muted-foreground/70">
 					{linkSources.map((source) => (
@@ -267,8 +313,8 @@ function LinkPanel() {
 					))}
 					<span className="text-[12px] text-muted-foreground/70">{m.moreSources()}</span>
 				</div>
-			</div>
-		</div>
+			</motion.div>
+		</motion.div>
 	)
 }
 

--- a/i18n/translations/bg-BG/desktop.json
+++ b/i18n/translations/bg-BG/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Пуснете аудио, видео или папка тук",
 	"orClickToBrowse": "или щракнете, за да прегледате файловете си",
 	"dropToAddToQueue": "Пуснете, за да добавите към опашката",
-	"pasteMediaLink": "Поставете видео или аудио връзки, по една на ред",
+	"pasteMediaLink": "Поставете видео или аудио връзка",
 	"worksWith": "Работи с",
 	"moreSources": "+1000 други",
 	"fromFile": "Файл",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Нов говорещ",
 	"speakerOfThisLine": "Този ред",
 	"linkOfTotal": "{current} от {total}",
-	"linksSkipped": "{count} от {total} връзки не можаха да бъдат изтеглени"
+	"linksSkipped": "{count} от {total} връзки не можаха да бъдат изтеглени",
+	"pasteAnotherLink": "Поставете още една връзка",
+	"addLink": "Добавяне към списъка",
+	"removeLink": "Премахване"
 }

--- a/i18n/translations/ca-AD/desktop.json
+++ b/i18n/translations/ca-AD/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Deixa aquí àudio, vídeo o una carpeta",
 	"orClickToBrowse": "o fes clic per triar els teus fitxers",
 	"dropToAddToQueue": "Deixa-ho anar per afegir-ho a la cua",
-	"pasteMediaLink": "Enganxa enllaços de vídeo o àudio, un per línia",
+	"pasteMediaLink": "Enganxa un enllaç de vídeo o àudio",
 	"worksWith": "Funciona amb",
 	"moreSources": "+1000 més",
 	"fromFile": "Fitxer",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Parlant nou",
 	"speakerOfThisLine": "Aquesta línia",
 	"linkOfTotal": "{current} de {total}",
-	"linksSkipped": "No s'han pogut baixar {count} de {total} enllaços"
+	"linksSkipped": "No s'han pogut baixar {count} de {total} enllaços",
+	"pasteAnotherLink": "Enganxa un altre enllaç",
+	"addLink": "Afegeix a la llista",
+	"removeLink": "Elimina"
 }

--- a/i18n/translations/cs-CZ/desktop.json
+++ b/i18n/translations/cs-CZ/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Přetáhněte sem zvuk, video nebo složku",
 	"orClickToBrowse": "nebo klikněte a vyberte soubory",
 	"dropToAddToQueue": "Přetažením přidáte do fronty",
-	"pasteMediaLink": "Vložte odkazy na video nebo zvuk, každý na samostatný řádek",
+	"pasteMediaLink": "Vložte odkaz na video nebo zvuk",
 	"worksWith": "Funguje s",
 	"moreSources": "+1000 dalších",
 	"fromFile": "Soubor",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Nový mluvčí",
 	"speakerOfThisLine": "Tento řádek",
 	"linkOfTotal": "{current} z {total}",
-	"linksSkipped": "{count} z {total} odkazů se nepodařilo stáhnout"
+	"linksSkipped": "{count} z {total} odkazů se nepodařilo stáhnout",
+	"pasteAnotherLink": "Vložte další odkaz",
+	"addLink": "Přidat do seznamu",
+	"removeLink": "Odebrat"
 }

--- a/i18n/translations/de-DE/desktop.json
+++ b/i18n/translations/de-DE/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Audio, Video oder einen Ordner hier ablegen",
 	"orClickToBrowse": "oder klicken, um Ihre Dateien zu durchsuchen",
 	"dropToAddToQueue": "Ablegen, um zur Warteschlange hinzuzufügen",
-	"pasteMediaLink": "Video- oder Audio-Links einfügen, einen pro Zeile",
+	"pasteMediaLink": "Einen Video- oder Audio-Link einfügen",
 	"worksWith": "Funktioniert mit",
 	"moreSources": "+1000 weitere",
 	"fromFile": "Datei",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Neuer Sprecher",
 	"speakerOfThisLine": "Diese Zeile",
 	"linkOfTotal": "{current} von {total}",
-	"linksSkipped": "{count} von {total} Links konnten nicht heruntergeladen werden"
+	"linksSkipped": "{count} von {total} Links konnten nicht heruntergeladen werden",
+	"pasteAnotherLink": "Noch einen Link einfügen",
+	"addLink": "Zur Liste hinzufügen",
+	"removeLink": "Entfernen"
 }

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Drop audio, video or a folder here",
 	"orClickToBrowse": "or click to browse your files",
 	"dropToAddToQueue": "Drop to add to the queue",
-	"pasteMediaLink": "Paste video or audio links, one per line",
+	"pasteMediaLink": "Paste a video or audio link",
 	"worksWith": "Works with",
 	"moreSources": "+1000 more",
 	"fromFile": "File",
@@ -592,5 +592,8 @@
 	"newSpeaker": "New speaker",
 	"speakerOfThisLine": "This line",
 	"linkOfTotal": "{current} of {total}",
-	"linksSkipped": "{count} of {total} links could not be downloaded"
+	"linksSkipped": "{count} of {total} links could not be downloaded",
+	"pasteAnotherLink": "Paste another link",
+	"addLink": "Add to the list",
+	"removeLink": "Remove"
 }

--- a/i18n/translations/es-ES/desktop.json
+++ b/i18n/translations/es-ES/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Arrastra aquí audio, vídeo o una carpeta",
 	"orClickToBrowse": "o haz clic para elegir tus archivos",
 	"dropToAddToQueue": "Suelta para añadir a la cola",
-	"pasteMediaLink": "Pega enlaces de vídeo o audio, uno por línea",
+	"pasteMediaLink": "Pega un enlace de vídeo o audio",
 	"worksWith": "Funciona con",
 	"moreSources": "+1000 más",
 	"fromFile": "Archivo",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Nuevo hablante",
 	"speakerOfThisLine": "Esta línea",
 	"linkOfTotal": "{current} de {total}",
-	"linksSkipped": "No se pudieron descargar {count} de {total} enlaces"
+	"linksSkipped": "No se pudieron descargar {count} de {total} enlaces",
+	"pasteAnotherLink": "Pega otro enlace",
+	"addLink": "Añadir a la lista",
+	"removeLink": "Quitar"
 }

--- a/i18n/translations/es-MX/desktop.json
+++ b/i18n/translations/es-MX/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Arrastra aquí audio, video o una carpeta",
 	"orClickToBrowse": "o haz clic para elegir tus archivos",
 	"dropToAddToQueue": "Suelta para añadir a la cola",
-	"pasteMediaLink": "Pega enlaces de video o audio, uno por línea",
+	"pasteMediaLink": "Pega un enlace de video o audio",
 	"worksWith": "Funciona con",
 	"moreSources": "+1000 más",
 	"fromFile": "Archivo",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Nuevo hablante",
 	"speakerOfThisLine": "Esta línea",
 	"linkOfTotal": "{current} de {total}",
-	"linksSkipped": "No se pudieron descargar {count} de {total} enlaces"
+	"linksSkipped": "No se pudieron descargar {count} de {total} enlaces",
+	"pasteAnotherLink": "Pega otro enlace",
+	"addLink": "Agregar a la lista",
+	"removeLink": "Quitar"
 }

--- a/i18n/translations/fr-FR/desktop.json
+++ b/i18n/translations/fr-FR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Déposez ici un fichier audio, une vidéo ou un dossier",
 	"orClickToBrowse": "ou cliquez pour parcourir vos fichiers",
 	"dropToAddToQueue": "Déposez pour ajouter à la file",
-	"pasteMediaLink": "Collez des liens vidéo ou audio, un par ligne",
+	"pasteMediaLink": "Collez un lien vidéo ou audio",
 	"worksWith": "Compatible avec",
 	"moreSources": "+1000 autres",
 	"fromFile": "Fichier",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Nouveau locuteur",
 	"speakerOfThisLine": "Cette ligne",
 	"linkOfTotal": "{current} sur {total}",
-	"linksSkipped": "{count} liens sur {total} n'ont pas pu être téléchargés"
+	"linksSkipped": "{count} liens sur {total} n'ont pas pu être téléchargés",
+	"pasteAnotherLink": "Collez un autre lien",
+	"addLink": "Ajouter à la liste",
+	"removeLink": "Retirer"
 }

--- a/i18n/translations/he-IL/desktop.json
+++ b/i18n/translations/he-IL/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "גררו לכאן אודיו, וידאו או תיקייה",
 	"orClickToBrowse": "או לחצו כדי לבחור קבצים",
 	"dropToAddToQueue": "שחררו כדי להוסיף לתור",
-	"pasteMediaLink": "הדביקו קישורי וידאו או אודיו, אחד בכל שורה",
+	"pasteMediaLink": "הדביקו קישור לווידאו או אודיו",
 	"worksWith": "עובד עם",
 	"moreSources": "+1000 נוספים",
 	"fromFile": "קובץ",
@@ -592,5 +592,8 @@
 	"newSpeaker": "דובר חדש",
 	"speakerOfThisLine": "שורה זו",
 	"linkOfTotal": "{current} מתוך {total}",
-	"linksSkipped": "{count} מתוך {total} קישורים לא ניתנים להורדה"
+	"linksSkipped": "{count} מתוך {total} קישורים לא ניתנים להורדה",
+	"pasteAnotherLink": "הדביקו קישור נוסף",
+	"addLink": "הוספה לרשימה",
+	"removeLink": "הסרה"
 }

--- a/i18n/translations/hi-IN/desktop.json
+++ b/i18n/translations/hi-IN/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "ऑडियो, वीडियो या फ़ोल्डर यहाँ छोड़ें",
 	"orClickToBrowse": "या फ़ाइलें चुनने के लिए क्लिक करें",
 	"dropToAddToQueue": "कतार में जोड़ने के लिए यहाँ छोड़ें",
-	"pasteMediaLink": "वीडियो या ऑडियो लिंक चिपकाएँ, प्रति पंक्ति एक",
+	"pasteMediaLink": "वीडियो या ऑडियो लिंक चिपकाएँ",
 	"worksWith": "इनके साथ काम करता है",
 	"moreSources": "+1000 और",
 	"fromFile": "फ़ाइल",
@@ -592,5 +592,8 @@
 	"newSpeaker": "नया वक्ता",
 	"speakerOfThisLine": "यह पंक्ति",
 	"linkOfTotal": "{total} में से {current}",
-	"linksSkipped": "{total} में से {count} लिंक डाउनलोड नहीं हो सके"
+	"linksSkipped": "{total} में से {count} लिंक डाउनलोड नहीं हो सके",
+	"pasteAnotherLink": "एक और लिंक चिपकाएँ",
+	"addLink": "सूची में जोड़ें",
+	"removeLink": "हटाएँ"
 }

--- a/i18n/translations/it-IT/desktop.json
+++ b/i18n/translations/it-IT/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Trascina qui audio, video o una cartella",
 	"orClickToBrowse": "oppure fai clic per scegliere i file",
 	"dropToAddToQueue": "Rilascia per aggiungere alla coda",
-	"pasteMediaLink": "Incolla link video o audio, uno per riga",
+	"pasteMediaLink": "Incolla un link video o audio",
 	"worksWith": "Funziona con",
 	"moreSources": "+1000 altri",
 	"fromFile": "File",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Nuovo parlante",
 	"speakerOfThisLine": "Questa riga",
 	"linkOfTotal": "{current} di {total}",
-	"linksSkipped": "Impossibile scaricare {count} link su {total}"
+	"linksSkipped": "Impossibile scaricare {count} link su {total}",
+	"pasteAnotherLink": "Incolla un altro link",
+	"addLink": "Aggiungi alla lista",
+	"removeLink": "Rimuovi"
 }

--- a/i18n/translations/ja-JP/desktop.json
+++ b/i18n/translations/ja-JP/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "音声・動画・フォルダをここにドロップ",
 	"orClickToBrowse": "またはクリックしてファイルを選択",
 	"dropToAddToQueue": "ドロップしてキューに追加",
-	"pasteMediaLink": "動画または音声のリンクを1行に1つ貼り付け",
+	"pasteMediaLink": "動画または音声のリンクを貼り付け",
 	"worksWith": "対応サービス",
 	"moreSources": "他1000件以上",
 	"fromFile": "ファイル",
@@ -592,5 +592,8 @@
 	"newSpeaker": "新しい話者",
 	"speakerOfThisLine": "この行",
 	"linkOfTotal": "{total} 件中 {current} 件目",
-	"linksSkipped": "{total} 件中 {count} 件のリンクをダウンロードできませんでした"
+	"linksSkipped": "{total} 件中 {count} 件のリンクをダウンロードできませんでした",
+	"pasteAnotherLink": "別のリンクを貼り付け",
+	"addLink": "リストに追加",
+	"removeLink": "削除"
 }

--- a/i18n/translations/ko-KR/desktop.json
+++ b/i18n/translations/ko-KR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "오디오, 비디오 또는 폴더를 여기에 놓으세요",
 	"orClickToBrowse": "또는 클릭해서 파일을 선택하세요",
 	"dropToAddToQueue": "놓으면 대기열에 추가됩니다",
-	"pasteMediaLink": "동영상 또는 오디오 링크를 한 줄에 하나씩 붙여넣기",
+	"pasteMediaLink": "동영상 또는 오디오 링크 붙여넣기",
 	"worksWith": "지원 사이트",
 	"moreSources": "+1000개 더",
 	"fromFile": "파일",
@@ -592,5 +592,8 @@
 	"newSpeaker": "새 화자",
 	"speakerOfThisLine": "이 줄",
 	"linkOfTotal": "{total}개 중 {current}",
-	"linksSkipped": "링크 {total}개 중 {count}개를 다운로드하지 못했습니다"
+	"linksSkipped": "링크 {total}개 중 {count}개를 다운로드하지 못했습니다",
+	"pasteAnotherLink": "다른 링크 붙여넣기",
+	"addLink": "목록에 추가",
+	"removeLink": "제거"
 }

--- a/i18n/translations/no-NO/desktop.json
+++ b/i18n/translations/no-NO/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Slipp lyd, video eller en mappe her",
 	"orClickToBrowse": "eller klikk for å bla gjennom filene dine",
 	"dropToAddToQueue": "Slipp for å legge til i køen",
-	"pasteMediaLink": "Lim inn video- eller lydlenker, én per linje",
+	"pasteMediaLink": "Lim inn en video- eller lydlenke",
 	"worksWith": "Fungerer med",
 	"moreSources": "+1000 flere",
 	"fromFile": "Fil",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Ny taler",
 	"speakerOfThisLine": "Denne linjen",
 	"linkOfTotal": "{current} av {total}",
-	"linksSkipped": "{count} av {total} lenker kunne ikke lastes ned"
+	"linksSkipped": "{count} av {total} lenker kunne ikke lastes ned",
+	"pasteAnotherLink": "Lim inn en lenke til",
+	"addLink": "Legg til i listen",
+	"removeLink": "Fjern"
 }

--- a/i18n/translations/pl-PL/desktop.json
+++ b/i18n/translations/pl-PL/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Upuść tutaj audio, wideo lub folder",
 	"orClickToBrowse": "lub kliknij, aby wybrać pliki",
 	"dropToAddToQueue": "Upuść, aby dodać do kolejki",
-	"pasteMediaLink": "Wklej linki do wideo lub audio, po jednym w wierszu",
+	"pasteMediaLink": "Wklej link do wideo lub audio",
 	"worksWith": "Działa z",
 	"moreSources": "+1000 innych",
 	"fromFile": "Plik",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Nowy mówca",
 	"speakerOfThisLine": "Ta linia",
 	"linkOfTotal": "{current} z {total}",
-	"linksSkipped": "Nie udało się pobrać {count} z {total} linków"
+	"linksSkipped": "Nie udało się pobrać {count} z {total} linków",
+	"pasteAnotherLink": "Wklej kolejny link",
+	"addLink": "Dodaj do listy",
+	"removeLink": "Usuń"
 }

--- a/i18n/translations/pt-BR/desktop.json
+++ b/i18n/translations/pt-BR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Solte aqui áudio, vídeo ou uma pasta",
 	"orClickToBrowse": "ou clique para escolher seus arquivos",
 	"dropToAddToQueue": "Solte para adicionar à fila",
-	"pasteMediaLink": "Cole links de vídeo ou áudio, um por linha",
+	"pasteMediaLink": "Cole um link de vídeo ou áudio",
 	"worksWith": "Funciona com",
 	"moreSources": "+1000 outros",
 	"fromFile": "Arquivo",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Novo falante",
 	"speakerOfThisLine": "Esta linha",
 	"linkOfTotal": "{current} de {total}",
-	"linksSkipped": "{count} de {total} links não puderam ser baixados"
+	"linksSkipped": "{count} de {total} links não puderam ser baixados",
+	"pasteAnotherLink": "Cole outro link",
+	"addLink": "Adicionar à lista",
+	"removeLink": "Remover"
 }

--- a/i18n/translations/ru-RU/desktop.json
+++ b/i18n/translations/ru-RU/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Перетащите сюда аудио, видео или папку",
 	"orClickToBrowse": "или нажмите, чтобы выбрать файлы",
 	"dropToAddToQueue": "Отпустите, чтобы добавить в очередь",
-	"pasteMediaLink": "Вставьте ссылки на видео или аудио, по одной в строке",
+	"pasteMediaLink": "Вставьте ссылку на видео или аудио",
 	"worksWith": "Работает с",
 	"moreSources": "+1000 других",
 	"fromFile": "Файл",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Новый говорящий",
 	"speakerOfThisLine": "Эта строка",
 	"linkOfTotal": "{current} из {total}",
-	"linksSkipped": "Не удалось скачать {count} из {total} ссылок"
+	"linksSkipped": "Не удалось скачать {count} из {total} ссылок",
+	"pasteAnotherLink": "Вставьте ещё одну ссылку",
+	"addLink": "Добавить в список",
+	"removeLink": "Убрать"
 }

--- a/i18n/translations/sv-SE/desktop.json
+++ b/i18n/translations/sv-SE/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Släpp ljud, video eller en mapp här",
 	"orClickToBrowse": "eller klicka för att välja filer",
 	"dropToAddToQueue": "Släpp för att lägga till i kön",
-	"pasteMediaLink": "Klistra in video- eller ljudlänkar, en per rad",
+	"pasteMediaLink": "Klistra in en video- eller ljudlänk",
 	"worksWith": "Fungerar med",
 	"moreSources": "+1000 fler",
 	"fromFile": "Fil",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Ny talare",
 	"speakerOfThisLine": "Den här raden",
 	"linkOfTotal": "{current} av {total}",
-	"linksSkipped": "{count} av {total} länkar kunde inte laddas ner"
+	"linksSkipped": "{count} av {total} länkar kunde inte laddas ner",
+	"pasteAnotherLink": "Klistra in en länk till",
+	"addLink": "Lägg till i listan",
+	"removeLink": "Ta bort"
 }

--- a/i18n/translations/tr-TR/desktop.json
+++ b/i18n/translations/tr-TR/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Ses, video veya klasörü buraya bırakın",
 	"orClickToBrowse": "ya da dosyalarınıza göz atmak için tıklayın",
 	"dropToAddToQueue": "Kuyruğa eklemek için bırakın",
-	"pasteMediaLink": "Video veya ses bağlantılarını her satıra bir tane yapıştırın",
+	"pasteMediaLink": "Bir video veya ses bağlantısı yapıştırın",
 	"worksWith": "Şunlarla çalışır",
 	"moreSources": "+1000 daha",
 	"fromFile": "Dosya",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Yeni konuşmacı",
 	"speakerOfThisLine": "Bu satır",
 	"linkOfTotal": "{current} / {total}",
-	"linksSkipped": "{total} bağlantıdan {count} tanesi indirilemedi"
+	"linksSkipped": "{total} bağlantıdan {count} tanesi indirilemedi",
+	"pasteAnotherLink": "Başka bir bağlantı yapıştırın",
+	"addLink": "Listeye ekle",
+	"removeLink": "Kaldır"
 }

--- a/i18n/translations/vi-VN/desktop.json
+++ b/i18n/translations/vi-VN/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "Kéo thả âm thanh, video hoặc thư mục vào đây",
 	"orClickToBrowse": "hoặc bấm để chọn tệp",
 	"dropToAddToQueue": "Thả để thêm vào hàng đợi",
-	"pasteMediaLink": "Dán liên kết video hoặc âm thanh, mỗi dòng một liên kết",
+	"pasteMediaLink": "Dán liên kết video hoặc âm thanh",
 	"worksWith": "Hoạt động với",
 	"moreSources": "+1000 nguồn khác",
 	"fromFile": "Tệp",
@@ -592,5 +592,8 @@
 	"newSpeaker": "Người nói mới",
 	"speakerOfThisLine": "Dòng này",
 	"linkOfTotal": "{current} / {total}",
-	"linksSkipped": "Không tải được {count} trong {total} liên kết"
+	"linksSkipped": "Không tải được {count} trong {total} liên kết",
+	"pasteAnotherLink": "Dán một liên kết khác",
+	"addLink": "Thêm vào danh sách",
+	"removeLink": "Xóa"
 }

--- a/i18n/translations/zh-CN/desktop.json
+++ b/i18n/translations/zh-CN/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "将音频、视频或文件夹拖到这里",
 	"orClickToBrowse": "或点击浏览文件",
 	"dropToAddToQueue": "拖放即可加入队列",
-	"pasteMediaLink": "粘贴视频或音频链接，每行一个",
+	"pasteMediaLink": "粘贴视频或音频链接",
 	"worksWith": "支持",
 	"moreSources": "以及 1000 多个网站",
 	"fromFile": "文件",
@@ -592,5 +592,8 @@
 	"newSpeaker": "新说话人",
 	"speakerOfThisLine": "此行",
 	"linkOfTotal": "第 {current} 个，共 {total} 个",
-	"linksSkipped": "{total} 个链接中有 {count} 个无法下载"
+	"linksSkipped": "{total} 个链接中有 {count} 个无法下载",
+	"pasteAnotherLink": "再粘贴一个链接",
+	"addLink": "添加到列表",
+	"removeLink": "移除"
 }

--- a/i18n/translations/zh-HK/desktop.json
+++ b/i18n/translations/zh-HK/desktop.json
@@ -501,7 +501,7 @@
 	"dropFilesHere": "將音頻、影片或資料夾拖到此處",
 	"orClickToBrowse": "或按一下瀏覽你的檔案",
 	"dropToAddToQueue": "拖放即可加入佇列",
-	"pasteMediaLink": "貼上影片或音訊連結，每行一個",
+	"pasteMediaLink": "貼上影片或音訊連結",
 	"worksWith": "支援",
 	"moreSources": "以及 1000 多個網站",
 	"fromFile": "檔案",
@@ -592,5 +592,8 @@
 	"newSpeaker": "新說話者",
 	"speakerOfThisLine": "此行",
 	"linkOfTotal": "第 {current} 個，共 {total} 個",
-	"linksSkipped": "{total} 個連結中有 {count} 個無法下載"
+	"linksSkipped": "{total} 個連結中有 {count} 個無法下載",
+	"pasteAnotherLink": "再貼上一個連結",
+	"addLink": "加入清單",
+	"removeLink": "移除"
 }


### PR DESCRIPTION
Follow-up to #1491, after trying it: the multi-line box explained nothing and shifted the layout as it grew.

- Single-line input again. Pasting several links at once drops them into a list under the box; a plus button inside the box parks one link so the next can be typed.
- The list keeps the card's width and scrolls vertically past a few rows. Rows animate in and out, and the card's re-centring is animated, so nothing jumps.
- Transcribe button has a fixed width and a count badge, so the box beside it never resizes.
- Each queued link can be removed until the run starts; box and list clear when it does.
- Mock mode now returns unique temp paths like the real app (a shared path made the third download onward fail with "file not found" in the mock only).

Type-check, ESLint, vitest, prettier, and the i18n audit pass. Verified in browser mock mode with three links, one of them failing.

https://claude.ai/code/session_01D6otLfmjwFoGyypYnwx8XF