### PR TITLE
Every Download button downloads; macOS picks its build in a modal

### DIFF
--- a/i18n/translations/bg-BG/website.json
+++ b/i18n/translations/bg-BG/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Насладете се на изцяло офлайн транскрибиране, при което никакви данни не напускат устройството ви.",
 	"feature-customize-title": "Пълна свобода",
 	"feature-customize-description": "Персонализирайте моделите без усилие в настройките за изживяване по ваша мярка.",
-	"changelog": "Списък с промени"
+	"changelog": "Списък с промени",
+	"download-for-mac": "Изтегляне за macOS",
+	"which-mac": "Изберете версията за вашия Mac. Не сте сигурни? Меню Apple → „За този Mac“ показва чипа.",
+	"apple-silicon-hint": "M1, M2, M3, M4 и по-нови",
+	"intel-hint": "Mac с Intel, 2020 г. и по-стари"
 }

--- a/i18n/translations/cs-CZ/website.json
+++ b/i18n/translations/cs-CZ/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Užijte si plně offline přepis – žádná data nikdy neopustí vaše zařízení.",
 	"feature-customize-title": "Naprostá volnost",
 	"feature-customize-description": "Snadno si v nastavení přizpůsobte modely podle svých potřeb.",
-	"changelog": "Seznam změn"
+	"changelog": "Seznam změn",
+	"download-for-mac": "Stáhnout pro macOS",
+	"which-mac": "Vyberte sestavení pro svůj Mac. Nevíte? Nabídka Apple → O tomto Macu ukáže čip.",
+	"apple-silicon-hint": "M1, M2, M3, M4 a novější",
+	"intel-hint": "Macy s Intelem, 2020 a starší"
 }

--- a/i18n/translations/de-DE/website.json
+++ b/i18n/translations/de-DE/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Genießen Sie vollständig offline arbeitende Transkription, sodass keine Daten je Ihr Gerät verlassen.",
 	"feature-customize-title": "Volle Freiheit",
 	"feature-customize-description": "Passen Sie Modelle mühelos in den Einstellungen an, für ein maßgeschneidertes Erlebnis.",
-	"changelog": "Änderungsprotokoll"
+	"changelog": "Änderungsprotokoll",
+	"download-for-mac": "Für macOS herunterladen",
+	"which-mac": "Wähle die Version für deinen Mac. Unsicher? Apple-Menü → Über diesen Mac zeigt den Chip.",
+	"apple-silicon-hint": "M1, M2, M3, M4 und neuer",
+	"intel-hint": "Intel-Macs, 2020 und älter"
 }

--- a/i18n/translations/en-US/website.json
+++ b/i18n/translations/en-US/website.json
@@ -73,5 +73,9 @@
 	"changelogImproved": "Improved",
 	"changelogFixed": "Fixed",
 	"changelogAll": "All releases",
-	"changelogUnknownVersion": "There is no release {version}."
+	"changelogUnknownVersion": "There is no release {version}.",
+	"download-for-mac": "Download for macOS",
+	"which-mac": "Pick the build for your Mac. Not sure? Apple menu → About This Mac shows the chip.",
+	"apple-silicon-hint": "M1, M2, M3, M4 and newer",
+	"intel-hint": "Intel Macs, 2020 and earlier"
 }

--- a/i18n/translations/es-MX/website.json
+++ b/i18n/translations/es-MX/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Disfruta de una transcripción totalmente sin conexión: ningún dato sale de tu dispositivo.",
 	"feature-customize-title": "Libertad total",
 	"feature-customize-description": "Personaliza los modelos desde los ajustes para una experiencia a tu medida.",
-	"changelog": "Registro de cambios"
+	"changelog": "Registro de cambios",
+	"download-for-mac": "Descargar para macOS",
+	"which-mac": "Elige la versión para tu Mac. ¿No estás seguro? Menú Apple → Acerca de esta Mac muestra el chip.",
+	"apple-silicon-hint": "M1, M2, M3, M4 y más recientes",
+	"intel-hint": "Mac con Intel, 2020 y anteriores"
 }

--- a/i18n/translations/fr-FR/website.json
+++ b/i18n/translations/fr-FR/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Profitez d'une transcription entièrement hors ligne : aucune donnée ne quitte votre appareil.",
 	"feature-customize-title": "Liberté totale",
 	"feature-customize-description": "Personnalisez les modèles dans les paramètres pour une expérience sur mesure.",
-	"changelog": "Journal des modifications"
+	"changelog": "Journal des modifications",
+	"download-for-mac": "Télécharger pour macOS",
+	"which-mac": "Choisissez la version pour votre Mac. Un doute ? Menu Pomme → À propos de ce Mac indique la puce.",
+	"apple-silicon-hint": "M1, M2, M3, M4 et plus récents",
+	"intel-hint": "Mac Intel, 2020 et antérieurs"
 }

--- a/i18n/translations/he-IL/website.json
+++ b/i18n/translations/he-IL/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "תיהנו מתמלול לא מקוון לחלוטין, שום מידע לא יוצא מהמכשיר שלכם.",
 	"feature-customize-title": "חופש מלא",
 	"feature-customize-description": "התאימו את המודלים בהגדרות בקלות, לחוויה שמתאימה בדיוק לכם.",
-	"changelog": "יומן שינויים"
+	"changelog": "יומן שינויים",
+	"download-for-mac": "הורדה ל-macOS",
+	"which-mac": "בחרו את הגרסה למחשב ה-Mac שלכם. לא בטוחים? תפריט Apple → אודות ה-Mac הזה מציג את השבב.",
+	"apple-silicon-hint": "M1, M2, M3, M4 וחדשים יותר",
+	"intel-hint": "מחשבי Mac עם Intel, 2020 ומטה"
 }

--- a/i18n/translations/ja-JP/website.json
+++ b/i18n/translations/ja-JP/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "完全オフラインで文字起こしできるため、データがデバイスの外に出ることはありません。",
 	"feature-customize-title": "自由自在なカスタマイズ",
 	"feature-customize-description": "設定からモデルを簡単にカスタマイズして、自分好みの環境に整えられます。",
-	"changelog": "変更履歴"
+	"changelog": "変更履歴",
+	"download-for-mac": "macOS 版をダウンロード",
+	"which-mac": "お使いの Mac に合うビルドを選んでください。不明な場合は Apple メニュー → このMacについて でチップを確認できます。",
+	"apple-silicon-hint": "M1、M2、M3、M4 以降",
+	"intel-hint": "Intel Mac（2020 年以前）"
 }

--- a/i18n/translations/ko-KR/website.json
+++ b/i18n/translations/ko-KR/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "완전 오프라인 전사로 데이터가 기기를 벗어나지 않습니다.",
 	"feature-customize-title": "완전한 자유",
 	"feature-customize-description": "설정에서 모델을 자유롭게 바꿔 나에게 맞는 환경을 만드세요.",
-	"changelog": "변경 사항"
+	"changelog": "변경 사항",
+	"download-for-mac": "macOS용 다운로드",
+	"which-mac": "내 Mac에 맞는 빌드를 선택하세요. 잘 모르겠다면 Apple 메뉴 → 이 Mac에 관하여 에서 칩을 확인할 수 있습니다.",
+	"apple-silicon-hint": "M1, M2, M3, M4 및 그 이후",
+	"intel-hint": "Intel Mac, 2020년 및 이전"
 }

--- a/i18n/translations/no-NO/website.json
+++ b/i18n/translations/no-NO/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Nyt helt offline transkripsjon – ingen data forlater enheten din.",
 	"feature-customize-title": "Full frihet",
 	"feature-customize-description": "Tilpass modellene enkelt i innstillingene for en opplevelse som passer deg.",
-	"changelog": "Endringslogg"
+	"changelog": "Endringslogg",
+	"download-for-mac": "Last ned for macOS",
+	"which-mac": "Velg versjonen for din Mac. Usikker? Apple-menyen → Om denne Macen viser brikken.",
+	"apple-silicon-hint": "M1, M2, M3, M4 og nyere",
+	"intel-hint": "Intel-Macer, 2020 og eldre"
 }

--- a/i18n/translations/pl-PL/website.json
+++ b/i18n/translations/pl-PL/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Korzystaj z transkrypcji w pełni offline — żadne dane nie opuszczają Twojego urządzenia.",
 	"feature-customize-title": "Pełna swoboda",
 	"feature-customize-description": "Dostosuj modele w ustawieniach, aby dopasować program do siebie.",
-	"changelog": "Lista zmian"
+	"changelog": "Lista zmian",
+	"download-for-mac": "Pobierz dla macOS",
+	"which-mac": "Wybierz wersję dla swojego Maca. Nie wiesz? Menu Apple → Ten Mac pokazuje układ.",
+	"apple-silicon-hint": "M1, M2, M3, M4 i nowsze",
+	"intel-hint": "Maki z Intelem, 2020 i starsze"
 }

--- a/i18n/translations/pt-BR/website.json
+++ b/i18n/translations/pt-BR/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Aproveite a transcrição totalmente offline: nenhum dado sai do seu dispositivo.",
 	"feature-customize-title": "Liberdade total",
 	"feature-customize-description": "Personalize os modelos nas configurações para uma experiência sob medida.",
-	"changelog": "Registro de alterações"
+	"changelog": "Registro de alterações",
+	"download-for-mac": "Baixar para macOS",
+	"which-mac": "Escolha a versão para o seu Mac. Não sabe? Menu Apple → Sobre este Mac mostra o chip.",
+	"apple-silicon-hint": "M1, M2, M3, M4 e mais recentes",
+	"intel-hint": "Macs com Intel, 2020 e anteriores"
 }

--- a/i18n/translations/ru-RU/website.json
+++ b/i18n/translations/ru-RU/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "Расшифровка работает полностью офлайн — данные не покидают ваше устройство.",
 	"feature-customize-title": "Полная свобода",
 	"feature-customize-description": "Настраивайте модели в параметрах под свои задачи.",
-	"changelog": "Список изменений"
+	"changelog": "Список изменений",
+	"download-for-mac": "Скачать для macOS",
+	"which-mac": "Выберите сборку для вашего Mac. Не уверены? Меню Apple → Об этом Mac покажет чип.",
+	"apple-silicon-hint": "M1, M2, M3, M4 и новее",
+	"intel-hint": "Mac на Intel, 2020 года и старше"
 }

--- a/i18n/translations/zh-CN/website.json
+++ b/i18n/translations/zh-CN/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "完全离线转录，数据绝不会离开您的设备。",
 	"feature-customize-title": "完全自由",
 	"feature-customize-description": "在设置中轻松自定义模型，打造专属体验。",
-	"changelog": "更新日志"
+	"changelog": "更新日志",
+	"download-for-mac": "下载 macOS 版",
+	"which-mac": "选择适合你 Mac 的版本。不确定？苹果菜单 → 关于本机 会显示芯片。",
+	"apple-silicon-hint": "M1、M2、M3、M4 及更新",
+	"intel-hint": "Intel 芯片 Mac，2020 年及更早"
 }

--- a/i18n/translations/zh-HK/website.json
+++ b/i18n/translations/zh-HK/website.json
@@ -68,5 +68,9 @@
 	"feature-privacy-description": "完全離線轉錄，資料絕不會離開您的裝置。",
 	"feature-customize-title": "完全自由",
 	"feature-customize-description": "在設定中輕鬆自訂模型，打造專屬體驗。",
-	"changelog": "更新日誌"
+	"changelog": "更新日誌",
+	"download-for-mac": "下載 macOS 版",
+	"which-mac": "選擇適合你 Mac 的版本。不確定？Apple 選單 → 關於此 Mac 會顯示晶片。",
+	"apple-silicon-hint": "M1、M2、M3、M4 及更新",
+	"intel-hint": "Intel 晶片 Mac，2020 年及更早"
 }

--- a/website/src/components/Cta.tsx
+++ b/website/src/components/Cta.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import mobile from 'is-mobile'
 import { m } from '../paraglide/messages.js'
 import { Button } from '~/components/ui/button'
@@ -9,6 +9,7 @@ import Linux from '~/icons/Linux'
 import Mac from '~/icons/Mac'
 import Windows from '~/icons/Windows'
 import { isVersionOverride, release as latestRelease } from '~/lib/release'
+import { onDownloadRequest } from '~/lib/download-intent'
 import linuxInstallOptions from '~/lib/linux_install_options.json'
 import CopyButton from './CopyButton'
 import PostDownload from './PostDownload'
@@ -35,7 +36,7 @@ interface CtaProps {
 
 export default function Cta({ onOpenKofi }: CtaProps) {
 	const [currentPlatform, setCurrentPlatform] = useState<Platform>('macos')
-	const [ctaClicked, setCtaClicked] = useState(false)
+	const [macModalOpen, setMacModalOpen] = useState(false)
 	const [mobileModalOpen, setMobileModalOpen] = useState(false)
 	const [linuxModalOpen, setLinuxModalOpen] = useState(false)
 	const [postDownloadOpen, setPostDownloadOpen] = useState(false)
@@ -44,10 +45,15 @@ export default function Cta({ onOpenKofi }: CtaProps) {
 
 	const asset = latestRelease.assets.find((releaseAsset) => releaseAsset.platform?.toLowerCase() === currentPlatform)
 
+	const ctaClickRef = useRef<() => void>(() => {})
+
 	useEffect(() => {
 		setCurrentPlatform(getOS())
 		setIsMobile(mobile() || window.screen.width < 480)
 	}, [])
+
+	// Another Download button on the page acts as if this one was clicked.
+	useEffect(() => onDownloadRequest(() => ctaClickRef.current()), [])
 
 	function ctaClick() {
 		if (isMobile) {
@@ -57,7 +63,7 @@ export default function Cta({ onOpenKofi }: CtaProps) {
 		}
 
 		if (currentPlatform === 'macos') {
-			setCtaClicked(true)
+			setMacModalOpen(true)
 			return
 		}
 
@@ -72,9 +78,10 @@ export default function Cta({ onOpenKofi }: CtaProps) {
 		}
 	}
 
+	ctaClickRef.current = ctaClick
+
 	function changePlatform(platform: Platform) {
 		setCurrentPlatform(platform)
-		setCtaClicked(false)
 		setCurrentURL(location.href)
 	}
 
@@ -114,23 +121,6 @@ export default function Cta({ onOpenKofi }: CtaProps) {
 					</a>
 				</Button>
 			</div>
-
-			{currentPlatform === 'macos' && ctaClicked && (
-				<div className="mt-4 flex gap-2">
-					<Button variant="outline" size="sm" className="animate-pulse-glow" asChild>
-						<a href={macSiliconAsset?.url} onClick={() => setPostDownloadOpen(true)}>
-							<Mac className="size-4" />
-							{m['apple-silicon']()}
-						</a>
-					</Button>
-					<Button variant="outline" size="sm" className="animate-pulse-glow" asChild>
-						<a href={macIntelAsset?.url} onClick={() => setPostDownloadOpen(true)}>
-							<Chip />
-							{m.intel()}
-						</a>
-					</Button>
-				</div>
-			)}
 
 			<div className="mt-6 flex flex-col items-center gap-2.5">
 				<div className="flex items-center gap-1 rounded-full border border-border p-1">
@@ -186,6 +176,40 @@ export default function Cta({ onOpenKofi }: CtaProps) {
 							{m.cancel()}
 						</Button>
 					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={macModalOpen} onOpenChange={setMacModalOpen}>
+				<DialogContent className="w-[88vw] max-w-[88vw] p-6 sm:!max-w-xl md:p-8">
+					<h3 className="pe-8 text-[24px] font-semibold tracking-[-0.03em] md:text-[28px]">{m['download-for-mac']()}</h3>
+					<p className="mt-1 text-[14px] text-muted-foreground">{m['which-mac']()}</p>
+					<div className="mt-6 grid gap-3 sm:grid-cols-2">
+						{[
+							{ asset: macSiliconAsset, label: m['apple-silicon'](), hint: m['apple-silicon-hint'](), icon: <Mac className="size-5" /> },
+							{ asset: macIntelAsset, label: m.intel(), hint: m['intel-hint'](), icon: <Chip /> },
+						].map((build) => (
+							<a
+								key={build.label}
+								href={build.asset?.url}
+								onClick={() => {
+									setMacModalOpen(false)
+									setPostDownloadOpen(true)
+								}}
+								className="group flex flex-col gap-3 rounded-2xl border border-border bg-muted/40 p-5 transition-colors hover:border-foreground/40 hover:bg-muted">
+								<span className="flex items-center gap-2 text-[16px] font-semibold text-foreground">
+									{build.icon}
+									{build.label}
+								</span>
+								<span className="text-[13px] text-muted-foreground">{build.hint}</span>
+								<span className="mt-auto text-[13px] font-medium text-foreground underline decoration-border underline-offset-4 group-hover:decoration-foreground">
+									{m.download()}
+								</span>
+							</a>
+						))}
+					</div>
+					<div className="mt-8 flex items-center justify-center">
+						<SupportButton onOpenKofi={onOpenKofi} />
+					</div>
 				</DialogContent>
 			</Dialog>
 

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -4,6 +4,7 @@ import { Button } from '~/components/ui/button'
 import Logo from '~/icons/Logo'
 import type { Locale } from '../paraglide/runtime.js'
 import LanguageSelector from './LanguageSelector'
+import { requestDownloadWhenReady } from '~/lib/download-intent'
 import { Moon, Sun } from 'lucide-react'
 
 interface NavProps {
@@ -18,18 +19,8 @@ export default function Nav({ locale, availableLocales, onLocaleChange }: NavPro
 
 	function onDownloadClick(event: React.MouseEvent<HTMLAnchorElement>) {
 		event.preventDefault()
-		const scrollToDownload = () => {
-			const target = document.getElementById('download')
-			if (target) target.scrollIntoView({ behavior: 'smooth', block: 'center' })
-			else window.scrollTo({ top: 0, behavior: 'smooth' })
-		}
-
-		if (location.pathname === '/') {
-			scrollToDownload()
-			return
-		}
-		navigate('/')
-		requestAnimationFrame(scrollToDownload)
+		if (location.pathname !== '/') navigate('/')
+		requestDownloadWhenReady()
 	}
 
 	return (

--- a/website/src/lib/download-intent.ts
+++ b/website/src/lib/download-intent.ts
@@ -1,0 +1,26 @@
+/**
+ * "Download" means the same thing wherever it is clicked: the header button, the
+ * closing band, the hero. The CTA owns the platform logic (Windows downloads at
+ * once, Linux opens its install options, macOS reveals the two builds), so the
+ * other buttons hand the click to it through this event instead of scrolling
+ * to a spot the visitor may already be looking at.
+ */
+const EVENT = 'vibe:download'
+
+export function requestDownload() {
+	window.dispatchEvent(new Event(EVENT))
+}
+
+/** Keep asking until the CTA is mounted: after a route change it is not there yet. */
+export function requestDownloadWhenReady(attempts = 30) {
+	if (document.getElementById('download')) {
+		requestDownload()
+		return
+	}
+	if (attempts > 0) requestAnimationFrame(() => requestDownloadWhenReady(attempts - 1))
+}
+
+export function onDownloadRequest(handler: () => void) {
+	window.addEventListener(EVENT, handler)
+	return () => window.removeEventListener(EVENT, handler)
+}

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 import { useOutletContext } from 'react-router-dom'
 import { Copy, Download, Languages, Layers, Pause, Plus, Search, Settings, ShieldCheck, SlidersHorizontal } from 'lucide-react'
+import { requestDownload } from '~/lib/download-intent'
 import { m } from '../paraglide/messages.js'
 import Cta from '~/components/Cta'
 import WallOfLove from '~/components/WallOfLove'
@@ -210,7 +211,7 @@ export default function Home() {
 	const ctaRef = useRef<HTMLDivElement>(null)
 
 	const scrollToCta = useCallback(() => {
-		ctaRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+		requestDownload()
 	}, [])
 
 	return (


### PR DESCRIPTION
- Header button and closing band dispatch a download request; the CTA handles it with its platform logic (Windows downloads at once and shows the post-download steps, Linux opens its install options, mobile its dialog). From another route it navigates home first and fires once the CTA is mounted
- macOS: a modal like the Linux one, two boxes (Apple silicon, Intel) with a hint on telling them apart, following the page direction; replaces the inline reveal
- Strings translated in every website locale

Checked in a local build: header from the changelog page opens the modal on this Mac, RTL layout in Hebrew.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna