### PR TITLE
Record two sign-server traps in the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -86,8 +86,13 @@ curl "$TUNNEL_URL/"                                     # {"status":"ok"}
 ```
 
 Values live only in `.env.local` (gitignored) — pass the file, never print or copy
-the values. The script buffers stdout, so its log stays empty until exit; judge it
-by the curl and later by the Windows job log.
+the values. The server prints a ready-to-paste `export SIGN_TUNNEL_SECRET=…` line
+at startup, so whatever you redirect its output to holds a live secret: keep that
+log outside the repo and delete it when the release is done.
+
+Check the tunnel with **curl**, not urllib or requests — Cloudflare answers a
+non-browser user-agent with `403 error code: 1010`, which looks exactly like a dead
+tunnel.
 
 **Gate:** the curl returns `{"status":"ok"}`. Never trigger step 5 before it does —
 an unsigned Windows build ships a SmartScreen warning to every user.


### PR DESCRIPTION
Both of these cost time during the 3.2.2 release, and neither is discoverable from the code.

- **Check the tunnel with curl.** Cloudflare answers a non-browser user-agent with `403 error code: 1010`. Through `urllib` the sign server looked dead when it was serving fine; `curl` returns `{"status":"ok"}`.
- **The startup banner contains a live secret.** `sign.py serve` prints a ready-to-paste `export SIGN_TUNNEL_SECRET=…`, so whatever its output is redirected to holds a credential until deleted. The skill now says to keep that log outside the repo and delete it when the release is done.

https://claude.ai/code/session_011VzcG6FnVRWR2aBLPrtWon