### PR TITLE
Docs: the engine is server/, shipped as vibe-server

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,32 +11,32 @@ Vibe is a desktop transcription app built with **Tauri** (Rust + TypeScript fron
 - **Frontend**: TypeScript + React (UI)
 - **Backend**: Rust/Tauri (`desktop/src-tauri/`)
 - Handles UI, file management, settings, analytics
-- Spawns and communicates with the Sona runner via local HTTP
+- Spawns and communicates with the server via local HTTP
 
-### Sona Runner (`sona/` folder)
+### Server (`server/`)
 
-- **Language**: Rust + whisper.cpp bindings
-- **Location**: Separate repository at `github.com/vibe-transcribe/sona` (also cloned locally in `./sona`)
-- **Purpose**: Single local runner process for audio transcription, model loading, streaming, and diarization
-- Bundled as one `sona` binary sidecar with the desktop app
-- Diarization is in-process in Sona via `diarize-rs`; Vibe does not bundle or spawn a separate `sona-diarize` binary
-- **Build**: Separate CI/CD in sona repository
-- **Distribution**: Pre-built Sona binaries downloaded during Vibe build (see the `setup` task in the root `chorefile`)
+- **Language**: Rust on ggml (`whisper-rs`, `parakeet-rs`, `nemotron-rs`, `vad-rs`, `diarize-rs`)
+- **Location**: `server/` in this repository, its own Cargo workspace; crate and binary `vibe-server`
+- **Purpose**: single local process for audio transcription, model loading, streaming, and diarization, behind an OpenAI-compatible HTTP API
+- Bundled as the `vibe-server` sidecar with the desktop app
+- Diarization is in-process via `diarize-rs`; Vibe does not bundle or spawn a separate binary
+- **Build**: `server-libs.yml` publishes the prebuilt ggml libraries (`libraries-ggml-<version>-r<revision>`, inputs under `server/libs/`); `server-release.yml` publishes `server-v*` prereleases; `server-test.yml` runs a release across platforms
+- **Distribution**: the app downloads the release named by `.server-version` at build time (`setup` task in the root `chorefile`); `chore server-build` stages an in-tree build instead
 
 ### FFmpeg Helper
 
-- macOS and Windows builds also bundle `ffmpeg` from the Sona release archives
-- Vibe passes its path to Sona with `SONA_FFMPEG_PATH`
+- macOS and Windows builds also bundle `ffmpeg` from the server release archives
+- Vibe passes its path to the server with `SONA_FFMPEG_PATH`
 
 ### Build Flow
 
 1. Vibe CI runs `chore setup <target-triple>`
-2. Script downloads pre-built Sona binaries from Sona releases
+2. It downloads the prebuilt `vibe-server` from the `server-v*` release in `.server-version`
 3. Binaries placed in `desktop/src-tauri/binaries/`
-4. Tauri bundles `sona` and, where configured, `ffmpeg` into the final app
+4. Tauri bundles `vibe-server` and, where configured, `ffmpeg` into the final app
 
 ## Key Point for Agents
 
-Native runtime compatibility issues for transcription usually come from the Sona runner or its linked whisper/ggml libraries, not the Vibe UI code.
+Native runtime compatibility issues for transcription usually come from the server or its linked ggml libraries, not the Vibe UI code.
 
-To fix Sona runtime compatibility issues, update **Sona's** build configuration in the Sona repository, then bump `.sona-version` in Vibe.
+To fix one, change `server/` (a ggml fix goes in `server/libs/patches/` with a revision bump), tag a `server-v*` release, then bump `.server-version` here.

--- a/docs/building.md
+++ b/docs/building.md
@@ -34,8 +34,8 @@ chore dev      # fetch the sidecars, then run the app
 chore build    # fetch the sidecars, then build for production
 ```
 
-Both start with `chore setup`, which downloads the sidecars pinned by
-`.sona-version` into `desktop/src-tauri/binaries/`. The same steps by hand:
+Both start with `chore setup`, which downloads the sidecars from the server
+release pinned by `.server-version` into `desktop/src-tauri/binaries/`. The same steps by hand:
 
 ```console
 chore setup
@@ -51,42 +51,19 @@ it fetches for this machine.
 On macOS, `chore upgrade` builds the app, replaces `/Applications/vibe.app` and
 relaunches it.
 
-## Build sona locally (dev)
+## Build the server locally (dev)
 
-Download prebuilt whisper.cpp libs (one-time):
-
-```console
-uv run sona/scripts/download-libs.py
-```
-
-**Windows only** — install [MSYS2](https://www.msys2.org/), then install MinGW and Vulkan headers:
+The engine lives in `server/` and ships as the `vibe-server` sidecar. To run the
+app against a build of the tree instead of the pinned release:
 
 ```console
-pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-vulkan-devel
+chore setup            # ffmpeg and the released server, once
+chore server-build     # fetch the ggml libraries, build server/, stage it as the sidecar
 ```
 
-Open an MSYS2 MinGW64 shell with your full Windows PATH (so `rustc`, `cargo`, etc. are available):
-
-```console
-C:\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -use-full-path
-```
-
-Then build sona and place it as sidecar (from `desktop/`):
-
-```console
-# macOS/Linux
-cargo build --manifest-path ../sona/Cargo.toml -p sona --release
-cp ../sona/target/release/sona ../desktop/src-tauri/binaries/sona-$(rustc -vV | awk '/host:/ {print $2}')
-# Windows
-cargo build --manifest-path ../sona/Cargo.toml -p sona --release
-cp ../sona/target/release/sona.exe ../desktop/src-tauri/binaries/sona-$(rustc -vV | awk '/host:/ {print $2}').exe
-```
-
-Then copy the binary into the dev target so `tauri dev` picks it up immediately:
-
-```console
-cp desktop/src-tauri/binaries/sona-$(rustc -vV | awk '/host:/ {print $2}') target/debug/sona
-```
+`server-build` puts `vibe-server-<triple>` where `setup` put the release, so
+`tauri dev` and `tauri build` pick it up unchanged. See `server/docs/BUILDING.md`
+for the engine on its own.
 
 ## Test
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,16 +1,16 @@
-# Sona 🎧
+# vibe-server 🎧
 
-Sona is a local transcription runner built on top of ggml.cpp.
+vibe-server is a local transcription runner built on top of ggml.cpp.
 
 It runs as a standalone process and exposes an OpenAI-compatible HTTP API, so other apps (desktop apps, Python scripts, etc.) can spawn it and talk to it easily.
 
 Think of it as a small, fast, local Whisper server you control.
 
-This runner is used by the [thewh1teagle/vibe](https://github.com/thewh1teagle/vibe) project.
+It is the engine of [Vibe](https://github.com/thewh1teagle/vibe) and lives in this repository under `server/`; it also runs on its own.
 
 ---
 
-## Why Sona ✨
+## Why vibe-server ✨
 
 - Fully local transcription
 - Cross-platform single binary
@@ -23,7 +23,7 @@ This runner is used by the [thewh1teagle/vibe](https://github.com/thewh1teagle/v
 
 ## Platform & GPU Support 🚀
 
-Sona ships prebuilt binaries for:
+vibe-server ships prebuilt binaries for:
 
 - macOS (x86_64 and arm64)
 - Linux (x86_64 and arm64)
@@ -35,19 +35,19 @@ GPU acceleration is enabled by default:
 - Linux: Vulkan
 - Windows: Vulkan
 
-Sona automatically uses the best available backend for the platform.
+vibe-server automatically uses the best available backend for the platform.
 
 ---
 
 ## How It Works 🧠
 
-1. Your app starts the Sona process
-2. Sona binds to a local port (optionally chosen by the OS)
-3. Your app talks to Sona over HTTP
+1. Your app starts the vibe-server process
+2. vibe-server binds to a local port (optionally chosen by the OS)
+3. Your app talks to vibe-server over HTTP
 4. Models are loaded and unloaded at runtime
 5. Transcription requests go through an OpenAI-compatible endpoint
 
-Sona is intentionally simple and predictable, so it can be embedded into larger systems.
+vibe-server is intentionally simple and predictable, so it can be embedded into larger systems.
 
 ---
 
@@ -55,23 +55,23 @@ Sona is intentionally simple and predictable, so it can be embedded into larger 
 
 ### 1. Download a release binary
 
-https://github.com/vibe-transcribe/sona/releases
+https://github.com/thewh1teagle/vibe/releases?q=server-v
 
 ### 2. Download a model
 
 ```console
-./sona pull https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
+./vibe-server pull https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
 ```
 
-### 3. Start Sona
+### 3. Start vibe-server
 
 ```console
-./sona serve --port 0
+./vibe-server serve --port 0
 ```
 
 Using port 0 lets the OS assign a free port automatically.
 
-When ready, Sona prints a single machine-readable line to stdout:
+When ready, vibe-server prints a single machine-readable line to stdout:
 
 ```json
 {"status":"ready","port":52341}
@@ -81,14 +81,14 @@ This is intended for parent processes to detect readiness and discover the bound
 
 ---
 
-## Using Sona 🔌
+## Using vibe-server 🔌
 
-Sona exposes an OpenAI-compatible transcription API.
+vibe-server exposes an OpenAI-compatible transcription API.
 
 This means:
 - You can use existing OpenAI SDKs
 - You don’t need custom client code
-- Switching between local (Sona) and remote (OpenAI) is trivial
+- Switching between local (vibe-server) and remote (OpenAI) is trivial
 
 See the full API reference here:
 - API docs: /docs
@@ -101,13 +101,13 @@ See the full API reference here:
 - One transcription runs at a time per process  
   concurrent requests return 429
 - Non-WAV audio is automatically converted using ffmpeg
-  - system ffmpeg or a bundled binary next to sona
+  - system ffmpeg or a bundled binary next to vibe-server
 
 ---
 
-## When to Use Sona 🎯
+## When to Use vibe-server 🎯
 
-Sona is a good fit if you want:
+vibe-server is a good fit if you want:
 - Local or offline transcription
 - Low-latency transcription in desktop apps
 - Full control over models and hardware
@@ -119,4 +119,4 @@ Sona is a good fit if you want:
 
 - API reference: /docs
 - OpenAPI schema: /openapi.json
-- Releases: https://github.com/vibe-transcribe/sona/releases
+- Releases: https://github.com/thewh1teagle/vibe/releases?q=server-v

--- a/server/docs/ARCHITECTURE.md
+++ b/server/docs/ARCHITECTURE.md
@@ -1,14 +1,14 @@
-# Sona Architecture 🧩
+# vibe-server Architecture 🧩
 
-This document describes how Sona is structured internally and how the runtime behaves.
+This document describes how vibe-server is structured internally and how the runtime behaves.
 
-Sona is intentionally simple: one process, one model, one transcription at a time.
+vibe-server is intentionally simple: one process, one model, one transcription at a time.
 
 ---
 
 ## Overview
 
-Sona is a single-process Rust binary with two operating modes:
+vibe-server is a single-process Rust binary with two operating modes:
 
 - `sona transcribe <model.bin> <audio>`  
   One-shot local transcription, no server.
@@ -17,7 +17,7 @@ Sona is a single-process Rust binary with two operating modes:
   Long-running HTTP runner with an OpenAI-compatible API.
 
 The server follows a **runner model**, not a shared service model:
-- one owner process spawns Sona
+- one owner process spawns vibe-server
 - the owner manages lifecycle
 - communication happens over local HTTP
 
@@ -64,7 +64,7 @@ High-level layout of the codebase:
 1. `server::serve` binds a TCP port  
    - `--port 0` is supported for auto-assigned ports
 
-2. Once bound, Sona prints exactly one machine-readable line to stdout:
+2. Once bound, vibe-server prints exactly one machine-readable line to stdout:
 
 ```json
 {"status":"ready","port":52341}
@@ -77,7 +77,7 @@ High-level layout of the codebase:
    - unload model by dropping the whisper context
    - exit cleanly
 
-This design makes Sona easy to supervise from another process.
+This design makes vibe-server easy to supervise from another process.
 
 ---
 
@@ -175,7 +175,7 @@ Effective behavior:
 - concurrent transcription requests return `429`
 
 Scaling is explicit and process-level:
-- run multiple Sona instances if needed
+- run multiple vibe-server instances if needed
 
 ---
 
@@ -193,7 +193,7 @@ Scaling is explicit and process-level:
 
 ## Current Boundaries 🚧
 
-Sona intentionally does **not** include:
+vibe-server intentionally does **not** include:
 
 - authentication or multi-tenant logic
 - internal job queues or async job IDs
@@ -202,4 +202,4 @@ Sona intentionally does **not** include:
 
 Integrations are expected to happen over HTTP.
 
-This keeps Sona small, predictable, and easy to embed.
+This keeps vibe-server small, predictable, and easy to embed.

--- a/server/docs/BUILDING.md
+++ b/server/docs/BUILDING.md
@@ -1,8 +1,8 @@
-# Building Sona
+# Building vibe-server
 
 ## Architecture
 
-The C library (ggml) and the Sona binary are built separately:
+The C library (ggml) and the vibe-server binary are built separately:
 
 1. **`libs/`** holds everything that determines the libraries: `libs/ggml-version` (the ggml release tag), `libs/patches/` (fixes ggml has not taken yet), and `libs/libs.chore` (the build recipe). Every task reads the tag from there.
 2. **`chore build-libs`** clones ggml at that tag, applies the patches, builds the static libraries for the current platform, and packages them; **`chore upload-libs`** does that and uploads the archive to the GitHub release tagged `libraries-ggml-{tag}-r{revision}`, with the revision from `libs/revision` (`chore libs-tag` prints the whole name). Bump the revision in the same commit as any change under `libs/`, and reset it to 1 when the ggml tag moves, so a changed bundle never replaces the one older sona tags still link against. The release notes record the git tree hash of `libs/` (`chore libs-id`); `upload-libs` fails when the tag already exists for another tree, which is what a forgotten bump looks like, and refuses uncommitted changes under `libs/`.
@@ -27,7 +27,7 @@ chore fetch-libs
 cargo build -p vibe-server --release
 ```
 
-On Windows, the Sona binary uses Rust's default MSVC target. The Vulkan loader is opened at runtime, so building and running Sona needs no Vulkan SDK; only `chore build-libs` does, for the headers and `glslc`:
+On Windows, the vibe-server binary uses Rust's default MSVC target. The Vulkan loader is opened at runtime, so building and running vibe-server needs no Vulkan SDK; only `chore build-libs` does, for the headers and `glslc`:
 
 ```bash
 cargo build -p vibe-server --release
@@ -55,7 +55,7 @@ AVX2 is compiled into every ggml CPU kernel, so one build cannot serve a CPU wit
 
 ## Releasing binaries
 
-`Release Sona` workflow builds and uploads Rust `sona` binaries for:
+`Release vibe-server` workflow builds and uploads Rust `sona` binaries for:
 - Linux: `amd64`, `arm64`
 - macOS: Apple Silicon and Intel
 - Windows: `amd64`


### PR DESCRIPTION
Vibe's building and architecture docs describe `server/`, `.server-version`, `chore server-build`, and the three server workflows; the server's own README and docs call the engine vibe-server and point releases at this repository. Environment variables keep their `SONA_` names.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna