### PR TITLE
Release notes on the website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,11 @@ jobs:
               if: runner.os == 'Linux'
               run: chore linux-deps
 
+            - name: Require release notes for this version
+              shell: bash
+              run: |
+                  version=$(python3 -c 'import json; print(json.load(open("desktop/src-tauri/tauri.conf.json"))["version"])')
+                  test -f "website/changelog/$version.md" || { echo "::error::website/changelog/$version.md is missing; write the release notes before releasing"; exit 1; }
             - name: Fetch the sidecars for ${{ matrix.target_triple }}
               run: chore setup ${{ matrix.target_triple }}
 
@@ -108,7 +113,7 @@ jobs:
               with:
                   tagName: v__VERSION__ # the action automatically replaces __VERSION__ with the app version.
                   releaseName: "v__VERSION__"
-                  releaseBody: "What's new? 🎉📣"
+                  releaseBody: "Release notes: https://thewh1teagle.github.io/vibe/changelog/__VERSION__\n\nSigned and notarized on macOS and Windows."
                   prerelease: true
                   args: ${{ matrix.args }} ${{ matrix.platform == 'windows-latest' && inputs.sign-windows && '--config src-tauri/tauri.windows.signing.conf.json' || '' }}
                   projectPath: "./desktop"

--- a/i18n/translations/en-US/website.json
+++ b/i18n/translations/en-US/website.json
@@ -67,5 +67,11 @@
 	"feature-privacy-title": "Ultimate privacy",
 	"feature-privacy-description": "Enjoy fully offline transcription, ensuring no data ever leaves your device.",
 	"feature-customize-title": "Total Freedom",
-	"feature-customize-description": "Customize models effortlessly in settings for a tailored experience."
+	"feature-customize-description": "Customize models effortlessly in settings for a tailored experience.",
+	"changelog": "Changelog",
+	"changelogNew": "New",
+	"changelogImproved": "Improved",
+	"changelogFixed": "Fixed",
+	"changelogAll": "All releases",
+	"changelogUnknownVersion": "There is no release {version}."
 }

--- a/website/changelog/0.0.2.md
+++ b/website/changelog/0.0.2.md
@@ -1,0 +1,19 @@
+---
+version: 0.0.2
+date: 2024-01-13
+title: "Optimize performance by `50%`using `OpenBLAS`"
+---
+
+## New
+
+- Add format options as `srt` `vtt` and `normal`
+- Common model path per `CLI` and `Desktop`
+
+## Improved
+
+- Optimize performance by `50%`using `OpenBLAS`
+- Improve design
+
+## Fixed
+
+- Fix multi language encoding

--- a/website/changelog/0.0.3.md
+++ b/website/changelog/0.0.3.md
@@ -1,0 +1,15 @@
+---
+version: 0.0.3
+date: 2024-01-15
+title: "Settings page"
+---
+
+## New
+
+- Settings page
+- Transcribe parametrs (prompt, temperature, etc...)
+- Option to select / download another models
+
+## Fixed
+
+- Better bug reporting

--- a/website/changelog/0.0.4.md
+++ b/website/changelog/0.0.4.md
@@ -1,0 +1,17 @@
+---
+version: 0.0.4
+date: 2024-01-18
+title: "Fix"
+---
+
+## New
+
+- Add option to reset app
+- Add `MacOS` support
+- Optimize `GPU` using `CoreML`
+
+## Fixed
+
+- Fix: remove model hash verify
+- Add modal if error happens
+- Improve error reporting to include log

--- a/website/changelog/0.0.5.md
+++ b/website/changelog/0.0.5.md
@@ -1,0 +1,10 @@
+---
+version: 0.0.5
+date: 2024-02-04
+title: "Auto updater"
+---
+
+## New
+
+- Auto updater
+- Allow export in multiple formats

--- a/website/changelog/0.0.6.md
+++ b/website/changelog/0.0.6.md
@@ -1,0 +1,14 @@
+---
+version: 0.0.6
+date: 2024-02-05
+title: "Windows shadows"
+---
+
+## New
+
+- Windows shadows
+- Center window on open
+
+## Fixed
+
+- Fix export as txt extension

--- a/website/changelog/0.0.8.md
+++ b/website/changelog/0.0.8.md
@@ -1,0 +1,13 @@
+---
+version: 0.0.8
+date: 2024-04-09
+title: "Add Portuguese language, thanks to [josemoura212](https://github.com/josemoura212)! 🙏"
+---
+
+## New
+
+- Add Portuguese language, thanks to [josemoura212](https://github.com/josemoura212)! 🙏
+
+## Fixed
+
+- Fix invalid segment error due to invalid utf-8 characters returned from whisper by adding a [patch](https://github.com/thewh1teagle/whisper-rs/commits/feat/get-segment-text-lossy/) to whisper-rs

--- a/website/changelog/0.0.9.md
+++ b/website/changelog/0.0.9.md
@@ -1,0 +1,12 @@
+---
+version: 0.0.9
+date: 2024-04-14
+title: "Realtime preview of transcription"
+---
+
+## New
+
+- Realtime preview of transcription
+- Option to abort transcription in progress
+- Show percentage while transcribing
+- Show progress when updating

--- a/website/changelog/1.0.0.md
+++ b/website/changelog/1.0.0.md
@@ -1,0 +1,17 @@
+---
+version: 1.0.0
+date: 2024-04-16
+title: "GPU optimization for Windows with OpenCL"
+---
+
+## New
+
+- Commit hash in system info collection
+
+## Improved
+
+- GPU optimization for Windows with OpenCL! (x1.5 faster)
+
+## Fixed
+
+- Fix translation in Hebrew for cancel transcript

--- a/website/changelog/1.0.1.md
+++ b/website/changelog/1.0.1.md
@@ -1,0 +1,9 @@
+---
+version: 1.0.1
+date: 2024-04-22
+title: "Fix on windows failed to load model if Username contains Hebrew characters"
+---
+
+## Fixed
+
+- Fix on windows failed to load model if Username contains Hebrew characters

--- a/website/changelog/1.0.2.md
+++ b/website/changelog/1.0.2.md
@@ -1,0 +1,9 @@
+---
+version: 1.0.2
+date: 2024-04-27
+title: "Wider UI"
+---
+
+## New
+
+- Wider UI

--- a/website/changelog/1.0.3.md
+++ b/website/changelog/1.0.3.md
@@ -1,0 +1,16 @@
+---
+version: 1.0.3
+date: 2024-04-30
+title: "Fixed model customize #54"
+---
+
+## New
+
+- Allow open settings by click #53
+- Add option to select whether to play sound / focus window when transcription complete
+- Use [custom eyre](https://github.com/thewh1teagle/eyre/tree/feat/report-serialize-backtrace) with serialize backtrace
+- Window maximized on first open
+
+## Fixed
+
+- Fixed model customize #54

--- a/website/changelog/1.0.4.md
+++ b/website/changelog/1.0.4.md
@@ -1,0 +1,10 @@
+---
+version: 1.0.4
+date: 2024-05-03
+title: "Smooth window creation"
+---
+
+## New
+
+- Smooth window creation
+- Add min window width and height

--- a/website/changelog/1.0.5.md
+++ b/website/changelog/1.0.5.md
@@ -1,0 +1,29 @@
+---
+version: 1.0.5
+date: 2024-05-15
+title: "Add option to drop files to window"
+---
+
+## New
+
+- Add option to drop files to window
+- Add option to open file by right click -> `Open with`
+- file drop animation
+- Support more audio formats such as `opus` (Thanks for @renatoianhez for the suggestion)
+- Add option to open app config dir for getting logs
+- Add params info on hover in advanced options (Thanks for @NHLOCAL)
+- Add Swedish language, (Thanks for @2bbe)
+- Option to cancel model download
+
+## Improved
+
+- Improve ux by replacing onClick with onMouseDown
+- Improve default window size
+- Improve settings window design
+- Update to latest tauri core / plugins
+- Improve offline installation
+
+## Fixed
+
+- Add crash log to panic hook
+- Fix taskbar progress animation

--- a/website/changelog/1.0.6.md
+++ b/website/changelog/1.0.6.md
@@ -1,0 +1,21 @@
+---
+version: 1.0.6
+date: 2024-05-19
+title: "Add `Chinese` language"
+---
+
+## New
+
+- Add `Chinese` language (Thanks for @Ifan24)
+- Add batch transcribe (Thanks for @renatoianhez)
+- Add native translation to languages selector
+
+## Improved
+
+- Improve language input `UI` by using option groups
+- Improve audio player
+
+## Fixed
+
+- Add error boundary in case of fatal render error
+- Fix `Windows` file path open crash

--- a/website/changelog/1.0.7.md
+++ b/website/changelog/1.0.7.md
@@ -1,0 +1,19 @@
+---
+version: 1.0.7
+date: 2024-05-20
+title: "Fix not a number JS error in realtime preview"
+---
+
+## New
+
+- Imrpve design by making filename in the audioplayer as link when hovering
+- Show logs in `Windows` by execute the following in `cmd.exe`:
+- add logs to check if cpu supports `f16c` instruction
+- use crate `showfile` to open files as selected state in file manager
+- Add `Nvidia` binary (transcribe 1 hour in less than 5 minuets)
+
+## Fixed
+
+- Fix not a number JS error in realtime preview (Thanks for @Ifan24 for reporting)
+- Fix when opening settings, keep default transcribe langauge instead of changing it
+- Add non `avx` binary in case of old CPU crash

--- a/website/changelog/1.0.8.md
+++ b/website/changelog/1.0.8.md
@@ -1,0 +1,19 @@
+---
+version: 1.0.8
+date: 2024-05-25
+title: "New formats"
+---
+
+## New
+
+- New formats: html, pdf
+- Show toast message after save file
+- Option to Print pdf
+- Add discord button in settings
+- Option to translate into English (advanced options) | Thanks for `hbacelar` for the suggestion!
+- Optimize windows with openblas
+- More tooltips
+
+## Fixed
+
+- Fix extra line in srt

--- a/website/changelog/1.0.9.md
+++ b/website/changelog/1.0.9.md
@@ -1,0 +1,20 @@
+---
+version: 1.0.9
+date: 2024-05-26
+title: "New formats"
+---
+
+## New
+
+- New formats: `JSON`
+- Remove focus color from print button
+
+## Improved
+
+- Better toast message on saving files
+
+## Fixed
+
+- Fix saving path
+- Fix translation in tooltips
+- Fix timestamps for `PDF` / `SRT`

--- a/website/changelog/2.0.0.md
+++ b/website/changelog/2.0.0.md
@@ -1,0 +1,19 @@
+---
+version: 2.0.0
+date: 2024-05-29
+title: "If `CPU` is unsupported"
+---
+
+## New
+
+- Add `Nvidia` to releases
+- Add release for older CPUs
+
+## Improved
+
+- Enable `metal` framework on `macOS` for `GPU` and improve speed by `~40%`
+- Update to `whisper.cpp` version `1.6.2`
+
+## Fixed
+
+- if `CPU` is unsupported - Show error message and open `URL` for fix on `Windows`

--- a/website/changelog/2.0.1.md
+++ b/website/changelog/2.0.1.md
@@ -1,0 +1,12 @@
+---
+version: 2.0.1
+date: 2024-06-03
+title: "Add French translation"
+---
+
+## New
+
+- 🇫🇷 Add French translation (Thanks for @oleole39!)
+- 🇨🇳 Add more Chinese translation (Thanks for @Ifan24!)
+- 🖥️ Add `cli` support. use Vibe from console directly!
+- ✨ Add Nvidia v11 and v12 (Cuda versions)

--- a/website/changelog/2.0.2.md
+++ b/website/changelog/2.0.2.md
@@ -1,0 +1,18 @@
+---
+version: 2.0.2
+date: 2024-06-07
+title: "Add option to record from speakers / microphone"
+---
+
+## New
+
+- 🎤 Add option to record from speakers / microphone! (macOS support included)
+- 📦 Add rpm installer
+
+## Improved
+
+- 🇫🇷 Improve French translation (Thanks for @oleole39!)
+
+## Fixed
+
+- 🛠️ Fix audio file encoding issues

--- a/website/changelog/2.0.3.md
+++ b/website/changelog/2.0.3.md
@@ -1,0 +1,15 @@
+---
+version: 2.0.3
+date: 2024-06-10
+title: "Add support for m4a"
+---
+
+## New
+
+- 🎧 Add support for m4a (Thanks for @yairl for reporting!)
+- 💻 Add nvidia, opencl, and rpm support for Linux (Thanks for @thegrasshopper104 for the suggestion!)
+- 🔗 Add option to paste model link and download directly in vibe
+
+## Fixed
+
+- 🎨 Fix tabs UI contrast (Thanks for @oleole39 for suggestion!)

--- a/website/changelog/2.0.4.md
+++ b/website/changelog/2.0.4.md
@@ -1,0 +1,15 @@
+---
+version: 2.0.4
+date: 2024-06-19
+title: "Catch whisper.cpp panics instead of crashing"
+---
+
+## New
+
+- 🛠️ Catch whisper.cpp panics instead of crashing
+- 🎨 Pretty app version in settings at bottom with nvidia / older cpu labels (Thanks for @josemoura212 for suggestion!)
+- 🔗 Add deep links. you can add `vibe://download?url=<any model url>` link to your website for let vibe users download modesl!
+
+## Fixed
+
+- 🛠 Fix batch export as json (Thanks for @DArlund for reporting!)

--- a/website/changelog/2.0.5.md
+++ b/website/changelog/2.0.5.md
@@ -1,0 +1,15 @@
+---
+version: 2.0.5
+date: 2024-06-23
+title: "Speed up by caching model context instead of reload it everytime"
+---
+
+## Improved
+
+- 🖌️ Speed up by caching model context instead of reload it everytime (Thanks for @Y-PLONI for suggest it!)
+- 🇵🇹 Improve Portuguese translations (Thanks for @josemoura212)
+- 🇵🇱 Add Polish translations (Thanks for @GitesHubisz)
+
+## Fixed
+
+- 🚧 Fix typo in `Install.md` (Thanks for @eltociear)

--- a/website/changelog/2.0.6.md
+++ b/website/changelog/2.0.6.md
@@ -1,0 +1,19 @@
+---
+version: 2.0.6
+date: 2024-06-27
+title: "Fix linux i18n"
+---
+
+## New
+
+- ⏱️ Add option to transcribe word timestamps
+- 🍏 Add macOS dmg installation background
+- 🔠 Max letters per sentence! (Thanks for @sdimantsd)
+
+## Improved
+
+- 💻 Set GPU preference to high performance on Windows by default
+
+## Fixed
+
+- 🌍 Fix linux i18n (Thanks for @oleole39)

--- a/website/changelog/2.1.0.md
+++ b/website/changelog/2.1.0.md
@@ -1,0 +1,20 @@
+---
+version: 2.1.0
+date: 2024-07-11
+title: "Improved internationalization support with custom locale detection"
+---
+
+## New
+
+- ⏱️ Added option to transcribe word timestamps
+- 🍏 Enhanced macOS DMG installation background
+- 🌐 Enhanced text manipulation with 'replaceAll' feature
+- 📦 Added Windows portable support
+- 📚 Added Swagger documentation for server APIs
+
+## Improved
+
+- 🌍 Improved internationalization support with custom locale detection
+- 💻 Set GPU preference to high performance on Windows by default
+- 🎮 Choose GPU device for improved performance (Thanks @israelxss!)
+- 🇵🇱 Improve Polish translations (Thanks for @GitesHubisz)

--- a/website/changelog/2.2.0.md
+++ b/website/changelog/2.2.0.md
@@ -1,0 +1,21 @@
+---
+version: 2.2.0
+date: 2024-08-01
+title: "Added support for Hindi"
+---
+
+## New
+
+- 🌐 Added support for Hindi (Thanks @lovishchhabra)
+- 💅 Refined overall UI design for a more polished look
+- 🛠️ Removed Windows 7 support to focus on more recent versions
+
+## Improved
+
+- ⚡ Enabled back OpenCL for Windows, improving performance on compatible hardware
+- 🎛️ Enhanced GPU device information and set GPU preference in settings for better control
+- 📜 Improved main navigation UI for a smoother user experience
+
+## Fixed
+
+- ⏰ Fixed incorrect timestamps by using custom whisper.cpp

--- a/website/changelog/2.4.0.md
+++ b/website/changelog/2.4.0.md
@@ -1,0 +1,14 @@
+---
+version: 2.4.0
+date: 2024-08-08
+title: "Fix language detection and preference on launch"
+---
+
+## New
+
+- 🗣️ Added speaker recognition (diarization)
+
+## Fixed
+
+- 🔧 Fix language detection and preference on launch
+- 🔧 Fix microphone recording on macOS

--- a/website/changelog/2.5.0.md
+++ b/website/changelog/2.5.0.md
@@ -1,0 +1,9 @@
+---
+version: 2.5.0
+date: 2024-08-23
+title: "Vulkan support for AMD, NVIDIA, and Intel GPUs—no need for CUDA, with faster computing"
+---
+
+## Improved
+
+- 🚀 Vulkan support for AMD, NVIDIA, and Intel GPUs—no need for CUDA, with faster computing

--- a/website/changelog/2.5.1.md
+++ b/website/changelog/2.5.1.md
@@ -1,0 +1,24 @@
+---
+version: 2.5.1
+date: 2024-08-29
+title: "Improved recording filenames for better organization"
+---
+
+## New
+
+- 📜 Default to storing documentation files in the `docs` folder
+- 🌐 Added support for special languages in speical models by model filename pattern
+- 🚀 Added Vulkan SDK support for older CPUs
+
+## Improved
+
+- 🎤 Improved recording filenames for better organization
+- 🔄 Normalize audio before transcription for improved accuracy
+- 🛠️ Enhanced logging for better debugging and issue tracking
+
+## Fixed
+
+- 🔧 Updated Tauri and fixed various package issues
+- 🔧 Fix(windows): show whisper.cpp errors in Windows correctly by redirecting stdout/stderr/ experimental
+- 🔧 Fix(windows): embed vulkan runtime DLLs
+- 🔧 Fix(linux): add vulkan runtime deb packages

--- a/website/changelog/2.5.2.md
+++ b/website/changelog/2.5.2.md
@@ -1,0 +1,9 @@
+---
+version: 2.5.2
+date: 2024-09-09
+title: "Fetch models directly from GitHub, with no more dependence on other cloud services"
+---
+
+## New
+
+- 🚀 Fetch models directly from GitHub, with no more dependence on other cloud services

--- a/website/changelog/2.5.3.md
+++ b/website/changelog/2.5.3.md
@@ -1,0 +1,13 @@
+---
+version: 2.5.3
+date: 2024-09-21
+title: "Updated Italian translations thanks @rsaleri"
+---
+
+## New
+
+- 🖥️ Include Vulkan runtime and VC++ Redistributable installer on Windows
+
+## Improved
+
+- 🇮🇹 Updated Italian translations thanks @rsaleri

--- a/website/changelog/2.5.4.md
+++ b/website/changelog/2.5.4.md
@@ -1,0 +1,9 @@
+---
+version: 2.5.4
+date: 2024-09-23
+title: "Check that Vulkan init works or provide instructions to download older vibe version"
+---
+
+## New
+
+- 🛠️ Check that Vulkan init works or provide instructions to download older vibe version

--- a/website/changelog/2.5.5.md
+++ b/website/changelog/2.5.5.md
@@ -1,0 +1,13 @@
+---
+version: 2.5.5
+date: 2024-09-28
+title: "Add option to download audio from popular websites"
+---
+
+## New
+
+- 🎶 Add option to download audio from popular websites
+
+## Fixed
+
+- 🛠️ Fix issue with diarization; ensure word timestamps are disabled if diarization is enabled

--- a/website/changelog/2.5.6.md
+++ b/website/changelog/2.5.6.md
@@ -1,0 +1,15 @@
+---
+version: 2.5.6
+date: 2024-10-03
+title: "Upgraded to Tauri v2 for improved performance and stability"
+---
+
+## New
+
+- 🎨 Enhanced tooltip design for a more user-friendly experience
+
+## Improved
+
+- ⬆️ Upgraded to Tauri v2 for improved performance and stability
+- 🌑 Improved contrast in dark mode for better readability
+- 🔄 Word timestamps are now automatically disabled during speaker recognition

--- a/website/changelog/2.6.0.md
+++ b/website/changelog/2.6.0.md
@@ -1,0 +1,9 @@
+---
+version: 2.6.0
+date: 2024-10-03
+title: "Summarize with Claude API for a more efficient and intuitive experience"
+---
+
+## New
+
+- 🤖 Summarize with Claude API for a more efficient and intuitive experience!

--- a/website/changelog/2.6.1.md
+++ b/website/changelog/2.6.1.md
@@ -1,0 +1,9 @@
+---
+version: 2.6.1
+date: 2024-10-05
+title: "Update whisper.cpp"
+---
+
+## Fixed
+
+- Update whisper.cpp. should fix some issues with Vulkan

--- a/website/changelog/2.6.2.md
+++ b/website/changelog/2.6.2.md
@@ -1,0 +1,9 @@
+---
+version: 2.6.2
+date: 2024-10-06
+title: "Update whisper.cpp and potentially fix vulkan errors"
+---
+
+## Fixed
+
+- Update whisper.cpp and potentially fix vulkan errors

--- a/website/changelog/2.6.3.md
+++ b/website/changelog/2.6.3.md
@@ -1,0 +1,15 @@
+---
+version: 2.6.3
+date: 2024-10-12
+title: "Various miscellaneous improvements for enhanced performance"
+---
+
+## Improved
+
+- 🔧 Various miscellaneous improvements for enhanced performance.
+
+## Fixed
+
+- 🐞 Bug report updated for better issue tracking.
+- 🛠️ Fix [#333](https://github.com/thewh1teagle/vibe/issues/333).
+- 🛠️ Fix [#331](https://github.com/thewh1teagle/vibe/issues/331) by applying default to release profile.

--- a/website/changelog/2.6.5.md
+++ b/website/changelog/2.6.5.md
@@ -1,0 +1,21 @@
+---
+version: 2.6.5
+date: 2024-11-11
+title: "Ollama support for seamless integration"
+---
+
+## New
+
+- 🤖 Ollama support for seamless integration!
+- 📄 Added support for exporting transcriptions in DOCX format.
+- 🎬 Start transcription automatically right after video download.
+
+## Improved
+
+- 📊 Improved logging from whisper.cpp with Vulkan.
+- 🔄 Updated whisper.cpp for enhanced performance.
+- 🚀 Updated Tauri for the latest improvements.
+
+## Fixed
+
+- 🛠️ Fixed crash issue when Documents folder is not found.

--- a/website/changelog/2.6.6.md
+++ b/website/changelog/2.6.6.md
@@ -1,0 +1,26 @@
+---
+version: 2.6.6
+date: 2024-11-11
+title: "Softer success sound for a smoother experience"
+---
+
+## New
+
+- 📄 Default format set to PDF for transcripts
+- 🎤 Support for multiple formats in batch transcription
+- 🧠 Added a button to check if LLM is working correctly
+- 🛠️ Enhanced speaker segment merging for more accurate transcription
+- 📝 Added labels to issue report for easier tracking
+- 📝 Add transcript summary tabs for easier navigation
+- 🌐 Added Spanish (Mexico) translation @EduardoZepeda
+
+## Improved
+
+- 🔊 Softer success sound for a smoother experience
+- 🌍 Improved internationalization (i18n) support
+- 🔏 (Self) Code signing on Windows for improved security
+- ✨ UI improvements: success toast, transcribe after recording, and better wording enhancements
+
+## Fixed
+
+- 🔧 Fixed Ollama 403 error and improved localhost port handling

--- a/website/changelog/2.6.7.md
+++ b/website/changelog/2.6.7.md
@@ -1,0 +1,18 @@
+---
+version: 2.6.7
+date: 2024-11-14
+title: "Save batch summary to `.summary.txt` file"
+---
+
+## New
+
+- 📝 Save batch summary to `.summary.txt` file
+- ✅ Added confirmation prompt before exiting the app
+- 🎬 New FFmpeg options: cached normalization and custom FFmpeg commands for advanced users
+- 🗑️ Automatically clean up old files on startup (keeps files for one day)
+- 📝 Enable logs by default to file for easier troubleshooting
+
+## Improved
+
+- 📑 Add transcript summary tabs for better organization
+- 🔄 Improved destination path handling to count from 1 (for better consistency)

--- a/website/changelog/2.6.8.md
+++ b/website/changelog/2.6.8.md
@@ -1,0 +1,9 @@
+---
+version: 2.6.8
+date: 2024-12-02
+title: "Hot fix crash issue on Windows 11 introduced in 2.6.7"
+---
+
+## Fixed
+
+- Hot fix crash issue on Windows 11 introduced in 2.6.7

--- a/website/changelog/2.6.9.md
+++ b/website/changelog/2.6.9.md
@@ -1,0 +1,17 @@
+---
+version: 2.6.9
+date: 2024-12-04
+title: "Collect logs in error report"
+---
+
+## New
+
+- Add presets for subtitles generation / restore defaults
+
+## Improved
+
+- Improve UI overflow in main window by params
+
+## Fixed
+
+- Collect logs in error report

--- a/website/changelog/3.0.0.md
+++ b/website/changelog/3.0.0.md
@@ -1,0 +1,19 @@
+---
+version: 3.0.0
+date: 2024-12-04
+title: "Improved privacy policy design and user experience"
+---
+
+## New
+
+- 🌐 Added a link to the Vibe website for privacy policy access
+- 📝 Added installation notes and documentation to help users get started easily
+
+## Improved
+
+- 🍏 Improved privacy policy design and user experience
+- 💻 Enhanced Linux installation options for a smoother setup
+
+## Fixed
+
+- 🌍 Fixed footer and landing page design improvements

--- a/website/changelog/3.0.1.md
+++ b/website/changelog/3.0.1.md
@@ -1,0 +1,26 @@
+---
+version: 3.0.1
+date: 2025-01-14
+title: "Clean updater files #410"
+---
+
+## New
+
+- Clean updater files #410
+- Remove file associations #478
+- Keep system awake while transcribe/record #337
+- More logging in setup
+- Add Vietnamese language
+- pdf dark mode #455
+- docs: Add clarity about coreml file usage by @andrewginns in https://github.com/thewh1teagle/vibe/pull/442
+- Feat/linux installer by @thewh1teagle in https://github.com/thewh1teagle/vibe/pull/448
+- feat: sign tauri plugins by @thewh1teagle in https://github.com/thewh1teagle/vibe/pull/450
+- Add Norwegian Language by @MechanikGamer in https://github.com/thewh1teagle/vibe/pull/459
+- @andrewginns made their first contribution in https://github.com/thewh1teagle/vibe/pull/442
+- @xinbenlv made their first contribution in https://github.com/thewh1teagle/vibe/pull/460
+- @MechanikGamer made their first contribution in https://github.com/thewh1teagle/vibe/pull/459
+
+## Fixed
+
+- Fix pdf export colors #455
+- Add zh-HK and fix zh-CN in static locales by @xinbenlv in https://github.com/thewh1teagle/vibe/pull/460

--- a/website/changelog/3.0.10.md
+++ b/website/changelog/3.0.10.md
@@ -1,0 +1,15 @@
+---
+version: 3.0.10
+date: 2026-02-10
+title: "Add optional GPU device selection"
+---
+
+## New
+
+- 🎮 Add optional GPU device selection
+- 🌐 Bypass system proxy for localhost connections
+
+## Fixed
+
+- ⏱️ Fix segment timestamps scaling in JSON/CSV
+- 🔧 Fix RTL layout issues

--- a/website/changelog/3.0.11.md
+++ b/website/changelog/3.0.11.md
@@ -1,0 +1,19 @@
+---
+version: 3.0.11
+date: 2026-02-11
+title: "Real-time audio visualizer while recording – see live feedback as you speak"
+---
+
+## New
+
+- 🎙️ Real-time audio visualizer while recording – see live feedback as you speak (#950)
+- 🔁 Re-summarize option – quickly regenerate summaries with one click
+
+## Improved
+
+- 🪟 Improved dictation dialog – more stable global shortcut handling
+
+## Fixed
+
+- 💖 Fixed Ko-fi dialog not closing properly
+- 🐧 Small Linux UI fixes

--- a/website/changelog/3.0.12.md
+++ b/website/changelog/3.0.12.md
@@ -1,0 +1,20 @@
+---
+version: 3.0.12
+date: 2026-02-12
+title: "Disable transcribe button when no model is selected with helpful hint"
+---
+
+## New
+
+- 🛡️ Disable transcribe button when no model is selected with helpful hint
+- ⬇️ Download models link moved to top of settings for easier access
+
+## Improved
+
+- 📋 Sona now reports version and commit hash on startup
+
+## Fixed
+
+- 🔧 Fix model loading crash for users with non-ASCII usernames on Windows
+- 🖥️ Graceful fallback to CPU when Vulkan GPU drivers are missing
+- 🔍 Better error messages when sona crashes during model loading

--- a/website/changelog/3.0.13.md
+++ b/website/changelog/3.0.13.md
@@ -1,0 +1,21 @@
+---
+version: 3.0.13
+date: 2026-02-14
+title: "Polished macOS installer design"
+---
+
+## New
+
+- ✨ Polished macOS installer design
+
+## Improved
+
+- 🪟 Windows app is now code-signed for better security and fewer warnings
+- 🍎 macOS app is now code-signed for better security and fewer warnings
+- 🐧 Better Linux compatibility (updated Ubuntu builds for wider glibc support)
+- 🎧 Safer transcription flow now checks audio files before running
+- 📦 Dependency handling improved on Linux for smoother installs
+
+## Fixed
+
+- ▶️ Fixed YouTube downloads on ARM devices

--- a/website/changelog/3.0.14.md
+++ b/website/changelog/3.0.14.md
@@ -1,0 +1,15 @@
+---
+version: 3.0.14
+date: 2026-02-24
+title: "Improved Windows code signing reliability"
+---
+
+## New
+
+- 🔐 Safer and more reliable Windows signing flow using a remote YubiKey signing server
+- 🧹 Cleanup of unused macOS signing configuration
+
+## Improved
+
+- 🪟 Improved Windows code signing reliability (more robust and consistent signed builds)
+- 🛠️ Better Windows tooling setup and verification steps (helps avoid install and update issues)

--- a/website/changelog/3.0.15.md
+++ b/website/changelog/3.0.15.md
@@ -1,0 +1,21 @@
+---
+version: 3.0.15
+date: 2026-03-01
+title: "Configurable recording save path"
+---
+
+## New
+
+- 🎙️ Configurable recording save path. choose where your recordings are stored
+- 🖱️ Easier copy actions with a new copy button for commands
+
+## Improved
+
+- 🍎 Improved system audio recording on macOS for better reliability by @Ada-lave in https://github.com/thewh1teagle/vibe/pull/978
+- 🌐 New "Wall of Love" section with international support and better mobile layout
+- 🗣️ Recent languages are now remembered for faster language switching
+- ✨ Visual polish and smoother animations across the app
+
+## Fixed
+
+- 🧠 Better handling of edge cases like missing audio devices

--- a/website/changelog/3.0.16.md
+++ b/website/changelog/3.0.16.md
@@ -1,0 +1,14 @@
+---
+version: 3.0.16
+date: 2026-03-04
+title: "Fix macOS system audio recording"
+---
+
+## New
+
+- 🔧 Internal improvements and dependency updates
+
+## Fixed
+
+- 🍏 Fix macOS system audio recording
+- ⚠️ Improved structured error messages for clearer failures

--- a/website/changelog/3.0.17.md
+++ b/website/changelog/3.0.17.md
@@ -1,0 +1,9 @@
+---
+version: 3.0.17
+date: 2026-03-06
+title: "Stable Timestamps"
+---
+
+## New
+
+- ⏱️ Add **Stable Timestamps** mode for much more accurate subtitle timing in videos, tutorials, movies, and TV shows (can be enabled in More Options)

--- a/website/changelog/3.0.18.md
+++ b/website/changelog/3.0.18.md
@@ -1,0 +1,14 @@
+---
+version: 3.0.18
+date: 2026-03-07
+title: "Improve transcription failure messages to make issues easier to understand"
+---
+
+## Improved
+
+- 🛠️ Improve transcription failure messages to make issues easier to understand
+- ⚡ Update the transcription engine for better stability and compatibility
+
+## Fixed
+
+- 🔧 Fix build issues

--- a/website/changelog/3.0.19.md
+++ b/website/changelog/3.0.19.md
@@ -1,0 +1,19 @@
+---
+version: 3.0.19
+date: 2026-03-13
+title: "Remember selected audio device across sessions"
+---
+
+## New
+
+- 🔌 Properly stop background audio process when quitting the app
+- ⚙️ Various internal improvements and cleanup
+
+## Improved
+
+- 🎙️ Remember selected audio device across sessions
+- 🧠 Improved CPU compatibility check (clear message if AVX2 is not supported)
+
+## Fixed
+
+- 📂 Fix batch transcription when folders contain files without extensions

--- a/website/changelog/3.0.20.md
+++ b/website/changelog/3.0.20.md
@@ -1,0 +1,15 @@
+---
+version: 3.0.20
+date: 2026-07-04
+title: "Sona has been completely rewritten in Rust for improved performance and maintainability"
+---
+
+## New
+
+- 🎤 Built-in speaker diarization, no separate runner required
+- 📦 Simpler build and packaging process for contributors
+
+## Improved
+
+- 🦀 Sona has been completely rewritten in Rust for improved performance and maintainability
+- 🚀 Faster startup and a more streamlined architecture

--- a/website/changelog/3.0.21.md
+++ b/website/changelog/3.0.21.md
@@ -1,0 +1,20 @@
+---
+version: 3.0.21
+date: 2026-07-10
+title: "Redesigned the main window and rebuilt Settings with a cleaner sidebar layout"
+---
+
+## New
+
+- 🎙️ Added toggle mode for Global Dictation—press once to start and again to stop
+- ✨ Added an optional floating dictation indicator so recording status stays visible
+
+## Improved
+
+- 🎨 Redesigned the main window and rebuilt Settings with a cleaner sidebar layout
+- 🛠️ Improved hotkey transcription errors and saved recording filenames
+
+## Fixed
+
+- ⚡ Improved Sona startup, model loading, error reporting, and process reliability
+- 🪟 Fixed Windows console popups when detecting GPU devices

--- a/website/changelog/3.0.22.md
+++ b/website/changelog/3.0.22.md
@@ -1,0 +1,22 @@
+---
+version: 3.0.22
+date: 2026-07-12
+title: "Added Nemotron 3.5 and Parakeet TDT v3 model support, including streaming transcription for dictation"
+---
+
+## New
+
+- 🎙️ Added Nemotron 3.5 and Parakeet TDT v3 model support, including streaming transcription for dictation
+- 🌍 Migrated the desktop app and website to Paraglide i18n and added translation tests
+- 🔄 Stop Sona cleanly before installing app updates
+
+## Improved
+
+- ⚡ Updated Sona to improve transcription and clarified the available transcription options
+- ✨ Improved the model selection flow
+- 🎨 Improved the Wall of Love design
+- 🛠️ Improved website deployment and type-checking reliability
+
+## Fixed
+
+- 🪟 Made Windows code signing optional and fixed build configuration

--- a/website/changelog/3.0.23.md
+++ b/website/changelog/3.0.23.md
@@ -1,0 +1,20 @@
+---
+version: 3.0.23
+date: 2026-07-15
+title: "Fixed Vibe and Sona remaining open after exiting on Windows, which could keep GPU memory occupied and prevent relaunching"
+---
+
+## New
+
+- 🧠 Added an Advanced setting to automatically unload inactive transcription models and release RAM/VRAM; set it to 0 to keep models loaded
+- ⏱️ Protected active uploads, VAD, diarization, and long transcriptions from idle unloading—the timeout begins only after processing finishes
+- 🌍 Added translations for the model inactivity setting in every supported language
+
+## Improved
+
+- ⚡ Improved model reuse so Sona skips reloading an already loaded matching model
+- 🔄 Updated Sona to v0.3.5 with Windows parent-process monitoring and reliable child-process cleanup
+
+## Fixed
+
+- 🪟 Fixed Vibe and Sona remaining open after exiting on Windows, which could keep GPU memory occupied and prevent relaunching

--- a/website/changelog/3.0.5.md
+++ b/website/changelog/3.0.5.md
@@ -1,0 +1,21 @@
+---
+version: 3.0.5
+date: 2025-04-24
+title: "Add Russian language support for i18n configuration"
+---
+
+## New
+
+- 🌍 Add Russian language support for i18n configuration
+- 🚀 Enhance model download functionality and set Hebrew-AI model for Hebrew locale
+- 📁 Transcribe Folder recursively
+- @vladkor97 made their first contribution in https://github.com/thewh1teagle/vibe/pull/559
+- @CarlosReyesPena made their first contribution in https://github.com/thewh1teagle/vibe/pull/572
+- @jdsmith104 made their first contribution in https://github.com/thewh1teagle/vibe/pull/583
+- @fatslow made their first contribution in https://github.com/thewh1teagle/vibe/pull/606
+
+## Improved
+
+- 🏎️ Replace largest Ivrit model with faster Turbo model (almost as accurate as Large v2, better at subtitle segmentation)
+- 📝 Update model conversion instructions for improved setup and efficiency
+- 🧠 Smarter transcription! You can now control how the model chooses what to say (sampling strategy + beam size)

--- a/website/changelog/3.0.6.md
+++ b/website/changelog/3.0.6.md
@@ -1,0 +1,22 @@
+---
+version: 3.0.6
+date: 2026-02-07
+title: "Sona sidecar"
+---
+
+## New
+
+- 🔁 More reliable transcription with a local HTTP flow (OpenAI-compatible, streamed)
+- 📡 Live progress + segment updates while transcribing
+
+## Improved
+
+- 🚀 Major architecture upgrade: Vibe now uses a **Sona sidecar** instead of an in-app whisper process
+- 🧩 Improved command-line support (better CLI detection + ffmpeg handling)
+- ⚙️ You can now see the local API address in Settings
+
+## Fixed
+
+- 🧠 Better stability and isolation (fewer crashes, easier debugging)
+- 🛠️ More stable builds across platforms (Windows + Linux fixes)
+- 🕵️ Anonymous analytics + better error tracking (helps catch issues faster)

--- a/website/changelog/3.0.7.md
+++ b/website/changelog/3.0.7.md
@@ -1,0 +1,20 @@
+---
+version: 3.0.7
+date: 2026-02-08
+title: "Support for much larger audio files"
+---
+
+## New
+
+- 📁 Support for much larger audio files (up to 15GB, was 1GB)
+- 🔄 More reliable model loading with automatic retry on connection hiccups
+- 🔒 Option to disable anonymous analytics in Settings
+
+## Improved
+
+- 🐧 Better sona binary detection on Linux (Arch, CachyOS, AUR installs)
+
+## Fixed
+
+- 🛡️ Clear error message when no model is selected instead of cryptic crash
+- 🔍 Improved error diagnostics for faster issue resolution

--- a/website/changelog/3.0.8.md
+++ b/website/changelog/3.0.8.md
@@ -1,0 +1,16 @@
+---
+version: 3.0.8
+date: 2026-02-08
+title: "Speaker Diarization"
+---
+
+## New
+
+- 🗣️ Speaker Diarization
+- 🎙️ Global Dictation Hotkey
+- 🎬 More Format Support
+- 📚 Flexible Summarization
+
+## Improved
+
+- ⚙️ Sona Engine Upgrade

--- a/website/changelog/3.0.9.md
+++ b/website/changelog/3.0.9.md
@@ -1,0 +1,10 @@
+---
+version: 3.0.9
+date: 2026-02-09
+title: "Fix diarization (speaker recognition) failing on YouTube downloads and non-16kHz audio files"
+---
+
+## Fixed
+
+- 🔊 Fix diarization (speaker recognition) failing on YouTube downloads and non-16kHz audio files
+- 📤 Fix large file upload failing with "Invalid argument" error

--- a/website/changelog/3.1.0.md
+++ b/website/changelog/3.1.0.md
@@ -1,0 +1,30 @@
+---
+version: 3.1.0
+date: 2026-08-21
+title: "Redesigned the whole app around one drop-to-transcribe screen, with a recents sidebar you can resize and search"
+---
+
+## New
+
+- 🎨 Redesigned the whole app around one drop-to-transcribe screen, with a recents sidebar you can resize and search
+- ✍️ Rebuilt transcript editing: click anywhere on a line and the caret lands where you clicked, Enter/Tab/arrows move between lines, Escape reverts
+- 🎧 The line being spoken is lit as it plays, the view follows along, and a timestamp click plays from there
+- 👀 New view options for the transcript — text size, timestamps, speaker labels and text direction
+- 📂 One picker takes files and folders together on macOS, and folders keep working by drag and drop everywhere
+- ⌨️ The global dictation shortcut is set by pressing the keys, with ready-made combos for the ones macOS reserves
+- 🔔 Optional "keep running in the tray": closing the window leaves Vibe running for global dictation, off by default (thanks @eggie04)
+- ⚙️ Settings moved out of the browser store into an editable app_config.json — agents and people can read and change it, and Vibe picks up the edit immediately
+- 🔢 Every number field in settings became a stepper you can hold, type into or reset, with "Never" and "Auto" spelled out
+- 🌍 Added Czech (thanks @feretCZ), Bulgarian and German (thanks @nimdassdev); every one of the 22 languages is complete
+
+## Improved
+
+- 🤖 AI summaries now run from the main window: automatically after a transcription when enabled, or on demand from the transcript's AI menu, rendered as markdown and saved with the transcript
+- 🔁 Re-transcribe from the sidebar now asks for language, model and options first
+- 🆙 An update waiting is shown on the sidebar toggle instead of hiding in a menu
+
+## Fixed
+
+- 🔤 Fixed uppercase extensions being ignored, so a folder of .MP3 files is no longer empty (thanks @plmelancon)
+- 🐛 In-app bug reports now arrive titled with the actual error instead of "App reports bug"
+- ↔️ RTL fixes throughout: the sidebar stays on the window's left, the player timeline drags the right way, and shortcuts read left to right

--- a/website/changelog/3.1.1.md
+++ b/website/changelog/3.1.1.md
@@ -1,0 +1,15 @@
+---
+version: 3.1.1
+date: 2026-08-22
+title: "Record from your phone"
+---
+
+## New
+
+- 📱 Record from your phone: scan the QR code in `Settings → Phone` once, and your phone can send recordings to this computer — it transcribes them with the model you already have loaded and sends the text straight back
+- 🏠 The phone side is a web app you add to your home screen: nothing to install from an app store, no account, and it works on cellular as well as wifi
+- 🔒 Audio travels over an encrypted peer-to-peer connection built on [iroh](https://www.iroh.computer/) — phone browsers can't hole-punch, so it passes through a relay that only ever sees ciphertext, never your audio
+- 💾 Phone recordings are saved to `Documents/Vibe` and show up in Recents like any other transcript, and a recording waits safely on the phone until your computer is reachable again
+- 🌍 The phone's language picker comes from whichever model you have loaded, so it always offers exactly what your desktop can actually do
+- 🚀 New "Launch at startup" setting, off by default, sitting next to "Keep running in the tray" — together they keep the desktop reachable when you reach for your phone
+- 🌐 Every new screen is translated into all 22 languages

--- a/website/changelog/3.1.10.md
+++ b/website/changelog/3.1.10.md
@@ -1,0 +1,10 @@
+---
+version: 3.1.10
+date: 2026-09-04
+title: "Correct transcripts on AMD graphics with older drivers"
+---
+
+## Fixed
+
+- 🧩 **No Vulkan runtime, no problem** — a Windows PC without a Vulkan loader (no `vulkan-1.dll`, typical of machines with no GPU driver installed) could not start the transcription engine at all. The engine now opens the loader at runtime and simply runs on the CPU when there is none. Upstream: ggml-org/ggml#1614
+- 🎯 **Correct transcripts on AMD graphics with older drivers** — on some AMD GPUs running a 2020-era Windows driver (seen on a Ryzen laptop's Radeon iGPU), the GPU produced nonsense: a lone "!" or random characters, while the CPU was right. The driver leaves the GPU unclassified in the engine, and the attention kernel then asked for a subgroup width the hardware cannot run. Sona 0.6.5 only asks for it where the driver can grant it, and the GPU transcribes correctly again, several times faster than the CPU. Upstream fix proposed to ggml (ggml-org/ggml#1619)

--- a/website/changelog/3.1.2.md
+++ b/website/changelog/3.1.2.md
@@ -1,0 +1,26 @@
+---
+version: 3.1.2
+date: 2026-08-23
+title: "Your settings stick again"
+---
+
+## New
+
+- 🖥️ **A CPU without AVX2 is named** — instead of dying anonymously, Vibe says the processor is unsupported and why
+- 🎙️ **Recordings are 9 dB louder** — mixing in system audio was quietly halving the level, then halving it again. Every recording made with system audio selected was far quieter than it should have been
+- ⌨️ **Dictation defaults to a two-key shortcut** — Option+Space on macOS, Ctrl+Space elsewhere, instead of a three-key chord
+- 🤖 **Install the agent skill** — `Settings → API & Agents` writes it to Claude Code and Codex so it is available in every session, with the transcripts folder and the local API baked in
+- 🪟 **Windows: the VC++ runtime is version-checked** — the installer only asked whether *any* runtime was present, so machines with an old one were skipped and crashed later with no message
+
+## Improved
+
+- ⚙️ **Your settings stick again** — every setting reverted to its default on restart in 3.1.1. The file on disk was always correct; the app simply never read it back. If you gave up re-setting your preferences, they are safe now
+- 🧠 **Half the memory to load a model** — measured 294 MB → 216 MB on a small model, and roughly one model copy less on large ones. Machines that used to run out of memory mid-load have room now
+
+## Fixed
+
+- 🔍 **Failures say why** — a sidecar that dies now reports its exit code and signal instead of a bare "sona process died", and a crash mid-transcription reads as a crash rather than "error decoding response body". Whisper's own diagnostics reach the log again, after being silently discarded by a no-op callback
+- 📦 **Broken model downloads are caught** — files are verified before they are used, incomplete ones are detected on startup and offered a re-download, and an interrupted download can no longer masquerade as an installed model
+- 📱 **The phone pairing QR scans** — one wrong character in the QR generator misplaced the alignment patterns on any code past a certain size, and the pairing code was just past it. No scanner could read it
+- 🔗 **yt-dlp stops nagging** — the update prompt appeared on every launch and forgot "Later" each time. It is now a dismissible toast at most once a week, and it offers the update when a download actually fails, which is when it helps
+- 🌍 The product name and a mistranslated setting fixed across all 22 languages

--- a/website/changelog/3.1.5.md
+++ b/website/changelog/3.1.5.md
@@ -1,0 +1,25 @@
+---
+version: 3.1.5
+date: 2026-08-27
+title: "PDF export is a real PDF"
+---
+
+## New
+
+- 🎛️ **The export dialog remembers you** — format, content, theme and both switches persist instead of resetting each time you open it, and the whole panel was rebuilt around one consistent row: nine one-line formats, a light/dark choice for the file itself, and a one-off text direction override
+- 📝 **Word documents are set for paper** — a real font that covers Hebrew and Arabic, a proper type scale, speaker labels that stay with their line across a page break, and no dark page. Their timestamps read forwards again
+- 📜 **A long list of recordings scrolls smoothly** — the sidebar only renders the rows you can see, so hundreds of projects cost what ten used to
+- 🗑️ **Delete every project at once** — `Settings → Transcription`, under the projects folder
+- 🌍 Translations filled in across all 21 languages, including the transcription language lists in Turkish and Swedish, which were almost entirely English
+- 🖥️ **Transcribe on the CPU** — a new setting in `Settings → Models` for machines whose GPU driver crashes. The engine always supported it; nothing exposed it
+
+## Improved
+
+- 🤝 **Meetings are detected in about a second** — the detector waited out a five-second debounce on every change, so a call that had already started stayed invisible for most of a sentence. Quitting a call clears the prompt promptly now too, and the window and process scans it relies on got cheaper rather than more frequent
+- ⚡ **The transcription engine draws the same samples whisper.cpp does** — sona v0.6.1, which also settles the output: the same audio now transcribes identically twice, where before it drifted. Metal on macOS, Vulkan on Linux and Windows
+
+## Fixed
+
+- 📄 **PDF export is a real PDF** — it used to drive the system print dialog, which on macOS returned before the job spooled and handed the printer a blank page. Vibe now generates the file directly: selectable text, embedded fonts, page numbers, and pages that break on their own
+- ✡️ **Hebrew and Arabic exports read the right way round** — the previous PDF engine had no bidirectional text support at all: it resolved one direction per line and reversed every glyph in it, English words and numbers included, so a Hebrew transcript came out backwards. Every export is now checked against the Unicode algorithm before it ships
+- 🎥 **Google Meet detection asks for the permission it needs** — reading a browser's window title requires Screen Recording on macOS, and Vibe checked for it without ever asking. It now requests it once and links straight to the settings pane if you decline. Zoom and Teams never needed it

--- a/website/changelog/3.1.6.md
+++ b/website/changelog/3.1.6.md
@@ -1,0 +1,13 @@
+---
+version: 3.1.6
+date: 2026-08-28
+title: "Scroll back through a transcript while it is still being written"
+---
+
+## Improved
+
+- 📜 **Scroll back through a transcript while it is still being written** — following the live text used to be impossible to escape: scrolling up, or clicking a line to play it, snapped you straight back to the tail on the next segment. The hand-off to the reader keyed off a scroll event that was ignored for 700 ms after any scroll Vibe made itself, and every arriving segment refreshed that window, so during a real transcription it never closed. Following now ends on the gestures you actually make — wheel, trackpad, scrollbar, Page Up — and picks up again when you scroll back to the bottom
+
+## Fixed
+
+- 🎥 **Google Meet detection asks for the permission it needs** — listed in the 3.1.5 notes, but the change landed just after that tag; this is the first build that has it. Reading a browser's window title requires Screen Recording on macOS, and Vibe checked for it without ever asking. It now requests it once and links straight to the settings pane if you decline. Zoom and Teams never needed it

--- a/website/changelog/3.1.7.md
+++ b/website/changelog/3.1.7.md
@@ -1,0 +1,16 @@
+---
+version: 3.1.7
+date: 2026-09-04
+title: "Name your speakers"
+---
+
+## New
+
+- 🗣️ **Name your speakers** — click a "Speaker 1" label in a finished transcript and type a name. It replaces the label on every line of that speaker, on screen and in every export (text, Markdown, HTML, SRT, VTT, PDF, DOCX; JSON keeps the index and adds `speakerName`). Names are saved with the project, so they are there when you reopen it
+- 🎯 **Put a line on the right speaker** — the same popover moves one line to another speaker, or to a new one. A short line that diarization left with no speaker at all now shows a dashed placeholder so it can be given one. Sona 0.6.2 also attributes such lines to the nearest speaker turn within 1.5 seconds, so far fewer arrive unlabelled in the first place
+- 🔗 **Transcribe several links in one go** — paste a batch of links into the link box, or add them one by one with the plus button, and they queue up in a list under it. They download in turn; one that fails is skipped and listed at the end, and the rest go straight to transcription. The box clears as soon as the run starts
+
+## Fixed
+
+- 🦜 **A Whisper prompt no longer blocks Parakeet or Nemotron** — those engines take no prompt, and a saved one made every run fail with "does not support text prompts". The prompt is now left out of the request when the loaded model reports it cannot use it (the translate switch too), so it stays saved for when you switch back to Whisper. The Settings prompt field says so when the selected model ignores it
+- 🪟 **Links with non-Latin titles no longer fail on Windows** — yt-dlp can print bytes that are not UTF-8, and reading its output aborted the whole download on the first one. Thanks to @mikemikimike (#1473)

--- a/website/changelog/3.1.9.md
+++ b/website/changelog/3.1.9.md
@@ -1,0 +1,15 @@
+---
+version: 3.1.9
+date: 2026-09-04
+title: "Transcription is back on older AMD graphics drivers"
+---
+
+## Improved
+
+- 🔍 **Errors now say what the engine printed** — when Sona dies mid-transcription, the error dialog, the logs, and the bug report carry its last lines instead of a bare "failed to read sona event line", so problems like the one above are identifiable from a report
+
+## Fixed
+
+- 🛠️ **Transcription is back on older AMD graphics drivers** — since the move to the new engine, machines with a 2020-era AMD driver (Vulkan 1.2, common on Ryzen laptops with Radeon graphics) crashed at the first GPU submit with "vkQueueSubmit: Invalid queue". The driver returns an empty queue handle from `vkGetDeviceQueue2`; Sona 0.6.4 falls back to `vkGetDeviceQueue` and the GPU works again. Updating the AMD driver is still a good idea, but no longer required
+- 🖥️ **Older Intel and AMD CPUs are back** — Vibe no longer refuses to transcribe on a CPU without AVX2. Sona ships its CPU engine twice, an AVX2 build and an AVX baseline build, and picks the one your processor can run when it starts. Any x86-64 machine from 2011 on now transcribes; the "Your CPU is not supported" message is gone
+- 🎮 **Out of GPU memory no longer kills the run** — when the graphics card runs out of memory partway through a file, Vibe reloads the model on the CPU, retries that file once, and finishes the rest of the queue on the CPU. That model is remembered as too large for your GPU and loads on the CPU from then on. Thanks to @mikemikimike for the report and the first pass (#1471, #1472)

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -3,6 +3,7 @@ import Layout from '~/components/Layout'
 import Home from '~/pages/Home'
 import Features from '~/pages/Features'
 import Docs from '~/pages/Docs'
+import Changelog from '~/pages/Changelog'
 
 export default function App() {
 	return (
@@ -12,6 +13,8 @@ export default function App() {
 					<Route index element={<Home />} />
 					<Route path="features" element={<Features />} />
 					<Route path="docs" element={<Docs />} />
+					<Route path="changelog" element={<Changelog />} />
+					<Route path="changelog/:version" element={<Changelog />} />
 				</Route>
 			</Routes>
 		</BrowserRouter>

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -49,6 +49,9 @@ export default function Footer({ onOpenKofi, onOpenPrivacyPolicy }: FooterProps)
 						<Link className={linkClass} to="/docs">
 							{m.documentation()}
 						</Link>
+						<Link className={linkClass} to="/changelog">
+							{m.changelog()}
+						</Link>
 					</div>
 					<div className="flex flex-col items-start gap-3">
 						<button className={linkClass} onClick={onOpenKofi}>

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -44,6 +44,9 @@ export default function Nav({ locale, availableLocales, onLocaleChange }: NavPro
 					<Link to="/features" className="rounded-full px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground">
 						{m.features()}
 					</Link>
+					<Link to="/changelog" className="rounded-full px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground">
+						{m.changelog()}
+					</Link>
 				</nav>
 
 				<ul className="ms-auto flex items-center gap-4">

--- a/website/src/lib/changelog.ts
+++ b/website/src/lib/changelog.ts
@@ -1,0 +1,56 @@
+/**
+ * Release notes live in `website/changelog/<version>.md`, one file per app
+ * release, written in the same PR as the version bump. The frontmatter carries
+ * the version, the date, and a headline; the body is `## New`, `## Improved`,
+ * `## Fixed` sections of bullets, rendered with a badge each.
+ */
+const files = import.meta.glob('../../changelog/*.md', { query: '?raw', import: 'default', eager: true }) as Record<string, string>
+
+export const sections = ['New', 'Improved', 'Fixed'] as const
+export type Section = (typeof sections)[number]
+
+export interface Release {
+	version: string
+	date: string
+	title: string
+	items: { section: Section; text: string }[]
+}
+
+function parse(raw: string): Release {
+	const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+	if (!match) throw new Error('changelog entry without frontmatter')
+	const meta: Record<string, string> = {}
+	for (const line of match[1].split('\n')) {
+		const i = line.indexOf(':')
+		if (i > 0) meta[line.slice(0, i).trim()] = line.slice(i + 1).trim().replace(/^"(.*)"$/, '$1')
+	}
+	const items: Release['items'] = []
+	let section: Section = 'New'
+	for (const line of match[2].split('\n')) {
+		const heading = line.match(/^##\s+(New|Improved|Fixed)\s*$/)
+		if (heading) {
+			section = heading[1] as Section
+			continue
+		}
+		const bullet = line.match(/^[-*]\s+(.+)$/)
+		if (bullet) items.push({ section, text: bullet[1] })
+	}
+	return { version: meta.version, date: meta.date, title: meta.title, items }
+}
+
+function compareVersions(a: string, b: string) {
+	const pa = a.split('.').map(Number)
+	const pb = b.split('.').map(Number)
+	for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return (pb[i] ?? 0) - (pa[i] ?? 0)
+	return 0
+}
+
+/** Every release, newest first. */
+export const releases: Release[] = Object.values(files)
+	.map(parse)
+	.sort((a, b) => compareVersions(a.version, b.version))
+
+export function findRelease(version: string | undefined) {
+	const wanted = (version ?? '').replace(/^v/, '')
+	return releases.find((r) => r.version === wanted)
+}

--- a/website/src/pages/Changelog.tsx
+++ b/website/src/pages/Changelog.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { marked } from 'marked'
+import { cn } from '~/lib/style'
+import { findRelease, releases, sections, type Release, type Section } from '~/lib/changelog'
+import { m } from '~/paraglide/messages.js'
+
+const badge: Record<Section, string> = {
+	New: 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300',
+	Improved: 'bg-sky-500/12 text-sky-700 dark:text-sky-300',
+	Fixed: 'bg-amber-500/14 text-amber-800 dark:text-amber-300',
+}
+
+const label: Record<Section, () => string> = {
+	New: () => m.changelogNew(),
+	Improved: () => m.changelogImproved(),
+	Fixed: () => m.changelogFixed(),
+}
+
+const inline = [
+	'[&_a]:underline [&_a]:decoration-border [&_a]:underline-offset-4 [&_a]:transition-colors hover:[&_a]:decoration-foreground',
+	'[&_strong]:font-medium [&_strong]:text-foreground',
+	'[&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[13px] [&_code]:text-foreground',
+].join(' ')
+
+function formatDate(date: string) {
+	return new Date(`${date}T00:00:00Z`).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })
+}
+
+function Entry({ release, single }: { release: Release; single: boolean }) {
+	const id = `v${release.version}`
+	return (
+		<article id={id} className="grid scroll-mt-24 gap-4 border-t border-border py-12 first:border-t-0 lg:grid-cols-[10rem_1fr] lg:gap-12" dir="ltr">
+			{/* The version and date stay put while the entry's notes scroll past. */}
+			<div className="lg:sticky lg:top-24 lg:self-start">
+				<Link to={`/changelog/${release.version}`} className="text-[15px] font-medium text-foreground transition-colors hover:text-primary">
+					{id}
+				</Link>
+				<time dateTime={release.date} className="mt-1 block text-[13px] text-muted-foreground">
+					{formatDate(release.date)}
+				</time>
+				{single && (
+					<Link to="/changelog" className="mt-4 block text-[13px] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground">
+						{m.changelogAll()}
+					</Link>
+				)}
+			</div>
+			<div className="max-w-[68ch]">
+				<h2 className="text-[1.5rem] font-semibold leading-tight tracking-[-0.02em] text-foreground">{release.title}</h2>
+				{sections.map((section) => {
+					const items = release.items.filter((item) => item.section === section)
+					if (items.length === 0) return null
+					return (
+						<section key={section} className="mt-7">
+							<span className={cn('inline-block rounded-full px-2.5 py-0.5 text-[12px] font-medium tracking-wide', badge[section])}>{label[section]()}</span>
+							<ul className="mt-3 list-disc space-y-2 ps-5 text-[15px] leading-7 text-muted-foreground">
+								{items.map((item, i) => (
+									<li key={i} className={inline} dangerouslySetInnerHTML={{ __html: marked.parseInline(item.text) as string }} />
+								))}
+							</ul>
+						</section>
+					)
+				})}
+			</div>
+		</article>
+	)
+}
+
+export default function Changelog() {
+	const { version } = useParams()
+	const one = version ? findRelease(version) : undefined
+	const shown = one ? [one] : releases
+
+	useEffect(() => {
+		document.title = one ? `Vibe v${one.version}: ${one.title}` : `Vibe ${m.changelog()}`
+		return () => {
+			document.title = 'Vibe'
+		}
+	}, [one])
+
+	return (
+		<main className="mx-auto w-full max-w-[1065px] px-5 pb-24 pt-14 lg:pt-20">
+			<header dir="ltr">
+				<p className="eyebrow">Vibe</p>
+				<h1 className="mt-4 text-[2rem] font-semibold leading-[1.08] tracking-[-0.03em] text-foreground lg:text-[2.5rem]">{m.changelog()}</h1>
+				{version && !one && <p className="mt-4 text-muted-foreground">{m.changelogUnknownVersion({ version })}</p>}
+			</header>
+			<div className="mt-6">
+				{shown.map((release) => (
+					<Entry key={release.version} release={release} single={Boolean(one)} />
+				))}
+			</div>
+		</main>
+	)
+}


### PR DESCRIPTION
- `website/changelog/<version>.md`, one per app release, written in the same PR as the bump: frontmatter `version`, `date`, `title`; body `## New`, `## Improved`, `## Fixed` bullets
- `/changelog` lists every release newest first, version and date sticky beside the notes; `/changelog/<version>` shows one. Nav and footer links. Badges per section
- 72 releases backfilled from the GitHub bodies (v0.0.2 to v3.1.10); sections assigned by keyword, hand-checked for 3.1.5 onwards. Skipped: the placeholder v0.0.1, the auto-generated v3.0.2, and one empty body
- Release workflow: a step fails early when `website/changelog/<version>.md` is missing; the GitHub release body becomes a link to the page plus the signing line

Checked in a local build: layout, sticky column on scroll, per-version route, 404 fallback intact.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna