### PR TITLE
Bump version to 3.1.11: auto-export, the batch moment, every audio track heard

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./gen/schemas/desktop-schema.json",
 	"productName": "vibe",
-	"version": "3.1.10",
+	"version": "3.1.11",
 	"identifier": "github.com.thewh1teagle.vibe",
 	"app": {
 		"macOSPrivateApi": true,

--- a/website/changelog/3.1.11.md
+++ b/website/changelog/3.1.11.md
@@ -1,0 +1,20 @@
+---
+version: 3.1.11
+date: 2026-09-04
+title: "Auto-export: every transcript written where you want it"
+---
+
+## New
+
+- 📤 **Auto-export** — turn it on once in Settings → Transcription and every transcript is written as soon as it finishes, in the formats you pick (VTT, SRT, text, Markdown, JSON, CSV, DOCX, PDF, HTML), next to each recording, in the projects folder, or in one folder you choose. Existing files are kept unless you ask to replace them, and a recording folder that cannot be written falls back to the projects folder. This brings back what the old batch page did, for the whole app
+- 🏁 **The batch moment** — transcribing several files now shows progress across the run with a time estimate, and ends with a card that says how many were exported, skipped, or failed, with an Open folder button, plus one desktop notification for the whole batch. Each file in the list says what it produced
+- 🧭 **Export menu in a batch** — the Export button becomes a menu with Export this transcript, Export all finished for anything done before auto-export was on, and the auto-export setting. Thanks to @LivingInternet for the report (#1480)
+
+## Improved
+
+- 🌓 **Theme switch** — a sun and a moon in Settings instead of a dropdown
+- 🗂️ **Every audio track is heard** — a recording with several audio tracks (OBS, Discord, one per speaker) used to be transcribed from one track only; the rest is now mixed in, so every speaker appears and the engine no longer repeats a line over silence it was never meant to hear
+
+## Fixed
+
+- 🔁 **Repeated sentence for minutes** — the loop reported on multi-track recordings, where the model heard silence on a dropped track while the speaker kept talking, is gone with the change above (#1518, #1505)


### PR DESCRIPTION
Notes in `website/changelog/3.1.11.md`. Server stays at v0.6.7.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna