### PR TITLE
Let VIBE_SERVER_CPU_VARIANT force the CPU backend build when CPUID lies

### DIFF
--- a/desktop/src-tauri/src/server/process.rs
+++ b/desktop/src-tauri/src/server/process.rs
@@ -49,7 +49,7 @@ pub(super) fn describe_exit(status: ExitStatus) -> String {
 /// missing an instruction set the build assumes. Naming it here is what turns these
 /// reports from a bare "vibe-server process died" into something identifiable.
 fn illegal_instruction_hint(status: ExitStatus) -> Option<&'static str> {
-    const MESSAGE: &str = "This looks like a CPU without AVX support: server picks an AVX2 or an AVX build of its CPU backend at startup, but nothing older, so it stops on the first instruction it cannot run. Vibe cannot transcribe on this machine.";
+    const MESSAGE: &str = "This looks like a CPU without AVX support, or one that advertises AVX2 it cannot run (a Hackintosh with spoofed CPUID does this): the server picks an AVX2 or an AVX build of its CPU backend at startup from what the CPU reports, so it stops on the first instruction it cannot run. Set VIBE_SERVER_CPU_VARIANT=baseline to force the AVX build.";
 
     #[cfg(unix)]
     {

--- a/server/crates/ggml-rs-sys/src/cpu_variant.rs
+++ b/server/crates/ggml-rs-sys/src/cpu_variant.rs
@@ -15,7 +15,16 @@ extern "C" {
 }
 
 /// The macro also checks that the OS saves the AVX register state, which a bare cpuid does not.
+///
+/// `VIBE_SERVER_CPU_VARIANT=baseline` (or `avx2`) overrides the detection. A machine can
+/// advertise AVX2 it cannot execute: a Hackintosh whose bootloader spoofs CPUID reports the
+/// flag, picks the Haswell build, and dies with SIGILL while loading the model (#1499).
 fn haswell() -> bool {
+    match std::env::var("VIBE_SERVER_CPU_VARIANT").ok().as_deref() {
+        Some("baseline") | Some("x64") => return false,
+        Some("avx2") | Some("hsw") => return true,
+        _ => {}
+    }
     is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") && is_x86_feature_detected!("bmi2")
 }
 


### PR DESCRIPTION
Adds a runtime override for the CPU backend pick (`baseline`/`avx2`) for machines whose CPUID advertises AVX2 they cannot execute (spoofed Hackintosh in #1499), and widens the desktop SIGILL hint to name that case.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna