### PR TITLE
Add llmman as a local AI platform beside Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - 👀 Realtime preview
 - 🤖 Supports Whisper, Nemotron 3.5, and Parakeet TDT v3 models
 - ✨ Summarize transcripts: Get quick, multilingual summaries using the Claude API
-- 🧠 Ollama support: Do local AI analysis and batch summaries with Ollama
+- 🧠 Ollama support: Do local AI analysis and batch summaries with Ollama or [llmman](https://github.com/llmmanorg/llmman)
 - 🌐 Translate to English from any language
 - 🖨️ Print transcript directly to any printer
 - 🔄 Automatic updates

--- a/desktop/src/lib/ai/ai.test.ts
+++ b/desktop/src/lib/ai/ai.test.ts
@@ -78,6 +78,13 @@ describe('createClient', () => {
 		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ stream: true, model: DEFAULT_AI.connection.model })
 	})
 
+	it('talks to llmman like Ollama, on its own port', async () => {
+		fetchMock.mockResolvedValue(streamResponse(['{"response":"ok"}', '{"done":true}']))
+		const text = await createClient({ ...DEFAULT_AI.connection, platform: 'llmman' }).stream('p', () => {})
+		expect(text).toBe('ok')
+		expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:17434/api/generate')
+	})
+
 	it('streams OpenAI SSE and stops at [DONE]', async () => {
 		fetchMock.mockResolvedValue(
 			streamResponse(['data: {"choices":[{"delta":{"content":"a"}}]}', '', 'data: {"choices":[{"delta":{"content":"b"}}]}', 'data: [DONE]']),

--- a/desktop/src/lib/ai/client.ts
+++ b/desktop/src/lib/ai/client.ts
@@ -1,5 +1,5 @@
 import { fetch } from '@tauri-apps/plugin-http'
-import { PLACEHOLDERS, type AiConnection } from './config'
+import { DEFAULT_AI, PLACEHOLDERS, type AiConnection } from './config'
 
 /** Output ceiling; the input side of the context is what is left after it and a margin. */
 const MAX_OUTPUT_TOKENS = 8_192
@@ -108,8 +108,16 @@ async function failure(label: string, response: Response) {
 	return new Error(`${label}: ${response.status} ${response.statusText}${detail ? ` · ${String(detail).slice(0, 300)}` : ''}`)
 }
 
+/** Ollama's `/api/generate`; llmman serves the same API, so it is the same client with another base URL. */
 class Ollama implements AiClient {
-	constructor(private connection: AiConnection) {}
+	constructor(
+		private connection: AiConnection,
+		private label = 'Ollama',
+		private baseUrl = connection.ollamaBaseUrl,
+	) {}
+	private url() {
+		return `${this.baseUrl.replace(/\/+$/, '')}/api/generate`
+	}
 	private body(prompt: string, stream: boolean) {
 		return JSON.stringify({
 			model: this.connection.model,
@@ -123,21 +131,13 @@ class Ollama implements AiClient {
 		return { 'Content-Type': 'application/json', Origin: 'http://127.0.0.1' }
 	}
 	async ask(prompt: string) {
-		const response = await fetch(`${this.connection.ollamaBaseUrl.replace(/\/+$/, '')}/api/generate`, {
-			method: 'POST',
-			headers: this.headers(),
-			body: this.body(prompt, false),
-		})
-		if (!response.ok) throw await failure('Ollama', response)
+		const response = await fetch(this.url(), { method: 'POST', headers: this.headers(), body: this.body(prompt, false) })
+		if (!response.ok) throw await failure(this.label, response)
 		return (await response.json())?.response ?? ''
 	}
 	async stream(prompt: string, onToken: (text: string) => void) {
-		const response = await fetch(`${this.connection.ollamaBaseUrl.replace(/\/+$/, '')}/api/generate`, {
-			method: 'POST',
-			headers: this.headers(),
-			body: this.body(prompt, true),
-		})
-		if (!response.ok) throw await failure('Ollama', response)
+		const response = await fetch(this.url(), { method: 'POST', headers: this.headers(), body: this.body(prompt, true) })
+		if (!response.ok) throw await failure(this.label, response)
 		let text = ''
 		await readLines(response, (line) => {
 			if (!line.trim()) return
@@ -241,6 +241,8 @@ class Claude implements AiClient {
 
 export function createClient(connection: AiConnection): AiClient {
 	if (connection.platform === 'ollama') return new Ollama(connection)
+	// Settings saved before llmman existed have no URL for it; fall back to its default port.
+	if (connection.platform === 'llmman') return new Ollama(connection, 'llmman', connection.llmmanBaseUrl || DEFAULT_AI.connection.llmmanBaseUrl)
 	if (connection.platform === 'openai') return new OpenAICompatible(connection)
 	return new Claude(connection)
 }

--- a/desktop/src/lib/ai/config.ts
+++ b/desktop/src/lib/ai/config.ts
@@ -20,7 +20,8 @@ export interface LegacyLlmConfig {
  * does to a sentence. Prompts belong to tasks, so changing the platform keeps them.
  */
 
-export type AiPlatform = 'ollama' | 'claude' | 'openai'
+/** `llmman` (https://github.com/llmmanorg/llmman) speaks the Ollama API on port 17434. */
+export type AiPlatform = 'ollama' | 'llmman' | 'claude' | 'openai'
 
 export interface AiConnection {
 	platform: AiPlatform
@@ -28,6 +29,7 @@ export interface AiConnection {
 	contextTokens: number
 	claudeApiKey: string
 	ollamaBaseUrl: string
+	llmmanBaseUrl: string
 	openaiBaseUrl: string
 	openaiApiKey: string
 }
@@ -117,6 +119,7 @@ export const DEFAULT_AI: AiSettings = {
 		contextTokens: 65_536,
 		claudeApiKey: '',
 		ollamaBaseUrl: 'http://localhost:11434',
+		llmmanBaseUrl: 'http://localhost:17434',
 		openaiBaseUrl: 'https://api.openai.com/v1',
 		openaiApiKey: '',
 	},
@@ -128,7 +131,7 @@ export const DEFAULT_AI: AiSettings = {
 
 /** The default model for a platform, so switching platforms never leaves a Claude model on Ollama. */
 export function defaultModel(platform: AiPlatform) {
-	return platform === 'ollama' ? 'gemma4:e2b' : platform === 'openai' ? 'gpt-5.6-luna' : 'claude-sonnet-5'
+	return platform === 'ollama' ? 'gemma4:e2b' : platform === 'llmman' ? 'gemma4' : platform === 'openai' ? 'gpt-5.6-luna' : 'claude-sonnet-5'
 }
 
 /** Old `%s` prompts become `{transcript}` or `{text}`; anything else is left alone. */
@@ -154,6 +157,7 @@ export function migrateLegacy(legacy: LegacyLlmConfig | null | undefined, autoSu
 			contextTokens: legacy.contextTokens ?? DEFAULT_AI.connection.contextTokens,
 			claudeApiKey: legacy.claudeApiKey ?? '',
 			ollamaBaseUrl: legacy.ollamaBaseUrl || DEFAULT_AI.connection.ollamaBaseUrl,
+			llmmanBaseUrl: DEFAULT_AI.connection.llmmanBaseUrl,
 			openaiBaseUrl: legacy.openaiBaseUrl || DEFAULT_AI.connection.openaiBaseUrl,
 			openaiApiKey: legacy.openaiApiKey ?? '',
 		},

--- a/desktop/src/pages/settings/sections/ai.tsx
+++ b/desktop/src/pages/settings/sections/ai.tsx
@@ -1,11 +1,11 @@
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { Check, ChevronRight, Copy, ExternalLink } from 'lucide-react'
+import { Boxes, Check, ChevronRight, Copy, ExternalLink } from 'lucide-react'
 import { siClaude, siOllama } from 'simple-icons'
 import { OPENAI_PATH } from '~/components/brand-glyph'
 import { m } from '~/paraglide/messages.js'
 import { ReactComponent as LinkIcon } from '~/icons/link.svg'
 import * as config from '~/lib/config'
-import { defaultModel, type AiPlatform, type AiSettings } from '~/lib/ai'
+import { DEFAULT_AI, defaultModel, type AiPlatform, type AiSettings } from '~/lib/ai'
 import NumberField from '~/components/number-field'
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
@@ -27,21 +27,27 @@ function LabelWithLink({ label, tooltip, onClick }: { label: string; tooltip: st
 	)
 }
 
-/** Brand marks for the providers, so the picker reads at a glance. */
-const platformIcons: Record<AiPlatform, { path: string; title: string }> = {
+/** Brand marks for the providers, so the picker reads at a glance; llmman has none and gets a neutral box. */
+const platformIcons: Partial<Record<AiPlatform, { path: string; title: string }>> = {
 	claude: { path: siClaude.path, title: siClaude.title },
 	ollama: { path: siOllama.path, title: siOllama.title },
 	openai: { path: OPENAI_PATH, title: 'OpenAI' },
 }
 
+const platformLabels: Record<AiPlatform, string> = { claude: 'Claude', llmman: 'llmman', ollama: 'Ollama', openai: 'OpenAI Compatible' }
+
 function PlatformOption({ platform }: { platform: AiPlatform }) {
 	const icon = platformIcons[platform]
 	return (
 		<span className="flex items-center gap-2">
-			<svg viewBox="0 0 24 24" role="img" aria-hidden className="h-4 w-4 shrink-0">
-				<path d={icon.path} fill="currentColor" />
-			</svg>
-			<span className="capitalize">{platform === 'openai' ? 'OpenAI Compatible' : platform}</span>
+			{icon ? (
+				<svg viewBox="0 0 24 24" role="img" aria-hidden className="h-4 w-4 shrink-0">
+					<path d={icon.path} fill="currentColor" />
+				</svg>
+			) : (
+				<Boxes aria-hidden className="h-4 w-4 shrink-0" strokeWidth={1.75} />
+			)}
+			<span>{platformLabels[platform]}</span>
 		</span>
 	)
 }
@@ -102,7 +108,7 @@ export function AiSection({ vm, onOpenPrompt }: { vm: SettingsViewModel; onOpenP
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							{(['claude', 'ollama', 'openai'] as const).map((name) => (
+							{(['claude', 'llmman', 'ollama', 'openai'] as const).map((name) => (
 								<SelectItem key={name} value={name}>
 									<PlatformOption platform={name} />
 								</SelectItem>
@@ -163,6 +169,30 @@ export function AiSection({ vm, onOpenPrompt }: { vm: SettingsViewModel; onOpenP
 								value={connection.model}
 								onChange={(e) => setConnection({ model: e.target.value })}
 								placeholder={defaultModel('ollama')}
+								className={`w-64 ${rowControlClass}`}
+							/>
+						</SettingsRow>
+					</>
+				)}
+
+				{connection.platform === 'llmman' && (
+					<>
+						<SettingsRow label={m.baseUrl()}>
+							<Input
+								value={connection.llmmanBaseUrl ?? ''}
+								onChange={(e) => setConnection({ llmmanBaseUrl: e.target.value })}
+								placeholder={DEFAULT_AI.connection.llmmanBaseUrl}
+								className={`w-64 ${rowControlClass}`}
+							/>
+						</SettingsRow>
+						<SettingsRow
+							label={
+								<LabelWithLink label={m.llmModel()} tooltip={m.findHere()} onClick={() => openUrl('https://github.com/llmmanorg/llmman')} />
+							}>
+							<Input
+								value={connection.model}
+								onChange={(e) => setConnection({ model: e.target.value })}
+								placeholder={defaultModel('llmman')}
 								className={`w-64 ${rowControlClass}`}
 							/>
 						</SettingsRow>

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,6 +41,10 @@ _Make sure to run the 'Run check` to see that it works_
 
 That's it! Summarization will now be active in Ollama.
 
+### Using llmman instead
+
+[llmman](https://github.com/llmmanorg/llmman) serves the same Ollama API on port `17434`, so it works the same way: install it, pull a model (`llmman pull gemma4`), run `llmman serve`, then pick `llmman` as the platform in Vibe's AI settings. The default URL `http://localhost:17434` matches its default bind.
+
 ## Stable Timestamps (Subtitles / Movies)
 
 Vibe includes a stable timestamp mode for tighter subtitle timing on long-form content.


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `client.ts`: no new client. `Ollama` takes a label and base URL; `createClient` passes `llmmanBaseUrl` for `llmman`.
- `config.ts`: `'llmman'` joins `AiPlatform`; `llmmanBaseUrl` (default `http://localhost:17434`) is added to `AiConnection`, `DEFAULT_AI` and `migrateLegacy`; `defaultModel('llmman')` is `gemma4`. Pre-existing settings without the field fall back to the default URL at runtime.
- `settings/sections/ai.tsx`: `llmman` picker entry (lucide `Boxes` icon, since simple-icons has no mark) plus URL and model rows reusing existing strings, so no locale changes.
- `docs/install.md` / `README.md`: short llmman note under the Ollama setup.

**Testing:** `tsc --noEmit` clean; `vitest run src/lib/ai` 12/12 (one new case asserting `llmman` hits `http://localhost:17434/api/generate`). Not run against a live server.

> AI-assisted, reviewed before submitting.
