### PR TITLE
Add a CPU instruction set setting and relaunch on the baseline build after an illegal instruction

### DIFF
--- a/desktop/src-tauri/src/analytics.rs
+++ b/desktop/src-tauri/src/analytics.rs
@@ -27,6 +27,8 @@ pub mod events {
     pub const CLI_SPAWN_FAILED: &str = "cli_spawn_failed";
     /// The string predates the rename; keeping it keeps the dashboards continuous.
     pub const SERVER_SPAWN_FAILED: &str = "sona_spawn_failed";
+    /// The engine died with an illegal instruction on the AVX2 build and was relaunched on the baseline one.
+    pub const SERVER_CPU_BASELINE_FALLBACK: &str = "server_cpu_baseline_fallback";
 
     // Phone handoff. Props are technical facts only: never a transcript, filename,
     // saved path, endpoint id, pairing token, model path, or chosen language.

--- a/desktop/src-tauri/src/cmd/config.rs
+++ b/desktop/src-tauri/src/cmd/config.rs
@@ -9,6 +9,66 @@ use tauri_plugin_store::StoreExt;
 /// Config key holding the base URL of the running local API. Must match `CONFIG_KEYS.apiBaseUrl`.
 pub const API_BASE_URL_KEY: &str = "api.baseUrl";
 
+/// Config key for the CPU backend build the engine should use. Must match `CONFIG_KEYS.cpuVariant`.
+pub const CPU_VARIANT_KEY: &str = "server.cpuVariant";
+
+/// Which build of the engine's CPU backend to run.
+///
+/// `Auto` lets the engine decide from CPUID. `Baseline` is for a machine that advertises
+/// AVX2 it cannot execute, which happens on a Hackintosh with spoofed CPUID (#1499): the
+/// engine then dies with an illegal instruction while loading the model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuVariant {
+    Auto,
+    Avx2,
+    Baseline,
+}
+
+impl CpuVariant {
+    fn parse(value: &str) -> Self {
+        match value {
+            "avx2" => Self::Avx2,
+            "baseline" => Self::Baseline,
+            _ => Self::Auto,
+        }
+    }
+
+    /// The value the engine reads from `VIBE_SERVER_CPU_VARIANT`; `None` leaves detection alone.
+    pub fn env_value(self) -> Option<&'static str> {
+        match self {
+            Self::Auto => None,
+            Self::Avx2 => Some("avx2"),
+            Self::Baseline => Some("baseline"),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Avx2 => "avx2",
+            Self::Baseline => "baseline",
+        }
+    }
+}
+
+/// The user's CPU build choice from `app_config.json`; `Auto` when unset or unreadable.
+pub fn cpu_variant(app_handle: &tauri::AppHandle) -> CpuVariant {
+    app_handle
+        .store(STORE_FILENAME)
+        .ok()
+        .and_then(|store| store.get(CPU_VARIANT_KEY))
+        .and_then(|value| value.as_str().map(CpuVariant::parse))
+        .unwrap_or(CpuVariant::Auto)
+}
+
+/// Persist the CPU build choice, so a fallback the app made on its own shows in Settings and holds.
+pub fn set_cpu_variant(app_handle: &tauri::AppHandle, variant: CpuVariant) -> Result<()> {
+    let store = app_handle.store(STORE_FILENAME).map_err(|e| eyre!("{:?}", e))?;
+    store.set(CPU_VARIANT_KEY, serde_json::Value::String(variant.as_str().to_string()));
+    store.save().map_err(|e| eyre!("{:?}", e))?;
+    Ok(())
+}
+
 /// Absolute path of `app_config.json`, so the UI (and agents told where to look) can find it.
 #[tauri::command]
 pub fn get_config_path(app_handle: tauri::AppHandle) -> Result<PathBuf> {

--- a/desktop/src-tauri/src/cmd/server_cmd.rs
+++ b/desktop/src-tauri/src/cmd/server_cmd.rs
@@ -94,25 +94,26 @@ pub async fn load_model(
         state_guard.process = None;
     }
 
+    let cpu_variant = crate::cmd::config::cpu_variant(&app_handle);
     if state_guard
         .process
         .as_ref()
-        .is_some_and(|process| process.unload_timeout_minutes() != unload_timeout_minutes)
+        .is_some_and(|process| process.unload_timeout_minutes() != unload_timeout_minutes || process.cpu_variant() != cpu_variant)
     {
-        tracing::debug!(unload_timeout_minutes, "restarting server to apply unload timeout");
+        tracing::debug!(unload_timeout_minutes, ?cpu_variant, "restarting server to apply settings");
         // Dropping ServerProcess kills and waits for its child process via its Drop implementation.
         state_guard.process = None;
     }
 
-    let spawn_server = || -> Result<crate::server::ServerProcess> {
+    let spawn_server = |cpu_variant: crate::cmd::config::CpuVariant| -> Result<crate::server::ServerProcess> {
         let binary_path = resolve_server_binary(&app_handle)?;
         let ffmpeg_path = resolve_ffmpeg_path(&app_handle);
-        crate::server::ServerProcess::spawn(&binary_path, ffmpeg_path.as_deref(), unload_timeout_minutes)
+        crate::server::ServerProcess::spawn(&binary_path, ffmpeg_path.as_deref(), unload_timeout_minutes, cpu_variant)
     };
 
     // Spawn server if not running
     if state_guard.process.is_none() {
-        match spawn_server() {
+        match spawn_server(cpu_variant) {
             Ok(process) => state_guard.process = Some(process),
             Err(e) => {
                 let error_msg = format!("{:#}", e);
@@ -127,10 +128,41 @@ pub async fn load_model(
     }
 
     // Load model via HTTP
-    let load_result = {
+    let mut load_result = {
         let server = state_guard.process.as_mut().unwrap();
         server.load_model(&model_path, gpu_device, no_gpu).await
     };
+
+    // A CPU that advertises AVX2 it cannot execute kills the engine on the first AVX2
+    // instruction, while the model loads. Once is enough to know: relaunch on the baseline
+    // build, and keep that choice so the next launch does not die again first (#1499).
+    if load_result.is_err()
+        && cpu_variant == crate::cmd::config::CpuVariant::Auto
+        && state_guard
+            .process
+            .as_mut()
+            .is_some_and(crate::server::ServerProcess::died_with_illegal_instruction)
+    {
+        tracing::warn!("server died with an illegal instruction while loading the model; retrying on the baseline CPU build");
+        crate::analytics::track_event_handle_with_props(
+            &app_handle,
+            crate::analytics::events::SERVER_CPU_BASELINE_FALLBACK,
+            None,
+        );
+        state_guard.process = None;
+        let process = spawn_server(crate::cmd::config::CpuVariant::Baseline)
+            .context("failed to respawn server on the baseline CPU build")?;
+        state_guard.process = Some(process);
+        load_result = state_guard
+            .process
+            .as_mut()
+            .unwrap()
+            .load_model(&model_path, gpu_device, no_gpu)
+            .await;
+        if load_result.is_ok() {
+            crate::cmd::config::set_cpu_variant(&app_handle, crate::cmd::config::CpuVariant::Baseline).log_error();
+        }
+    }
 
     // Asking for the CPU is a choice rather than a failure, so there is nothing to fall back to.
     let gpu_fallback = match load_result {
@@ -143,7 +175,7 @@ pub async fn load_model(
             if let Some(mut old) = state_guard.process.take() {
                 old.kill();
             }
-            let process = spawn_server().context("failed to respawn server")?;
+            let process = spawn_server(crate::cmd::config::cpu_variant(&app_handle)).context("failed to respawn server")?;
             state_guard.process = Some(process);
 
             let server = state_guard.process.as_mut().unwrap();
@@ -172,7 +204,13 @@ pub async fn get_model_metadata(app_handle: tauri::AppHandle, model_path: String
     if state.process.as_mut().is_none_or(|process| !process.is_alive()) {
         let binary_path = resolve_server_binary(&app_handle)?;
         let ffmpeg_path = resolve_ffmpeg_path(&app_handle);
-        state.process = Some(crate::server::ServerProcess::spawn(&binary_path, ffmpeg_path.as_deref(), 5)?);
+        let cpu_variant = crate::cmd::config::cpu_variant(&app_handle);
+        state.process = Some(crate::server::ServerProcess::spawn(
+            &binary_path,
+            ffmpeg_path.as_deref(),
+            5,
+            cpu_variant,
+        )?);
     }
     state.process.as_ref().unwrap().model_metadata(&model_path).await
 }
@@ -190,19 +228,21 @@ pub async fn start_api_server(
     unload_timeout_minutes: u32,
 ) -> Result<String> {
     let mut state_guard = server_state.lock().await;
+    let cpu_variant = crate::cmd::config::cpu_variant(&app_handle);
     if state_guard
         .process
         .as_ref()
-        .is_some_and(|process| process.unload_timeout_minutes() != unload_timeout_minutes)
+        .is_some_and(|process| process.unload_timeout_minutes() != unload_timeout_minutes || process.cpu_variant() != cpu_variant)
     {
-        tracing::debug!(unload_timeout_minutes, "restarting server to apply unload timeout");
+        tracing::debug!(unload_timeout_minutes, ?cpu_variant, "restarting server to apply settings");
         // Dropping ServerProcess kills and waits for its child process via its Drop implementation.
         state_guard.process = None;
     }
     if state_guard.process.is_none() {
         let binary_path = resolve_server_binary(&app_handle)?;
         let ffmpeg_path = resolve_ffmpeg_path(&app_handle);
-        let process = crate::server::ServerProcess::spawn(&binary_path, ffmpeg_path.as_deref(), unload_timeout_minutes)?;
+        let process =
+            crate::server::ServerProcess::spawn(&binary_path, ffmpeg_path.as_deref(), unload_timeout_minutes, cpu_variant)?;
         state_guard.process = Some(process);
     }
     let process = state_guard.process.as_ref().context("API server process missing")?;

--- a/desktop/src-tauri/src/server/mod.rs
+++ b/desktop/src-tauri/src/server/mod.rs
@@ -48,6 +48,7 @@ pub struct ModelMetadata {
 pub struct ServerProcess {
     port: u16,
     unload_timeout_minutes: u32,
+    cpu_variant: crate::cmd::config::CpuVariant,
     child: Child,
     /// Cached because `try_wait` hands the status over exactly once.
     exit_status: Option<std::process::ExitStatus>,

--- a/desktop/src-tauri/src/server/process.rs
+++ b/desktop/src-tauri/src/server/process.rs
@@ -1,4 +1,5 @@
 use super::{ReadySignal, ServerProcess, StderrTail};
+use crate::cmd::config::CpuVariant;
 use eyre::{bail, Context, ContextCompat, Result};
 use std::io::BufRead;
 use std::path::Path;
@@ -49,24 +50,26 @@ pub(super) fn describe_exit(status: ExitStatus) -> String {
 /// missing an instruction set the build assumes. Naming it here is what turns these
 /// reports from a bare "vibe-server process died" into something identifiable.
 fn illegal_instruction_hint(status: ExitStatus) -> Option<&'static str> {
-    const MESSAGE: &str = "This looks like a CPU without AVX support, or one that advertises AVX2 it cannot run (a Hackintosh with spoofed CPUID does this): the server picks an AVX2 or an AVX build of its CPU backend at startup from what the CPU reports, so it stops on the first instruction it cannot run. Set VIBE_SERVER_CPU_VARIANT=baseline to force the AVX build.";
+    const MESSAGE: &str = "This looks like a CPU without AVX support, or one that advertises AVX2 it cannot run (a Hackintosh with spoofed CPUID does this): the server picks an AVX2 or an AVX build of its CPU backend at startup from what the CPU reports, so it stops on the first instruction it cannot run. Choose the baseline CPU build in Settings → Advanced.";
+    is_illegal_instruction(status).then_some(MESSAGE)
+}
 
+/// SIGILL on unix; STATUS_ILLEGAL_INSTRUCTION, surfaced as the exit code, on Windows.
+pub fn is_illegal_instruction(status: ExitStatus) -> bool {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
-        if status.signal() == Some(4) {
-            return Some(MESSAGE);
-        }
+        return status.signal() == Some(4);
     }
     #[cfg(windows)]
     {
-        // STATUS_ILLEGAL_INSTRUCTION, which Windows surfaces as the exit code.
-        if status.code() == Some(0xC000_001D_u32 as i32) {
-            return Some(MESSAGE);
-        }
+        return status.code() == Some(0xC000_001D_u32 as i32);
     }
-    let _ = status;
-    None
+    #[allow(unreachable_code)]
+    {
+        let _ = status;
+        false
+    }
 }
 
 #[cfg(unix)]
@@ -130,8 +133,17 @@ fn build_client() -> Result<reqwest::Client> {
 }
 
 impl ServerProcess {
-    pub fn spawn(binary_path: &Path, ffmpeg_path: Option<&Path>, unload_timeout_minutes: u32) -> Result<Self> {
-        tracing::debug!("spawning server at {}", binary_path.display());
+    pub fn spawn(
+        binary_path: &Path,
+        ffmpeg_path: Option<&Path>,
+        unload_timeout_minutes: u32,
+        cpu_variant: CpuVariant,
+    ) -> Result<Self> {
+        tracing::debug!(
+            "spawning server at {} (cpu variant {})",
+            binary_path.display(),
+            cpu_variant.as_str()
+        );
         let unload_timeout = if unload_timeout_minutes == 0 {
             "0".to_string()
         } else {
@@ -154,6 +166,9 @@ impl ServerProcess {
         if let Some(ffmpeg) = ffmpeg_path {
             tracing::debug!("setting VIBE_SERVER_FFMPEG_PATH={}", ffmpeg.display());
             cmd.env("VIBE_SERVER_FFMPEG_PATH", ffmpeg);
+        }
+        if let Some(value) = cpu_variant.env_value() {
+            cmd.env("VIBE_SERVER_CPU_VARIANT", value);
         }
         #[cfg(target_os = "windows")]
         {
@@ -251,6 +266,7 @@ impl ServerProcess {
         Ok(Self {
             port: signal.port,
             unload_timeout_minutes,
+            cpu_variant,
             child,
             exit_status: None,
             client: build_client()?,
@@ -284,6 +300,15 @@ impl ServerProcess {
 
     pub fn unload_timeout_minutes(&self) -> u32 {
         self.unload_timeout_minutes
+    }
+
+    pub fn cpu_variant(&self) -> CpuVariant {
+        self.cpu_variant
+    }
+
+    /// The child is gone and died on an instruction this CPU cannot run.
+    pub fn died_with_illegal_instruction(&mut self) -> bool {
+        self.exit_status().is_some_and(is_illegal_instruction)
     }
 
     /// Bounded wait for the collector to reach EOF before snapshotting: the child

--- a/desktop/src/lib/config-keys.ts
+++ b/desktop/src/lib/config-keys.ts
@@ -23,6 +23,8 @@ export const CONFIG_KEYS = {
 	/** Models that ran out of GPU memory here, loaded on the CPU from then on. */
 	gpuOutOfMemoryModels: 'model.gpuOutOfMemoryModels',
 	unloadTimeoutMinutes: 'model.unloadTimeoutMinutes',
+	// Which build of the engine's CPU backend to run: auto, avx2, or baseline. Read by Rust at spawn.
+	cpuVariant: 'server.cpuVariant',
 	modelPromptDismissed: 'model.downloadPromptDismissed',
 
 	// Transcription

--- a/desktop/src/pages/settings/sections/advanced.tsx
+++ b/desktop/src/pages/settings/sections/advanced.tsx
@@ -6,10 +6,17 @@ import NumberField from '~/components/number-field'
 import { ReactComponent as CopyIcon } from '~/icons/copy.svg'
 import { ReactComponent as FolderIcon } from '~/icons/folder.svg'
 import { ReactComponent as ResetIcon } from '~/icons/reset.svg'
-import { ActionRow, SettingsGroup, SettingsRow, type SettingsViewModel } from './shared'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import type { CpuVariant } from '~/providers/preference'
+import { ActionRow, SettingsGroup, SettingsRow, rowControlClass, type SettingsViewModel } from './shared'
 
 export function AdvancedSection({ vm }: { vm: SettingsViewModel }) {
 	const { fakeUpdate, setFakeUpdate } = useContext(UpdaterContext)
+	const cpuVariants: Array<{ value: CpuVariant; label: string }> = [
+		{ value: 'auto', label: m.cpuVariantAuto() },
+		{ value: 'avx2', label: m.cpuVariantAvx2() },
+		{ value: 'baseline', label: m.cpuVariantBaseline() },
+	]
 
 	return (
 		<div className="space-y-6">
@@ -39,6 +46,23 @@ export function AdvancedSection({ vm }: { vm: SettingsViewModel }) {
 						format={(minutes) => (minutes === 0 ? m.never() : undefined)}
 						onChange={vm.preference.setUnloadTimeoutMinutes}
 					/>
+				</SettingsRow>
+			</SettingsGroup>
+
+			<SettingsGroup title={m.processor()}>
+				<SettingsRow label={m.cpuVariant()} description={m.cpuVariantInfo()} clampDescription={false}>
+					<Select value={vm.preference.cpuVariant} onValueChange={(value: CpuVariant) => vm.preference.setCpuVariant(value)}>
+						<SelectTrigger className={`w-44 ${rowControlClass}`}>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{cpuVariants.map((choice) => (
+								<SelectItem key={choice.value} value={choice.value}>
+									{choice.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</SettingsRow>
 			</SettingsGroup>
 

--- a/desktop/src/providers/preference.tsx
+++ b/desktop/src/providers/preference.tsx
@@ -17,6 +17,9 @@ import { message } from '@tauri-apps/plugin-dialog'
 import { invoke } from '@tauri-apps/api/core'
 import type { ModelMetadata } from '~/lib/model'
 
+/** Which build of the engine's CPU backend to run; `auto` lets CPUID decide. */
+export type CpuVariant = 'auto' | 'avx2' | 'baseline'
+
 type Direction = 'ltr' | 'rtl'
 export type HomeTab = 'record' | 'file' | 'link'
 
@@ -116,6 +119,8 @@ export interface Preference {
 	noGpu: boolean
 	setNoGpu: ModifyState<boolean>
 	unloadTimeoutMinutes: number
+	cpuVariant: CpuVariant
+	setCpuVariant: ModifyState<CpuVariant>
 	setUnloadTimeoutMinutes: ModifyState<number>
 
 	recentLanguages: { code: string; ts: number }[]
@@ -263,6 +268,7 @@ export function PreferenceProvider({ children }: { children: ReactNode }) {
 	const [gpuDevice, setGpuDevice] = usePersisted<number | null>(CONFIG_KEYS.gpuDevice, null)
 	const [noGpu, setNoGpu] = usePersisted<boolean>(CONFIG_KEYS.noGpu, false)
 	const [unloadTimeoutMinutes, setUnloadTimeoutMinutes] = usePersisted<number>(CONFIG_KEYS.unloadTimeoutMinutes, 5)
+	const [cpuVariant, setCpuVariant] = usePersisted<CpuVariant>(CONFIG_KEYS.cpuVariant, 'auto')
 	const [saveTranscripts, setSaveTranscripts] = usePersisted<boolean>(CONFIG_KEYS.saveTranscripts, true)
 	const [meetingDetectionEnabled, setMeetingDetectionEnabled] = usePersisted<boolean>(CONFIG_KEYS.meetingDetectionEnabled, false)
 	const [autoTranscribeAfterRecording, setAutoTranscribeAfterRecording] = usePersisted<boolean>(CONFIG_KEYS.autoTranscribeAfterRecording, false)
@@ -447,6 +453,8 @@ export function PreferenceProvider({ children }: { children: ReactNode }) {
 		setNoGpu,
 		setGpuDevice,
 		unloadTimeoutMinutes,
+		cpuVariant,
+		setCpuVariant,
 		setUnloadTimeoutMinutes,
 		analyticsEnabled,
 		setAnalyticsEnabled,

--- a/i18n/translations/en-US/desktop.json
+++ b/i18n/translations/en-US/desktop.json
@@ -662,5 +662,11 @@
 	"askFailed": "Could not get an answer",
 	"removeQuestion": "Remove",
 	"summaryOff": "Summaries are off. Turn them on in Settings → AI.",
-	"openAiSettings": "Open AI settings"
+	"openAiSettings": "Open AI settings",
+	"processor": "Processor",
+	"cpuVariant": "CPU instruction set",
+	"cpuVariantInfo": "Automatic follows what the processor reports. Pick Baseline if transcription dies with an illegal instruction.",
+	"cpuVariantAuto": "Automatic",
+	"cpuVariantAvx2": "AVX2",
+	"cpuVariantBaseline": "Baseline (AVX)"
 }


### PR DESCRIPTION
## Summary
- Settings → Advanced → Processor: CPU instruction set (Automatic / AVX2 / Baseline), stored as `server.cpuVariant` and passed to the engine as `VIBE_SERVER_CPU_VARIANT` when it is spawned; changing it restarts the engine
- When the engine dies with an illegal instruction while loading the model and the setting is Automatic, the desktop relaunches it once on the baseline build and persists that choice (analytics event `server_cpu_baseline_fallback`)
- Fixes the SIGILL in #1499: the reporter's Hackintosh advertises AVX2 an i5-3570K cannot run

Needs the engine override from #1532 (next server release).

## Test plan
- [x] cargo check + clippy, tsc, i18n audit
- [x] Mock app: Advanced row renders

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna