### PR TITLE
Point the test workflow, docs, and handoff at server/fixtures

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: samples
+          sparse-checkout: server/fixtures
 
       - name: Setup MSYS2 wget (Windows)
         if: runner.os == 'Windows'
@@ -65,14 +65,14 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           tar xzf ${{ matrix.pattern }}
-          ./vibe.app/Contents/MacOS/vibe transcribe ggml-tiny.bin samples/short.mp4
+          ./vibe.app/Contents/MacOS/vibe transcribe ggml-tiny.bin server/fixtures/short.mp4
 
       - name: Install and test (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb ./${{ matrix.pattern }}
-          xvfb-run -a vibe transcribe ggml-tiny.bin samples/short.mp4
+          xvfb-run -a vibe transcribe ggml-tiny.bin server/fixtures/short.mp4
 
       - name: Install and test (Windows)
         if: runner.os == 'Windows'
@@ -80,4 +80,4 @@ jobs:
         run: |
           $installer = (Get-Item vibe_*_x64-setup.exe).FullName
           Start-Process -FilePath $installer -ArgumentList "/S" -Wait
-          & "$env:LOCALAPPDATA\vibe\vibe.exe" transcribe ggml-tiny.bin samples\short.mp4
+          & "$env:LOCALAPPDATA\vibe\vibe.exe" transcribe ggml-tiny.bin server\fixtures\short.mp4

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -2,7 +2,7 @@
 
 Try the following, the more you try the better the chance we'll find the cause :)
 
-1. Is the audio file valid? try with different one, eg. download [vibe/samples/single.wav](https://github.com/thewh1teagle/vibe/raw/main/samples/single.wav)
+1. Is the audio file valid? try with different one, eg. download [server/fixtures/single.wav](https://github.com/thewh1teagle/vibe/raw/main/server/fixtures/single.wav)
 2. Do you have errors? report it with the 'report button'
 3. Do you experience crash without errors? try to run from the terminal with logs enabled:
 4. Do you use other model than the default one? Please use the default one that comes with Vibe when checking.
@@ -44,7 +44,7 @@ Does it happens with original Whisper?
 
 1. Download one of the `zip` files from [releases/tag/v1.6.0](https://github.com/ggerganov/whisper.cpp/releases/tag/v1.6.0) (Scroll down and choose `whisper-bin-x64.zip` in `Windows`
 2. Extract them and open the folder, then open explorer in that folder and hit `Ctrl` + `l` in `explorer, type `cmd` and enter
-3. Download [vibe/samples/single.wav](https://github.com/thewh1teagle/vibe/raw/main/samples/single.wav) and place it in the same folder (and check that the file is ok)
+3. Download [server/fixtures/single.wav](https://github.com/thewh1teagle/vibe/raw/main/server/fixtures/single.wav) and place it in the same folder (and check that the file is ok)
 4. Try to transcribe by execute
 
 ```console

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,6 +114,6 @@ Xvfb :1 -screen 0 1024x768x24 &
 export DISPLAY=1
 
 wget https://github.com/thewh1teagle/vibe/releases/download/v0.0.1/ggml-medium.bin
-wget https://github.com/thewh1teagle/vibe/raw/main/samples/single.wav
+wget https://github.com/thewh1teagle/vibe/raw/main/server/fixtures/single.wav
 vibe --model ggml-medium.bin --file single.wav
 ```

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -17,7 +17,7 @@ The desktop half lives in `desktop/src-tauri`.
 ```sh
 just phone         # build the wasm, then run the PWA on http://localhost:8088
 just phone-tunnel  # same, but over an HTTPS tunnel a real phone can load
-just phone-probe '<pairing-url>' samples/single.wav
+just phone-probe '<pairing-url>' server/fixtures/single.wav
 just phone-caps '<pairing-url>'
 ```
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -3,7 +3,6 @@
 .DS_Store
 libs/lib/
 models/
-samples/
 vibe-server
 !vibe-server/
 ggml-src/


### PR DESCRIPTION
#1513 moved the files but its reference updates did not land; this is that half: the app's test-release workflow (sparse checkout and paths), the docs' raw links, the handoff README, and the stale `samples/` ignore in `server/`.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna