### PR TITLE
Attach sona's stderr to a transcription error even when the child is not yet reaped

### DIFF
--- a/desktop/src-tauri/src/cmd/transcribe.rs
+++ b/desktop/src-tauri/src/cmd/transcribe.rs
@@ -68,7 +68,14 @@ async fn transcribe_error(sona_state: &State<'_, Mutex<SonaState>>, error: eyre:
             code: "internal_error".to_string(),
             message,
         },
-        None => CommandError::from(error),
+        None => {
+            let mut command_error = CommandError::from(error);
+            let stderr = crate::sona::recent_stderr(sona_state).await;
+            if !stderr.is_empty() {
+                command_error.message.push_str(&format!("\n\nsona stderr: {stderr}"));
+            }
+            command_error
+        }
     }
 }
 

--- a/desktop/src-tauri/src/handoff/transfer.rs
+++ b/desktop/src-tauri/src/handoff/transfer.rs
@@ -82,7 +82,14 @@ pub(super) async fn sona_transfer_error(
     }
     match crate::sona::death_report(sona_state, crate::cmd::transcribe::SONA_DIED).await {
         Some(message) => TransferError::new("internal_error", message),
-        None => TransferError::from(error),
+        None => {
+            let stderr = crate::sona::recent_stderr(sona_state).await;
+            if stderr.is_empty() {
+                TransferError::from(error)
+            } else {
+                TransferError::new("internal_error", format!("{error:#}\n\nsona stderr: {stderr}"))
+            }
+        }
     }
 }
 

--- a/desktop/src-tauri/src/sona/mod.rs
+++ b/desktop/src-tauri/src/sona/mod.rs
@@ -110,6 +110,17 @@ pub async fn death_report(state: &tokio::sync::Mutex<crate::setup::SonaState>, c
     state.process.as_mut()?.death_report(context).await
 }
 
+/// What the sidecar printed lately, for an error that is not a death but that its
+/// stderr may still explain (a GPU driver complaining before the request fails, say).
+pub async fn recent_stderr(state: &tokio::sync::Mutex<crate::setup::SonaState>) -> String {
+    let state = state.lock().await;
+    state
+        .process
+        .as_ref()
+        .map(|process| process.recent_stderr())
+        .unwrap_or_default()
+}
+
 #[derive(Debug, Deserialize)]
 struct ReadySignal {
     #[allow(dead_code)]

--- a/desktop/src-tauri/src/sona/process.rs
+++ b/desktop/src-tauri/src/sona/process.rs
@@ -14,6 +14,8 @@ const READY_TIMEOUT: Duration = Duration::from_secs(60);
 /// pipe, so death paths wait this long for the collector to reach EOF.
 const STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 const STDERR_POLL_INTERVAL: Duration = Duration::from_millis(20);
+/// How long a death report waits for a child whose output already broke to become reapable.
+const EXIT_GRACE: Duration = Duration::from_secs(2);
 /// Nothing on a connection can go idle longer than this before we throw it away.
 /// Shorter than any idle close on the sona side, so a request is never handed a
 /// socket the server has already dropped.
@@ -294,14 +296,27 @@ impl SonaProcess {
         stderr_snapshot(&self.stderr_buf)
     }
 
-    fn recent_stderr(&self) -> String {
+    pub fn recent_stderr(&self) -> String {
         stderr_snapshot(&self.stderr_buf)
     }
 
     /// `Some(message)` when the child is gone, describing how it died and what it
     /// last printed. `None` while it is still running.
+    ///
+    /// A broken response stream reaches the caller a few milliseconds before the
+    /// child is reapable, so a short wait here is what turns "error decoding
+    /// response body" into the exit code and the stderr that explain it.
     pub async fn death_report(&mut self, context: &str) -> Option<String> {
-        let status = self.exit_status()?;
+        let deadline = Instant::now() + EXIT_GRACE;
+        let status = loop {
+            if let Some(status) = self.exit_status() {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(STDERR_POLL_INTERVAL).await;
+        };
         let stderr = self.stderr_after_exit().await;
         let mut message = format!("{context} ({})", describe_exit(status));
         if let Some(hint) = illegal_instruction_hint(status) {


### PR DESCRIPTION
A broken response stream reaches the app a few milliseconds before the sidecar is reapable, so the death report found it alive and the user saw only `failed to read sona event line: error decoding response body`, with nothing from the process that had just printed why (seen on a Ryzen 4500U laptop where the AMD Vulkan driver dies at the first `vkQueueSubmit`).

- `death_report` waits up to two seconds for the exit before giving up
- When the child really is still running, the recent stderr tail is appended to the error instead, on both the transcribe and handoff paths

The error text reaches the dialog, the logs, and the `transcribe_failed` analytics event, so reports now say what sona printed.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna