### PR TITLE
Finish the rename: installer hook, VIBE_SERVER_* environment, and the engine's own prose

### DIFF
--- a/.github/workflows/server-libs.yml
+++ b/.github/workflows/server-libs.yml
@@ -76,5 +76,5 @@ jobs:
       - name: Build and upload
         env:
           GH_TOKEN: ${{ github.token }}
-          SONA_WINDOWS_LIB_FLAVOR: ${{ matrix.windows_lib_flavor }}
+          VIBE_SERVER_WINDOWS_LIB_FLAVOR: ${{ matrix.windows_lib_flavor }}
         run: chore upload-libs

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Build vibe-server
         shell: bash
         env:
-          SONA_COMMIT: ${{ github.sha }}
+          VIBE_SERVER_COMMIT: ${{ github.sha }}
         run: |
-          export SONA_VERSION="${VERSION#server-}"
+          export VIBE_SERVER_VERSION="${VERSION#server-}"
           cargo build -p vibe-server --release ${{ matrix.cargo_flags }}
           src="target/release/vibe-server"
           if [[ "${{ runner.os }}" == "Windows" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,5 @@ tauri-plugin-aptabase/
 **/project.inlang/cache/
 **/project.inlang/project_id
 
-# Scratch artifacts for the sona/whisper output comparison (includes a 47MB binary).
+# Scratch artifacts for the engine/whisper output comparison (includes a 47MB binary).
 plans/

--- a/.skills/aptabase-analytics-report/SKILL.md
+++ b/.skills/aptabase-analytics-report/SKILL.md
@@ -127,7 +127,7 @@ Separate user-input mistakes from runtime, environment, and packaging failures. 
 
 Build buckets from the current data, then map the high-volume failures to code paths before proposing changes:
 
-- `desktop/src-tauri/src/sona.rs`: spawn, load-model, and transcribe HTTP failures
+- `desktop/src-tauri/src/server/`: spawn, load-model, and transcribe HTTP failures
 - `desktop/src-tauri/src/cmd/mod.rs`: input validation and surfaced transcription errors
 
 Read `references/error-buckets.md` for the general workflow on discovering the current event set and deriving buckets from the current repository state.

--- a/.skills/aptabase-analytics-report/references/error-buckets.md
+++ b/.skills/aptabase-analytics-report/references/error-buckets.md
@@ -48,7 +48,7 @@ Name buckets based on the current dominant patterns in the export. Keep the name
 
 After identifying the dominant current failures, inspect the relevant code paths:
 
-- `desktop/src-tauri/src/sona.rs` for spawn, process lifecycle, load-model, and transcribe request issues
+- `desktop/src-tauri/src/server/` for spawn, process lifecycle, load-model, and transcribe request issues
 - `desktop/src-tauri/src/cmd/mod.rs` for input validation and surfaced command errors
 - any other current call sites that emit analytics props or errors
 

--- a/desktop/src-tauri/entitlements.plist
+++ b/desktop/src-tauri/entitlements.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
     Hardened runtime entitlements. Applied to the main `vibe` binary AND to the
-    `sona` / `ffmpeg` sidecars, which Tauri re-signs with the same entitlements
+    `vibe-server` / `ffmpeg` sidecars, which Tauri re-signs with the same entitlements
     (see tauri.macos.conf.json: hardenedRuntime = true).
 
     Keep this list minimal: every entitlement here is a hole in the hardened
@@ -12,10 +12,10 @@
     bundle with `otool -L` / `codesign -dvvv`):
 
       com.apple.security.cs.disable-library-validation
-          Not needed. `sona` and `ffmpeg` link only Apple system frameworks and
+          Not needed. `vibe-server` and `ffmpeg` link only Apple system frameworks and
           /usr/lib; the bundle ships no third-party dylibs, and nothing is
           dlopen'd at runtime on macOS. (The libonnxruntime_providers_*.dylib
-          strings inside `sona` are CUDA/TensorRT/OpenVINO/QNN/CANN execution
+          strings inside `vibe-server` are CUDA/TensorRT/OpenVINO/QNN/CANN execution
           providers - non-Apple platforms, never loaded here.) Adding this would
           let any unsigned or foreign-team dylib be injected into the sidecars
           for no benefit.
@@ -43,9 +43,9 @@
 
     <!--
         Permits MAP_JIT mappings (write-then-execute pages requested explicitly
-        via mmap MAP_JIT). Added for the `sona` sidecar's GPU path.
+        via mmap MAP_JIT). Added for the `vibe-server` sidecar's GPU path.
 
-        Why: `sona` links Metal/MetalKit and embeds the ggml Metal kernels as
+        Why: `vibe-server` links Metal/MetalKit and embeds the ggml Metal kernels as
         *source* rather than a precompiled .metallib - the binary contains
         `ggml_metal_library_init_from_source`, `newLibraryWithSource:options:error:`
         and ~125 raw `kernel void` shader bodies. Shaders are therefore compiled

--- a/desktop/src-tauri/src/analytics.rs
+++ b/desktop/src-tauri/src/analytics.rs
@@ -25,6 +25,7 @@ pub mod events {
     /// Server finished under the CLI: carries the exit code and wall-clock duration.
     pub const CLI_FINISHED: &str = "cli_finished";
     pub const CLI_SPAWN_FAILED: &str = "cli_spawn_failed";
+    /// The string predates the rename; keeping it keeps the dashboards continuous.
     pub const SERVER_SPAWN_FAILED: &str = "sona_spawn_failed";
 
     // Phone handoff. Props are technical facts only: never a transcript, filename,

--- a/desktop/src-tauri/src/cli.rs
+++ b/desktop/src-tauri/src/cli.rs
@@ -89,7 +89,7 @@ pub async fn run(app_handle: &AppHandle) -> Result<()> {
         .stderr(std::process::Stdio::piped());
 
     if let Some(ref ffmpeg) = ffmpeg_path {
-        cmd.env("SONA_FFMPEG_PATH", ffmpeg);
+        cmd.env("VIBE_SERVER_FFMPEG_PATH", ffmpeg);
     }
 
     let mut child = match cmd.spawn() {

--- a/desktop/src-tauri/src/server/process.rs
+++ b/desktop/src-tauri/src/server/process.rs
@@ -141,7 +141,7 @@ impl ServerProcess {
         cmd.args(["serve", "--port", "0"])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .env("SONA_UNLOAD_TIMEOUT", unload_timeout)
+            .env("VIBE_SERVER_UNLOAD_TIMEOUT", unload_timeout)
             // ggml_print_backtrace forks gdb/lldb on abort, which can hang the
             // dying child and produces nothing useful in a shipped build.
             .env("GGML_NO_BACKTRACE", "1");
@@ -152,8 +152,8 @@ impl ServerProcess {
         }
 
         if let Some(ffmpeg) = ffmpeg_path {
-            tracing::debug!("setting SONA_FFMPEG_PATH={}", ffmpeg.display());
-            cmd.env("SONA_FFMPEG_PATH", ffmpeg);
+            tracing::debug!("setting VIBE_SERVER_FFMPEG_PATH={}", ffmpeg.display());
+            cmd.env("VIBE_SERVER_FFMPEG_PATH", ffmpeg);
         }
         #[cfg(target_os = "windows")]
         {

--- a/desktop/src-tauri/vc_redist.nsh
+++ b/desktop/src-tauri/vc_redist.nsh
@@ -21,6 +21,8 @@
 
 !macro NSIS_HOOK_PREINSTALL
     ; Keep one entry per bundled sidecar that can outlive the main application.
+    !insertmacro StopSidecarBeforeInstall "vibe-server.exe"
+    ; Installs before 3.1.11 shipped the engine as sona.exe; an upgrade must stop it too.
     !insertmacro StopSidecarBeforeInstall "sona.exe"
 !macroend
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Vibe is a desktop transcription app built with **Tauri** (Rust + TypeScript fron
 ### FFmpeg Helper
 
 - macOS and Windows builds also bundle `ffmpeg` from the server release archives
-- Vibe passes its path to the server with `SONA_FFMPEG_PATH`
+- Vibe passes its path to the server with `VIBE_SERVER_FFMPEG_PATH`
 
 ### Build Flow
 

--- a/scripts/sign_windows.py
+++ b/scripts/sign_windows.py
@@ -44,7 +44,7 @@ import httpx
 # SIGN_PATTERNS = [
 #     "vibe.exe",
 #     "vibe*setup*.exe",
-#     "sona*.exe",
+#     "vibe-server*.exe",
 # ]
 SIGN_PATTERNS = ["*"]
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -4,8 +4,8 @@
 libs/lib/
 models/
 samples/
-sona
-!sona/
+vibe-server
+!vibe-server/
 ggml-src/
 ggml-build/
 *.tar.gz
@@ -20,8 +20,6 @@ __pycache__/
 *.pyc
 target/
 *.onnx
-sona-diarize
-sona-diarize-*-*
 
 # Sortformer GGUF port: large artifacts stay out of git
 # Recorded ONNX reference dumps. Regenerate with baseline/regen.sh (needs the

--- a/server/chorefile
+++ b/server/chorefile
@@ -1,4 +1,4 @@
-# Sona project tasks. Run `chore list` to see them.
+# vibe-server tasks. Run `chore list` to see them.
 #
 # The pinned ggml release tag, e.g. "v0.22.0".
 version=$(read $ROOT/libs/ggml-version)
@@ -26,7 +26,7 @@ task fetch-headers {
 	}
 }
 
-# Package a built sona binary with ffmpeg: package-release <binary> <goos> <goarch> <out>.
+# Package a built vibe-server binary with ffmpeg: package-release <binary> <goos> <goarch> <out>.
 task package-release binary goos goarch out {
 	if !exists $1 { fail "binary not found: $1" }
 	stage=$ROOT/target/server-package

--- a/server/crates/diarize-rs/Cargo.toml
+++ b/server/crates/diarize-rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Speaker diarization library for Sona using NVIDIA Sortformer"
+description = "Speaker diarization library for vibe-server using NVIDIA Sortformer"
 
 [lib]
 name = "diarize_rs"

--- a/server/crates/diarize-rs/src/host/mod.rs
+++ b/server/crates/diarize-rs/src/host/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! Derived from <https://github.com/altunenes/parakeet-rs>, which is licensed
 //! `MIT OR Apache-2.0`. Taken under the MIT option, whose notice the MIT-licensed
-//! Sona repository must carry forward:
+//! vibe-server must carry forward:
 //!
 //! > MIT License
 //! >

--- a/server/crates/ggml-rs-sys/Cargo.toml
+++ b/server/crates/ggml-rs-sys/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Raw FFI bindings to Sona's pinned GGML runtime"
+description = "Raw FFI bindings to vibe-server's pinned GGML runtime"
 links = "ggml"
 build = "build.rs"
 

--- a/server/crates/ggml-rs-sys/build.rs
+++ b/server/crates/ggml-rs-sys/build.rs
@@ -73,7 +73,7 @@ fn link_platform() {
             println!("cargo:rustc-link-lib=c++");
         }
         // The Vulkan loader is opened at runtime (libs/patches/0003), so nothing links
-        // against it: a machine without one starts sona and runs on the CPU.
+        // against it: a machine without one starts vibe-server and runs on the CPU.
         Ok("linux") => {
             println!("cargo:rustc-link-lib=static=ggml-vulkan");
             for lib in ["stdc++", "m", "pthread", "gomp", "dl"] {

--- a/server/crates/ggml-rs-sys/src/cpu_variant.rs
+++ b/server/crates/ggml-rs-sys/src/cpu_variant.rs
@@ -4,7 +4,7 @@
 //! FMA, BMI2) and for the AVX baseline, with every symbol suffixed `_hsw` or `_x64` by
 //! `chore build-libs` (`stage-cpu-variant` in libs/libs.chore). ggml's backend registry resolves `ggml_backend_cpu_reg` at link
 //! time; this is the definition it finds, and it forwards to the build the CPU can run.
-//! Nothing else in ggml or in Sona names a CPU backend symbol directly: the rest goes
+//! Nothing else in ggml or in vibe-server names a CPU backend symbol directly: the rest goes
 //! through the registry and `ggml_backend_reg_get_proc_address`.
 
 use crate::ggml_backend_reg_t;

--- a/server/crates/nemotron-rs/src/lib.rs
+++ b/server/crates/nemotron-rs/src/lib.rs
@@ -1,4 +1,4 @@
-//! Native Nemotron ASR inference built on Sona's shared GGML runtime.
+//! Native Nemotron ASR inference built on vibe-server's shared GGML runtime.
 
 mod decoder;
 mod encoder;

--- a/server/crates/parakeet-rs/src/lib.rs
+++ b/server/crates/parakeet-rs/src/lib.rs
@@ -1,4 +1,4 @@
-//! Native Parakeet ASR inference built on Sona's shared GGML runtime.
+//! Native Parakeet ASR inference built on vibe-server's shared GGML runtime.
 
 mod decoder;
 mod encoder;

--- a/server/crates/vad-rs/Cargo.toml
+++ b/server/crates/vad-rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Silero VAD segmentation on ggml for Sona"
+description = "Silero VAD segmentation on ggml for vibe-server"
 
 [dependencies]
 thiserror = "2"

--- a/server/crates/vibe-server/src/audio.rs
+++ b/server/crates/vibe-server/src/audio.rs
@@ -111,13 +111,13 @@ fn find_ffmpeg() -> anyhow::Result<PathBuf> {
         return Ok(path);
     }
 
-    if let Ok(path) = std::env::var("SONA_FFMPEG_PATH") {
+    if let Ok(path) = std::env::var("VIBE_SERVER_FFMPEG_PATH") {
         let path = PathBuf::from(path);
         if path.exists() {
             return Ok(path);
         }
         eprintln!(
-            "warning: SONA_FFMPEG_PATH set to {:?} but not found, continuing search",
+            "warning: VIBE_SERVER_FFMPEG_PATH set to {:?} but not found, continuing search",
             path
         );
     }

--- a/server/crates/vibe-server/src/cli.rs
+++ b/server/crates/vibe-server/src/cli.rs
@@ -5,11 +5,11 @@ use whisper_rs::{ContextOptions, TranscribeOptions};
 use crate::server::format;
 use crate::{audio, pull, server};
 
-const VERSION: &str = match option_env!("SONA_VERSION") {
+const VERSION: &str = match option_env!("VIBE_SERVER_VERSION") {
     Some(value) => value,
     None => "dev",
 };
-const COMMIT: &str = match option_env!("SONA_COMMIT") {
+const COMMIT: &str = match option_env!("VIBE_SERVER_COMMIT") {
     Some(value) => value,
     None => "dev",
 };
@@ -65,7 +65,7 @@ enum Command {
         port: u16,
         #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
         exit_with_parent: bool,
-        #[arg(long, env = "SONA_UNLOAD_TIMEOUT", default_value = "0")]
+        #[arg(long, env = "VIBE_SERVER_UNLOAD_TIMEOUT", default_value = "0")]
         unload_timeout: crate::server::unload_timeout::UnloadTimeout,
     },
     Pull {

--- a/server/crates/vibe-server/src/server/mod.rs
+++ b/server/crates/vibe-server/src/server/mod.rs
@@ -110,7 +110,7 @@ impl ServerState {
         format::VerboseJson,
         format::VerboseSegment
     )),
-    tags((name = "sona", description = "Sona transcription server"))
+    tags((name = "vibe-server", description = "vibe-server transcription server"))
 )]
 struct ApiDoc;
 

--- a/server/crates/vibe-server/src/server/routes/skill.rs
+++ b/server/crates/vibe-server/src/server/routes/skill.rs
@@ -1,9 +1,9 @@
 use axum::http::{header, HeaderMap};
 use axum::response::IntoResponse;
 
-const TEMPLATE: &str = r#"# Sona Local Transcription API
+const TEMPLATE: &str = r#"# vibe-server Local Transcription API
 
-You are using Sona, a local whisper.cpp transcription HTTP API.
+You are using vibe-server, a local transcription HTTP API on ggml.
 
 Base URL: {{base_url}}
 OpenAPI schema: {{base_url}}/openapi.json

--- a/server/crates/whisper-rs/src/context.rs
+++ b/server/crates/whisper-rs/src/context.rs
@@ -1,7 +1,7 @@
 //! The historical whisper-rs API surface (`Context`, `set_verbose`), now
 //! implemented on the pure-Rust engine instead of whisper.cpp FFI. Option
 //! mapping and callback semantics are kept from the previous implementation
-//! so sona is unaffected.
+//! so vibe-server is unaffected.
 
 use std::ffi::{c_char, c_void, CStr};
 use std::io::Write;

--- a/server/crates/whisper-rs/src/lib.rs
+++ b/server/crates/whisper-rs/src/lib.rs
@@ -6,7 +6,7 @@
 //! the pinned GGML release linked through `ggml-rs-sys`.
 //!
 //! Two API levels: [`Context`] keeps the historical whisper-rs surface that
-//! sona consumes, and [`Whisper`]/[`FullParams`] expose the engine directly.
+//! vibe-server consumes, and [`Whisper`]/[`FullParams`] expose the engine directly.
 
 mod error;
 #[cfg_attr(not(feature = "ffi"), allow(dead_code))]

--- a/server/docs/ARCHITECTURE.md
+++ b/server/docs/ARCHITECTURE.md
@@ -10,10 +10,10 @@ vibe-server is intentionally simple: one process, one model, one transcription a
 
 vibe-server is a single-process Rust binary with two operating modes:
 
-- `sona transcribe <model.bin> <audio>`  
+- `vibe-server transcribe <model.bin> <audio>`  
   One-shot local transcription, no server.
 
-- `sona serve [model.bin] --port <n>`  
+- `vibe-server serve [model.bin] --port <n>`  
   Long-running HTTP runner with an OpenAI-compatible API.
 
 The server follows a **runner model**, not a shared service model:
@@ -29,13 +29,13 @@ This keeps ownership, shutdown, and scaling explicit and predictable.
 
 High-level layout of the codebase:
 
-- `crates/sona/src/cli.rs`  
+- `crates/vibe-server/src/cli.rs`  
   CLI entrypoints:
   - `transcribe`
   - `serve`
   - `pull`
 
-- `crates/sona/src/audio.rs`  
+- `crates/vibe-server/src/audio.rs`  
   Audio decoding and normalization:
   - Converts input to `16kHz` mono `float32`
   - Fallback to `ffmpeg` for all other formats
@@ -50,7 +50,7 @@ High-level layout of the codebase:
 - `crates/diarize-rs`  
   In-process Sortformer diarization.
 
-- `crates/sona/src/server`  
+- `crates/vibe-server/src/server`  
   HTTP layer:
   - routing
   - model lifecycle
@@ -186,7 +186,7 @@ Scaling is explicit and process-level:
 - Headers fetched to `libs/include` (checked in)
 - Rust binary links against platform whisper / ggml libs
 - Release packaging bundles:
-  - `sona`
+  - `vibe-server`
   - `ffmpeg` binary (when applicable)
 
 ---

--- a/server/docs/BUILDING.md
+++ b/server/docs/BUILDING.md
@@ -5,7 +5,7 @@
 The C library (ggml) and the vibe-server binary are built separately:
 
 1. **`libs/`** holds everything that determines the libraries: `libs/ggml-version` (the ggml release tag), `libs/patches/` (fixes ggml has not taken yet), and `libs/libs.chore` (the build recipe). Every task reads the tag from there.
-2. **`chore build-libs`** clones ggml at that tag, applies the patches, builds the static libraries for the current platform, and packages them; **`chore upload-libs`** does that and uploads the archive to the GitHub release tagged `libraries-ggml-{tag}-r{revision}`, with the revision from `libs/revision` (`chore libs-tag` prints the whole name). Bump the revision in the same commit as any change under `libs/`, and reset it to 1 when the ggml tag moves, so a changed bundle never replaces the one older sona tags still link against. The release notes record the git tree hash of `libs/` (`chore libs-id`); `upload-libs` fails when the tag already exists for another tree, which is what a forgotten bump looks like, and refuses uncommitted changes under `libs/`.
+2. **`chore build-libs`** clones ggml at that tag, applies the patches, builds the static libraries for the current platform, and packages them; **`chore upload-libs`** does that and uploads the archive to the GitHub release tagged `libraries-ggml-{tag}-r{revision}`, with the revision from `libs/revision` (`chore libs-tag` prints the whole name). Bump the revision in the same commit as any change under `libs/`, and reset it to 1 when the ggml tag moves, so a changed bundle never replaces the one older server tags still link against. The release notes record the git tree hash of `libs/` (`chore libs-id`); `upload-libs` fails when the tag already exists for another tree, which is what a forgotten bump looks like, and refuses uncommitted changes under `libs/`.
 3. **`chore fetch-libs`** downloads the prebuilt static libraries for the current platform from the release named by the current `libs/` into `libs/lib/` (ignored by git).
 4. **`chore fetch-headers`** fetches the C headers into `libs/include/`, checked into git: they come from the same ggml tag as the libraries, so a header change changes the `libs/` tree like any other input.
 5. The binary links against `libs/include/` and `libs/lib/`.
@@ -33,7 +33,7 @@ On Windows, the vibe-server binary uses Rust's default MSVC target. The Vulkan l
 cargo build -p vibe-server --release
 ```
 
-The library workflow also builds a `windows-amd64-gnu` ggml bundle for compatibility (`SONA_WINDOWS_LIB_FLAVOR=gnu`), but release binaries use `windows-amd64-msvc`.
+The library workflow also builds a `windows-amd64-gnu` ggml bundle for compatibility (`VIBE_SERVER_WINDOWS_LIB_FLAVOR=gnu`), but release binaries use `windows-amd64-msvc`.
 
 ### Two CPU backends on x86_64
 
@@ -47,15 +47,15 @@ AVX2 is compiled into every ggml CPU kernel, so one build cannot serve a CPU wit
 
 1. Update the tag in `libs/ggml-version`
 2. Run `chore fetch-headers` and commit the updated headers
-3. Set `libs/revision` to 1, commit, then trigger the `Build GGML libs` workflow (or run `chore upload-libs` locally). The same applies to any change under `libs/`, with the revision bumped instead: the bundle for the new tag must exist before a sona release can fetch it
+3. Set `libs/revision` to 1, commit, then trigger the `Build Server Libs` workflow (or run `chore upload-libs` locally). The same applies to any change under `libs/`, with the revision bumped instead: the bundle for the new tag must exist before a sona release can fetch it
 
 ## Packaging a release archive
 
-`chore package-release <binary> <darwin|windows> <amd64|arm64> <out.tar.gz|out.zip>` bundles a built `sona` binary with ffmpeg the way the release workflow does.
+`chore package-release <binary> <darwin|windows> <amd64|arm64> <out.tar.gz|out.zip>` bundles a built `vibe-server` binary with ffmpeg the way the release workflow does.
 
 ## Releasing binaries
 
-`Release vibe-server` workflow builds and uploads Rust `sona` binaries for:
+`Release vibe-server` workflow builds and uploads Rust `vibe-server` binaries for:
 - Linux: `amd64`, `arm64`
 - macOS: Apple Silicon and Intel
 - Windows: `amd64`
@@ -63,7 +63,7 @@ AVX2 is compiled into every ggml CPU kernel, so one build cannot serve a CPU wit
 It also injects the CLI version at build time via environment variables:
 
 ```bash
-SONA_VERSION=<tag> SONA_COMMIT=<sha> cargo build -p vibe-server --release
+VIBE_SERVER_VERSION=<tag> VIBE_SERVER_COMMIT=<sha> cargo build -p vibe-server --release
 ```
 
 You can run releases in two ways:

--- a/server/libs/libs.chore
+++ b/server/libs/libs.chore
@@ -5,7 +5,7 @@
 # A bundle is published under libraries-ggml-<version>-r<revision>. The revision is
 # libs/revision, bumped by hand in the same commit as any change under libs/ (the
 # ggml tag, the patches, this recipe) and reset to 1 when the ggml tag moves, so a
-# changed bundle never replaces the one an older sona tag still links against.
+# changed bundle never replaces the one an older server tag still links against.
 # The git tree hash of libs/ is recorded in the release notes and checked by
 # upload-libs: a release that already exists for another tree means the bump was
 # forgotten. Uncommitted edits are not in the hash, so upload-libs refuses them.
@@ -24,12 +24,12 @@ task libs-tag {
 	echo "libraries-ggml-$version-r$revision"
 }
 
-# Print the Windows import library flavor: SONA_WINDOWS_LIB_FLAVOR, or the host toolchain's.
+# Print the Windows import library flavor: VIBE_SERVER_WINDOWS_LIB_FLAVOR, or the host toolchain's.
 task lib-flavor {
 	flavor=$ENV
-	if $OS == windows && env SONA_WINDOWS_LIB_FLAVOR {
-		flavor=$(env SONA_WINDOWS_LIB_FLAVOR)
-		if $flavor != gnu && $flavor != msvc { fail "unsupported SONA_WINDOWS_LIB_FLAVOR: $flavor" }
+	if $OS == windows && env VIBE_SERVER_WINDOWS_LIB_FLAVOR {
+		flavor=$(env VIBE_SERVER_WINDOWS_LIB_FLAVOR)
+		if $flavor != gnu && $flavor != msvc { fail "unsupported VIBE_SERVER_WINDOWS_LIB_FLAVOR: $flavor" }
 	}
 	echo "$flavor"
 }
@@ -111,7 +111,7 @@ task build-libs {
 
 	# AVX2 is compiled into every CPU kernel, so one build cannot also serve a CPU
 	# without it. Build the CPU backend a second time at the AVX baseline (2011+);
-	# stage-cpu-variant suffixes each build's symbols and sona picks one at startup.
+	# stage-cpu-variant suffixes each build's symbols and vibe-server picks one at startup.
 	build_x64=$ROOT/ggml-build-x64
 	if $ARCH == x86_64 {
 		remove $build_x64


### PR DESCRIPTION
- NSIS upgrade hook stops `vibe-server.exe`, and still `sona.exe` for installs that predate the rename
- Environment: server reads `VIBE_SERVER_FFMPEG_PATH`, `VIBE_SERVER_UNLOAD_TIMEOUT`, `VIBE_SERVER_VERSION`, `VIBE_SERVER_COMMIT`; the app sets the first two; `server-libs` takes `VIBE_SERVER_WINDOWS_LIB_FLAVOR`. No fallback to the old names, so `.server-version` must move to a server built from this tree before the next app release (server-v0.6.6 next)
- Everything inside `server/` that said Sona (Cargo descriptions, comments, the OpenAPI tag, the skill template, ignore rules, docs) says vibe-server
- Signing script pattern, entitlements comments, and the analytics skill references updated
- Kept: `sona_spawn_failed` as the analytics event string, and the historical text inside `libs/patches/0001`

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna