### PR TITLE
Resolve the libs tree id relative to server/ so upload-libs works in the monorepo

### DIFF
--- a/server/libs/libs.chore
+++ b/server/libs/libs.chore
@@ -16,7 +16,7 @@ revision=$(read $ROOT/libs/revision)
 
 # Print the short tree hash of libs/ at HEAD.
 task libs-id {
-	echo "$(git -C $ROOT rev-parse --short=12 HEAD:libs)"
+	echo "$(git -C $ROOT rev-parse --short=12 HEAD:./libs)"
 }
 
 # Print the GitHub release tag the current libs/ inputs are published under.


### PR DESCRIPTION
First libs build since the move into `server/`: `git rev-parse HEAD:libs` resolves against the repo root and fails with "Needed a single revision". `HEAD:./libs` resolves against the working directory.

https://claude.ai/code/session_01TgmkaiiuPu65pSqXptMAna