### PR TITLE
chmod the renamed sidecar, not the old name

### DIFF
--- a/chorefile
+++ b/chorefile
@@ -99,7 +99,7 @@ task setup target=$TRIPLE {
     # into place. Testing the target rather than $OS keeps a cross-compile from
     # chmod-ing a name that was never written.
     if $exe == "" {
-        chmod 755 $bin/sona-$1
+        chmod 755 $bin/vibe-server-$1$exe
         chmod 755 $bin/ffmpeg-$1
     }
     echo "installed vibe-server-$1 and ffmpeg-$1"


### PR DESCRIPTION
One `chmod` in `chore setup` still named `sona-<triple>`, so on macOS and Windows the extracted `vibe-server` was never made executable by that line.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna