### PR TITLE
Keep the fetched ggml libraries under libs/lib too, and retire third_party/

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,7 +1,7 @@
 *.wav
 *.mp3
 .DS_Store
-third_party/lib/
+libs/lib/
 models/
 samples/
 sona

--- a/server/chorefile
+++ b/server/chorefile
@@ -10,7 +10,7 @@ ggml_blob=https://github.com/ggml-org/ggml/blob
 # directory names the release they are stored under.
 include libs/libs.chore
 
-# Fetch the pinned ggml headers into third_party/include.
+# Fetch the pinned ggml headers into libs/include.
 task fetch-headers {
 	out=$ROOT/libs/include
 	mkdir $out

--- a/server/crates/ggml-rs-sys/build.rs
+++ b/server/crates/ggml-rs-sys/build.rs
@@ -5,7 +5,7 @@ fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let root = manifest_dir.parent().and_then(Path::parent).unwrap();
     let include_dir = root.join("libs/include");
-    let lib_dir = root.join("third_party/lib");
+    let lib_dir = root.join("libs/lib");
     let wrapper = manifest_dir.join("wrapper.h");
 
     for path in [&wrapper, &include_dir, &lib_dir] {

--- a/server/docs/ARCHITECTURE.md
+++ b/server/docs/ARCHITECTURE.md
@@ -182,8 +182,8 @@ Scaling is explicit and process-level:
 ## Build & Packaging 🛠️
 
 - Whisper commit pinned via `.whispercpp-commit`
-- Platform-specific static libs downloaded to `third_party/lib`
-- Headers fetched to `third_party/include`
+- Platform-specific static libs downloaded to `libs/lib` (ignored)
+- Headers fetched to `libs/include` (checked in)
 - Rust binary links against platform whisper / ggml libs
 - Release packaging bundles:
   - `sona`

--- a/server/docs/BUILDING.md
+++ b/server/docs/BUILDING.md
@@ -6,9 +6,9 @@ The C library (ggml) and the Sona binary are built separately:
 
 1. **`libs/`** holds everything that determines the libraries: `libs/ggml-version` (the ggml release tag), `libs/patches/` (fixes ggml has not taken yet), and `libs/libs.chore` (the build recipe). Every task reads the tag from there.
 2. **`chore build-libs`** clones ggml at that tag, applies the patches, builds the static libraries for the current platform, and packages them; **`chore upload-libs`** does that and uploads the archive to the GitHub release tagged `libraries-ggml-{tag}-r{revision}`, with the revision from `libs/revision` (`chore libs-tag` prints the whole name). Bump the revision in the same commit as any change under `libs/`, and reset it to 1 when the ggml tag moves, so a changed bundle never replaces the one older sona tags still link against. The release notes record the git tree hash of `libs/` (`chore libs-id`); `upload-libs` fails when the tag already exists for another tree, which is what a forgotten bump looks like, and refuses uncommitted changes under `libs/`.
-3. **`chore fetch-libs`** downloads the prebuilt static libraries for the current platform from the release named by the current `libs/` into `third_party/lib/`.
+3. **`chore fetch-libs`** downloads the prebuilt static libraries for the current platform from the release named by the current `libs/` into `libs/lib/` (ignored by git).
 4. **`chore fetch-headers`** fetches the C headers into `libs/include/`, checked into git: they come from the same ggml tag as the libraries, so a header change changes the `libs/` tree like any other input.
-5. The binary links against `libs/include/` and `third_party/lib/`.
+5. The binary links against `libs/include/` and `libs/lib/`.
 
 This separation means contributors never need to build ggml locally; they just fetch the libraries.
 

--- a/server/libs/libs.chore
+++ b/server/libs/libs.chore
@@ -49,7 +49,7 @@ task platform-id {
 	}
 }
 
-# Download the prebuilt ggml static libraries for this platform into third_party.
+# Download the prebuilt ggml static libraries for this platform into libs/lib.
 task fetch-libs {
 	platform=$(platform-id)
 	tag=$(libs-tag)
@@ -58,10 +58,15 @@ task fetch-libs {
 	echo "release: $tag"
 	mkdir $ROOT/target
 	download gh://$repo/$tag/ggml-libs-$platform.tar.gz $ROOT/target/ggml-libs-$platform.tar.gz --timeout 120
-	# The archive also carries include/; the headers the build uses are the checked-in libs/include.
-	extract $ROOT/target/ggml-libs-$platform.tar.gz $ROOT/third_party
+	# Only lib/ is taken: the archive also carries include/, and the headers the
+	# build uses are the checked-in libs/include from the same ggml tag.
+	remove $ROOT/target/ggml-libs
+	extract $ROOT/target/ggml-libs-$platform.tar.gz $ROOT/target/ggml-libs
+	remove $ROOT/libs/lib
+	move $ROOT/target/ggml-libs/lib $ROOT/libs/lib
+	remove $ROOT/target/ggml-libs
 	remove $ROOT/target/ggml-libs-$platform.tar.gz
-	echo "extracted to $ROOT/third_party"
+	echo "extracted to $ROOT/libs/lib"
 }
 
 # Build the ggml static libraries for this platform and package them into an archive.


### PR DESCRIPTION
Everything ggml now sits under `server/libs/`: the tag, the patches, the recipe, the checked-in headers, and the fetched, ignored `lib/`. `fetch-libs` takes only `lib/` out of the archive, since the headers in it are the same ones checked in. `third_party/` is gone.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna